### PR TITLE
Add VLAN_TAG variable with conditional VLAN tag support in interface creation

### DIFF
--- a/scripts/install-proxmox.sh
+++ b/scripts/install-proxmox.sh
@@ -85,7 +85,7 @@ pct create "$CTID" "$TEMPLATE" \
   --rootfs "${STORAGE}:${DISK_SIZE}" \
   --memory "$RAM" \
   --cores "$CORES" \
-  --net0 "name=eth0,bridge=${BRIDGE},ip=dhcp" \
+  --net0 "name=eth0,bridge=${BRIDGE},ip=dhcp${VLAN_TAG:+,tag=${VLAN_TAG}}" \
   --ostype debian \
   --unprivileged 1 \
   --features "nesting=1" \


### PR DESCRIPTION
Adds an optional `VLAN_TAG` environment variable to the LXC network configuration. When set, the container's `eth0` interface will be tagged with the specified VLAN ID. This is necessary for hosts using a VLAN-aware bridge (e.g. `bridge-vlan-aware` yes) where the DHCP server lives on a specific VLAN.

If `VLAN_TAG` is not set, behavior is unchanged.

