### PR TITLE
feat: add Status Timeline modal with interactive sector inspection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
-import { ReactFlowProvider, type Connection, type Edge } from '@xyflow/react'
+import { ReactFlowProvider, type Connection } from '@xyflow/react'
 import { type Node } from '@xyflow/react'
 import { applyDagreLayout } from '@/utils/layout'
 import { serializeNode, serializeEdge, deserializeApiNode, deserializeApiEdge, type ApiNode, type ApiEdge } from '@/utils/canvasSerializer'
@@ -26,19 +26,21 @@ import { ShortcutsModal } from '@/components/modals/ShortcutsModal'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { useAuthStore } from '@/stores/authStore'
 import { useThemeStore } from '@/stores/themeStore'
-import { canvasApi } from '@/api/client'
+import { canvasApi, settingsApi } from '@/api/client'
 import { demoNodes, demoEdges } from '@/utils/demoData'
 import { useStatusPolling } from '@/hooks/useStatusPolling'
-import type { NodeData, EdgeData } from '@/types'
+import type { NodeData, EdgeData, NodeDimensions } from '@/types'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 const STANDALONE_STORAGE_KEY = 'homelable_canvas'
 
 export default function App() {
-  const { loadCanvas, markSaved, markUnsaved, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, nodes, edges, snapshotHistory, undo, redo, copySelectedNodes, pasteNodes } = useCanvasStore()
+  const { loadCanvas, markSaved, markUnsaved, selectedNodeId, selectedNodeIds, addNode, updateNode, setNodeDimensions, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, nodes, edges, snapshotHistory, undo, redo, copySelectedNodes, pasteNodes } = useCanvasStore()
   const canvasRef = useRef<HTMLDivElement>(null)
   const { isAuthenticated } = useAuthStore()
   const { activeTheme, setTheme } = useThemeStore()
+  const setAppSettings = useSettingsStore((s) => s.setSettings)
 
   useStatusPolling()
 
@@ -78,6 +80,20 @@ export default function App() {
   useEffect(() => { handleSaveRef.current = handleSave }, [handleSave])
 
   // Load canvas on auth (or immediately in standalone mode)
+  useEffect(() => {
+    if (STANDALONE || !isAuthenticated) return
+    settingsApi.get()
+      .then((res) => setAppSettings({
+        intervalSeconds: res.data.interval_seconds,
+        scanIntervalSeconds: res.data.scan_interval_seconds,
+        defaultNodeColor: res.data.default_node_color ?? null,
+        defaultEdgeColor: res.data.default_edge_color ?? null,
+        nodeTypeColors: res.data.node_type_colors ?? {},
+        edgeTypeColors: res.data.edge_type_colors ?? {},
+      }))
+      .catch(() => undefined)
+  }, [isAuthenticated, setAppSettings])
+
   useEffect(() => {
     if (STANDALONE) {
       try {
@@ -147,7 +163,7 @@ export default function App() {
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
-  const handleAddNode = useCallback((data: Partial<NodeData>) => {
+  const handleAddNode = useCallback((data: Partial<NodeData>, dimensions?: NodeDimensions) => {
     snapshotHistory()
     const id = generateUUID()
     const isProxmox = data.type === 'proxmox'
@@ -163,7 +179,8 @@ export default function App() {
       position,
       data: { status: 'unknown', services: [], ...data } as NodeData,
       ...(data.parent_id ? { parentId: data.parent_id, extent: 'parent' as const } : {}),
-      ...(isProxmox ? { width: 300, height: 200 } : {}),
+      width: dimensions?.width ?? (isProxmox ? 300 : undefined),
+      height: dimensions?.height ?? (isProxmox ? 200 : undefined),
     }
     addNode(newNode)
     toast.success(`Added "${data.label}"`)
@@ -236,11 +253,14 @@ export default function App() {
     setEditNodeId(id)
   }, [])
 
-  const handleUpdateNode = useCallback((data: Partial<NodeData>) => {
+  const handleUpdateNode = useCallback((data: Partial<NodeData>, dimensions?: NodeDimensions) => {
     if (!editNodeId) return
     snapshotHistory()
     const existingNode = nodes.find((n) => n.id === editNodeId)
     updateNode(editNodeId, data)
+    if (dimensions) {
+      setNodeDimensions(editNodeId, dimensions.width, dimensions.height)
+    }
     // If proxmox container_mode changed, apply structural changes (children parentId, node dimensions)
     if (data.type === 'proxmox' && typeof data.container_mode === 'boolean') {
       setProxmoxContainerMode(editNodeId, data.container_mode)
@@ -271,7 +291,7 @@ export default function App() {
       }
     }
     setEditNodeId(null)
-  }, [editNodeId, updateNode, setProxmoxContainerMode, nodes, edges, deleteEdge, onConnect, snapshotHistory])
+  }, [editNodeId, updateNode, setNodeDimensions, setProxmoxContainerMode, nodes, edges, deleteEdge, onConnect, snapshotHistory])
 
   const handleAutoLayout = useCallback(() => {
     const laid = applyDagreLayout(nodes, edges)
@@ -339,8 +359,8 @@ export default function App() {
     setPendingConnection(null)
   }, [pendingConnection, onConnect, nodes, updateNode, snapshotHistory])
 
-  const handleEdgeDoubleClick = useCallback((edge: Edge<EdgeData>) => {
-    setEditEdgeId(edge.id)
+  const handleEdgeEditRequest = useCallback((edgeId: string) => {
+    setEditEdgeId(edgeId)
   }, [])
 
   const handleEdgeUpdate = useCallback((data: EdgeData) => {
@@ -359,6 +379,17 @@ export default function App() {
 
   const editNode = editNodeId ? nodes.find((n) => n.id === editNodeId) : null
   const editEdge = editEdgeId ? edges.find((e) => e.id === editEdgeId) : null
+
+  useEffect(() => {
+    const handleOpenEdgeEditor = (event: Event) => {
+      const detail = (event as CustomEvent<{ edgeId?: string }>).detail
+      if (detail?.edgeId) {
+        handleEdgeEditRequest(detail.edgeId)
+      }
+    }
+    window.addEventListener('homelable:edit-edge', handleOpenEdgeEditor)
+    return () => window.removeEventListener('homelable:edit-edge', handleOpenEdgeEditor)
+  }, [handleEdgeEditRequest])
 
   if (!STANDALONE && !isAuthenticated) return <LoginPage />
 
@@ -392,7 +423,6 @@ export default function App() {
               <div ref={canvasRef} className="flex-1 min-w-0 h-full">
                 <CanvasContainer
                   onConnect={handleEdgeConnect}
-                  onEdgeDoubleClick={handleEdgeDoubleClick}
                   onNodeDragStart={snapshotHistory}
                   onOpenPending={(deviceId) => {
                     setHighlightPendingId(undefined)
@@ -424,6 +454,7 @@ export default function App() {
           onClose={() => setEditNodeId(null)}
           onSubmit={handleUpdateNode}
           initial={editNode?.data}
+          initialDimensions={{ width: editNode?.width, height: editNode?.height }}
           title="Edit Node"
           proxmoxNodes={nodes.filter((n) => n.type === 'proxmox').map((n) => ({ id: n.id, label: n.data.label }))}
         />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -66,6 +66,32 @@ export const scanApi = {
 }
 
 export const settingsApi = {
-  get: () => api.get<{ interval_seconds: number }>('/settings'),
-  save: (data: { interval_seconds: number }) => api.post<{ interval_seconds: number }>('/settings', data),
+  get: () => api.get<{
+    interval_seconds: number
+    scan_interval_seconds: number
+    default_node_color: string | null
+    default_edge_color: string | null
+    node_type_colors: Record<string, string>
+    edge_type_colors: Record<string, string>
+  }>('/settings'),
+  save: (data: {
+    interval_seconds: number
+    scan_interval_seconds: number
+    default_node_color: string | null
+    default_edge_color: string | null
+    node_type_colors: Record<string, string>
+    edge_type_colors: Record<string, string>
+  }) =>
+    api.post<{
+      interval_seconds: number
+      scan_interval_seconds: number
+      default_node_color: string | null
+      default_edge_color: string | null
+      node_type_colors: Record<string, string>
+      edge_type_colors: Record<string, string>
+    }>('/settings', data),
+}
+
+export const nodeHistoryApi = {
+  list: (params?: { node_id?: string; start_date?: string; end_date?: string; limit?: number }) => api.get('/node-history', { params }),
 }

--- a/frontend/src/components/modals/StatusTimelineModal.tsx
+++ b/frontend/src/components/modals/StatusTimelineModal.tsx
@@ -1,0 +1,492 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Activity, Loader2, RefreshCw } from 'lucide-react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { nodeHistoryApi } from '@/api/client'
+import { useSettingsStore } from '@/stores/settingsStore'
+import { useCanvasStore } from '@/stores/canvasStore'
+import { toast } from 'sonner'
+
+interface StatusHistoryItem {
+  id: string
+  node_id: string
+  node_label: string
+  status: string
+  response_time_ms: number | null
+  checked_at: string
+}
+
+interface StatusTimelineModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+interface GroupedStatus {
+  nodeId: string
+  label: string
+  events: StatusHistoryItem[]
+}
+
+interface TimelineSegment extends StatusHistoryItem {
+  startPercent: number
+  widthPercent: number
+}
+
+const HOURS = Array.from({ length: 24 }, (_, hour) => `${hour.toString().padStart(2, '0')}:00`)
+
+function toIsoRange(date: string) {
+  const start = new Date(`${date}T00:00:00`)
+  const end = new Date(`${date}T23:59:59`)
+  return {
+    start: start.toISOString(),
+    end: end.toISOString(),
+  }
+}
+
+function getStatusTone(status: string) {
+  if (status === 'online') return '#39d353'
+  if (status === 'offline') return '#f85149'
+  return '#8b949e'
+}
+
+function hexToRgba(hex: string, alpha: number) {
+  const normalized = hex.replace('#', '')
+  const value = normalized.length === 3
+    ? normalized.split('').map((char) => char + char).join('')
+    : normalized
+  const int = Number.parseInt(value, 16)
+  const r = (int >> 16) & 255
+  const g = (int >> 8) & 255
+  const b = int & 255
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function getMinuteOffset(dateIso: string) {
+  const date = new Date(dateIso)
+  return date.getHours() * 60 + date.getMinutes() + date.getSeconds() / 60
+}
+
+function formatCheckTime(dateIso: string) {
+  return new Date(dateIso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function formatShortTime(dateIso: string) {
+  return new Date(dateIso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function getSectorLabel(startMinute: number, sectorMinutes: number) {
+  const start = new Date()
+  start.setHours(0, Math.floor(startMinute), 0, 0)
+  const end = new Date()
+  end.setHours(0, Math.min(24 * 60, Math.floor(startMinute + sectorMinutes)), 0, 0)
+  const format = (value: Date) => value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return `${format(start)} - ${format(end)}`
+}
+
+function buildSegments(events: StatusHistoryItem[]): TimelineSegment[] {
+  if (events.length === 0) return []
+  const sorted = [...events].sort((a, b) => +new Date(a.checked_at) - +new Date(b.checked_at))
+  return sorted.map((event, index) => {
+    const startMinute = getMinuteOffset(event.checked_at)
+    const nextMinute = index < sorted.length - 1 ? getMinuteOffset(sorted[index + 1].checked_at) : 24 * 60
+    const endMinute = Math.max(startMinute + 3, nextMinute)
+    return {
+      ...event,
+      startPercent: (startMinute / (24 * 60)) * 100,
+      widthPercent: Math.max(0.35, ((endMinute - startMinute) / (24 * 60)) * 100),
+    }
+  })
+}
+
+function findSegmentForMinute(segments: TimelineSegment[], minute: number) {
+  return segments.find((segment) => {
+    const startMinute = (segment.startPercent / 100) * 24 * 60
+    const endMinute = startMinute + (segment.widthPercent / 100) * 24 * 60
+    return minute >= startMinute && minute < endMinute
+  }) ?? null
+}
+
+function TimelineRow({ group, detailed, active }: { group: GroupedStatus; detailed: boolean; active: boolean }) {
+  const segments = useMemo(() => buildSegments(group.events), [group.events])
+  const latestStatus = group.events[group.events.length - 1]?.status ?? 'unknown'
+  const sectorMinutes = detailed ? 15 : 60
+  const sectorCount = (24 * 60) / sectorMinutes
+  const [activeSectorIndex, setActiveSectorIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    setActiveSectorIndex(null)
+  }, [group.nodeId, detailed])
+
+  const sectorInfo = useMemo(() => {
+    if (activeSectorIndex == null) return null
+    const startMinute = activeSectorIndex * sectorMinutes
+    const segment = findSegmentForMinute(segments, startMinute)
+    return {
+      label: getSectorLabel(startMinute, sectorMinutes),
+      segment,
+    }
+  }, [activeSectorIndex, sectorMinutes, segments])
+
+  return (
+    <div className={`grid gap-2 items-center ${detailed ? 'grid-cols-1' : 'grid-cols-[220px_minmax(0,1fr)]'}`}>
+      {!detailed && (
+        <div className={`rounded-2xl border px-3 py-3 transition-colors ${active ? 'border-[#00d4ff]/35 bg-[#112131]' : 'border-border bg-[#0f1722]'}`}>
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="truncate text-sm text-foreground">{group.label}</div>
+              <div className="text-[10px] font-mono text-muted-foreground">{group.events.length} checks</div>
+            </div>
+            <span
+              className="h-3 w-3 shrink-0 rounded-full"
+              style={{ backgroundColor: getStatusTone(latestStatus) }}
+              title={latestStatus}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className={`rounded-2xl border p-3 transition-colors ${active ? 'border-[#00d4ff]/25 bg-[#0d1621]' : 'border-border bg-[#0b131d]'}`}>
+        {detailed && (
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="truncate text-base font-medium text-foreground">{group.label}</div>
+              <div className="text-[11px] font-mono text-muted-foreground">{group.events.length} checks in the selected day</div>
+            </div>
+            <div className="flex items-center gap-2 text-[11px] font-mono">
+              <span className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-1 text-muted-foreground">
+                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: getStatusTone(latestStatus) }} />
+                {latestStatus}
+              </span>
+            </div>
+          </div>
+        )}
+
+        <div className={`grid ${detailed ? 'grid-cols-[repeat(24,minmax(0,1fr))]' : 'grid-cols-[repeat(24,minmax(0,1fr))]'} gap-2 border-b border-border pb-3 text-[10px] font-mono uppercase tracking-[0.12em] text-muted-foreground`}>
+          {HOURS.map((hour) => (
+            <div key={`${group.nodeId}-${hour}`} className="text-center">{hour}</div>
+          ))}
+        </div>
+
+        <div className={`relative mt-3 overflow-hidden rounded-2xl border border-white/5 ${detailed ? 'h-24' : 'h-14'}`}>
+          <div
+            className={`absolute inset-0 grid ${detailed ? 'grid-cols-96' : 'grid-cols-24'} overflow-hidden z-10`}
+            onMouseLeave={() => setActiveSectorIndex(null)}
+            onPointerLeave={() => setActiveSectorIndex(null)}
+          >
+            {Array.from({ length: sectorCount }, (_, index) => (
+              <button
+                key={`${group.nodeId}-sector-${index}`}
+                type="button"
+                className={`border-r border-white/6 last:border-r-0 transition-colors focus:outline-none ${activeSectorIndex === index ? 'bg-white/10' : 'bg-transparent hover:bg-white/5'}`}
+                onMouseEnter={() => setActiveSectorIndex(index)}
+                onFocus={() => setActiveSectorIndex(index)}
+                onBlur={() => setActiveSectorIndex(null)}
+                onClick={() => setActiveSectorIndex(index)}
+                aria-label={`Sector ${getSectorLabel(index * sectorMinutes, sectorMinutes)}`}
+              />
+            ))}
+          </div>
+
+          {segments.map((segment) => {
+            const tone = getStatusTone(segment.status)
+            return (
+              <div
+                key={segment.id}
+                className="pointer-events-none absolute inset-y-2 overflow-hidden rounded-xl border text-[10px] font-mono text-white"
+                style={{
+                  left: `${segment.startPercent}%`,
+                  width: `${segment.widthPercent}%`,
+                  minWidth: detailed ? '26px' : '18px',
+                  borderColor: hexToRgba(tone, 0.92),
+                  background: `linear-gradient(90deg, ${hexToRgba(tone, 0.2)} 0%, ${hexToRgba(tone, 0.82)} 16%, ${hexToRgba(tone, 0.86)} 100%)`,
+                }}
+                title={`${segment.status} - ${formatCheckTime(segment.checked_at)}${segment.response_time_ms != null ? ` - ${segment.response_time_ms} ms` : ''}`}
+              >
+                <div className="absolute inset-y-0 left-0 w-px bg-white/35" />
+                <div className="relative flex h-full min-w-0 items-center gap-2 px-2 py-1">
+                  <div className="h-2 w-2 shrink-0 rounded-full bg-white/85" />
+                  <div className="min-w-0 leading-tight">
+                    <div className="truncate">{segment.status}</div>
+                    <div className="truncate opacity-80">{formatShortTime(segment.checked_at)}</div>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="mt-3 rounded-xl border border-border bg-[#0a1118] px-3 py-2 text-xs">
+          {sectorInfo?.segment ? (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span className="font-mono text-[#8b949e]">{sectorInfo.label}</span>
+              <span className="inline-flex items-center gap-1 text-foreground">
+                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: getStatusTone(sectorInfo.segment.status) }} />
+                {sectorInfo.segment.status}
+              </span>
+              <span className="font-mono text-[#dff9ff]">{formatCheckTime(sectorInfo.segment.checked_at)}</span>
+              {sectorInfo.segment.response_time_ms != null && (
+                <span className="font-mono text-muted-foreground">{sectorInfo.segment.response_time_ms} ms</span>
+              )}
+            </div>
+          ) : sectorInfo ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="font-mono text-[#8b949e]">{sectorInfo.label}</span>
+              <span className="text-muted-foreground">No checks in this sector</span>
+            </div>
+          ) : (
+            <div className="text-muted-foreground">
+              {detailed ? 'Tap or hover a sector to inspect the check for that interval.' : 'Hover or tap a sector to inspect its check.'}
+            </div>
+          )}
+        </div>
+
+        {detailed && (
+          <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {[...group.events]
+              .sort((a, b) => +new Date(b.checked_at) - +new Date(a.checked_at))
+              .map((event) => (
+                <div
+                  key={event.id}
+                  className={`rounded-xl border px-3 py-2 text-xs transition-colors ${
+                    sectorInfo?.segment?.id === event.id
+                      ? 'border-[#00d4ff]/45 bg-[#112131]'
+                      : 'border-border bg-[#0a1118]'
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="inline-flex items-center gap-1 text-foreground">
+                      <span className="h-2 w-2 rounded-full" style={{ backgroundColor: getStatusTone(event.status) }} />
+                      {event.status}
+                    </span>
+                    <span className="font-mono text-muted-foreground">{formatCheckTime(event.checked_at)}</span>
+                  </div>
+                  {event.response_time_ms != null && (
+                    <div className="mt-1 font-mono text-[11px] text-[#dff9ff]">{event.response_time_ms} ms</div>
+                  )}
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function StatusTimelineModal({ open, onClose }: StatusTimelineModalProps) {
+  const intervalSeconds = useSettingsStore((s) => s.intervalSeconds)
+  const nodesState = useCanvasStore((s) => s.nodes)
+  const nodes = Array.isArray(nodesState) ? nodesState : []
+  const [items, setItems] = useState<StatusHistoryItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [selectedDate, setSelectedDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [filterNodeId, setFilterNodeId] = useState('all')
+  const [activeNodeId, setActiveNodeId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!open) return
+    const firstLoad = items.length === 0
+    if (firstLoad) {
+      setLoading(true)
+    } else {
+      setRefreshing(true)
+    }
+    try {
+      const range = toIsoRange(selectedDate)
+      const res = await nodeHistoryApi.list({
+        node_id: filterNodeId !== 'all' ? filterNodeId : undefined,
+        start_date: range.start,
+        end_date: range.end,
+        limit: 10000,
+      })
+      setItems(res.data as StatusHistoryItem[])
+    } catch {
+      toast.error('Failed to load status timeline')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [open, selectedDate, filterNodeId, items.length])
+
+  useEffect(() => {
+    if (!open) return
+    load()
+  }, [open, load])
+
+  useEffect(() => {
+    if (!open || intervalSeconds <= 0) return
+    const timer = window.setInterval(load, intervalSeconds * 1000)
+    return () => window.clearInterval(timer)
+  }, [open, intervalSeconds, load])
+
+  const groups = useMemo<GroupedStatus[]>(() => {
+    const grouped = new Map<string, { label: string; events: StatusHistoryItem[] }>()
+    for (const item of [...items].reverse()) {
+      const existing = grouped.get(item.node_id)
+      if (existing) {
+        existing.events.push(item)
+      } else {
+        grouped.set(item.node_id, { label: item.node_label, events: [item] })
+      }
+    }
+    return [...grouped.entries()]
+      .map(([nodeId, value]) => ({ nodeId, ...value }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [items])
+
+  useEffect(() => {
+    if (groups.length === 0) {
+      setActiveNodeId(null)
+      return
+    }
+    if (activeNodeId && !groups.some((group) => group.nodeId === activeNodeId)) {
+      setActiveNodeId(null)
+    }
+  }, [groups, activeNodeId])
+
+  useEffect(() => {
+    if (!open) return
+    setActiveNodeId(null)
+  }, [open, selectedDate, filterNodeId])
+
+  const nodeOptions = useMemo(
+    () => nodes
+      .filter((node) => node.data.type !== 'groupRect' && node.data.type !== 'group')
+      .map((node) => ({ id: node.id, label: node.data.label }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [nodes],
+  )
+
+  const totalOnline = items.filter((item) => item.status === 'online').length
+  const totalOffline = items.filter((item) => item.status === 'offline').length
+  const displayedGroups = activeNodeId ? groups.filter((group) => group.nodeId === activeNodeId) : groups
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose() }}>
+      <DialogContent
+        className="max-w-none w-[calc(100vw-16px)] h-[calc(100vh-16px)] p-0 overflow-hidden bg-[#081019] text-foreground border border-border"
+        style={{ width: 'calc(100vw - 16px)', maxWidth: 'calc(100vw - 16px)', height: 'calc(100vh - 16px)' }}
+      >
+        <DialogHeader className="border-b border-border px-6 py-4 bg-[linear-gradient(180deg,rgba(0,212,255,0.08),rgba(8,16,25,0.2))]">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#00d4ff]/20 bg-[#00d4ff]/10 text-[#00d4ff] shadow-[0_0_24px_rgba(0,212,255,0.12)]">
+                <Activity size={20} />
+              </div>
+              <div>
+                <DialogTitle>Status Timeline</DialogTitle>
+                <p className="text-xs text-muted-foreground">24h grid view without horizontal card scrolling.</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="date"
+                value={selectedDate}
+                onChange={(event) => setSelectedDate(event.target.value)}
+                className="rounded-md border border-border bg-[#11161d] px-3 py-2 text-xs text-foreground"
+              />
+              <select
+                value={filterNodeId}
+                onChange={(event) => setFilterNodeId(event.target.value)}
+                className="min-w-[240px] rounded-md border border-border bg-[#11161d] px-3 py-2 text-xs text-foreground"
+              >
+                <option value="all">All devices</option>
+                {nodeOptions.map((node) => (
+                  <option key={node.id} value={node.id}>{node.label}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={load}
+                className="flex items-center gap-1 rounded-md border border-border bg-[#11161d] px-3 py-2 text-xs text-foreground hover:bg-[#18202a]"
+              >
+                {refreshing ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+                {refreshing ? 'Refreshing' : 'Refresh'}
+              </button>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="grid h-full min-h-0 grid-cols-[280px_minmax(0,1fr)]">
+          <aside className="overflow-y-auto border-r border-border bg-[linear-gradient(180deg,#09111a,#0c1621)] px-4 py-4">
+            <div className="grid grid-cols-2 gap-2">
+              <MetricCard label="Devices" value={String(groups.length)} tone="cyan" />
+              <MetricCard label="Checks" value={String(items.length)} tone="slate" />
+              <MetricCard label="Online" value={String(totalOnline)} tone="green" />
+              <MetricCard label="Offline" value={String(totalOffline)} tone="red" />
+            </div>
+            <div className="mt-5">
+              <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Devices</p>
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={() => setActiveNodeId(null)}
+                  className={`flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
+                    activeNodeId == null
+                      ? 'border-[#00d4ff]/40 bg-[#00d4ff]/10 text-[#dff9ff]'
+                      : 'border-border bg-[#0f1722] text-muted-foreground hover:bg-[#15202c]'
+                  }`}
+                >
+                  <span>All devices</span>
+                  <span className="text-[11px] font-mono">{groups.length}</span>
+                </button>
+                {groups.map((group) => (
+                  <button
+                    key={group.nodeId}
+                    type="button"
+                    onClick={() => setActiveNodeId(group.nodeId)}
+                    className={`flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
+                      activeNodeId === group.nodeId
+                        ? 'border-[#00d4ff]/40 bg-[#00d4ff]/10 text-[#dff9ff]'
+                        : 'border-border bg-[#0f1722] text-muted-foreground hover:bg-[#15202c]'
+                    }`}
+                  >
+                    <span className="truncate">{group.label}</span>
+                    <span className="text-[11px] font-mono">{group.events.length}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </aside>
+
+          <div className="min-h-0 overflow-y-auto bg-[radial-gradient(circle_at_top,rgba(0,212,255,0.08),transparent_32%),linear-gradient(180deg,#0a111b,#0d1117)] px-5 py-4">
+            {loading && <p className="py-8 text-center text-sm text-muted-foreground">Loading status timeline...</p>}
+            {!loading && displayedGroups.length === 0 && (
+              <div className="flex h-full items-center justify-center">
+                <p className="text-sm text-muted-foreground">No checks recorded for this day.</p>
+              </div>
+            )}
+            {!loading && displayedGroups.length > 0 && (
+              <div className="rounded-3xl border border-border bg-[linear-gradient(180deg,rgba(17,22,29,0.98),rgba(13,17,23,0.98))] p-4 shadow-[0_20px_60px_rgba(0,0,0,0.25)]">
+                <div className="mt-3 space-y-2">
+                  {displayedGroups.map((group) => (
+                    <TimelineRow
+                      key={group.nodeId}
+                      group={group}
+                      detailed={activeNodeId === group.nodeId}
+                      active={activeNodeId === group.nodeId || (activeNodeId == null && filterNodeId === 'all')}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function MetricCard({ label, value, tone }: { label: string; value: string; tone: 'cyan' | 'green' | 'red' | 'slate' }) {
+  const styles = {
+    cyan: 'border-[#00d4ff]/20 bg-[#00d4ff]/10 text-[#dff9ff]',
+    green: 'border-[#39d353]/20 bg-[#39d353]/10 text-[#dff9e8]',
+    red: 'border-[#f85149]/20 bg-[#f85149]/10 text-[#ffe7e5]',
+    slate: 'border-border bg-[#0f1722] text-[#e6edf3]',
+  }
+  return (
+    <div className={`rounded-2xl border px-3 py-3 ${styles[tone]}`}>
+      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</div>
+      <div className="mt-1 text-xl font-semibold">{value}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/modals/__tests__/NodeModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModal.test.tsx
@@ -130,6 +130,32 @@ describe('NodeModal', () => {
     expect(data.notes).toBe('rack A')
   })
 
+  it('submits explicit width and height when provided', () => {
+    const onSubmit = vi.fn()
+    render(<NodeModal open onClose={vi.fn()} onSubmit={onSubmit} />)
+    fireEvent.change(screen.getByPlaceholderText('My Server'), { target: { value: 'Sized Node' } })
+    const numericInputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(numericInputs[0], { target: { value: '240' } })
+    fireEvent.change(numericInputs[1], { target: { value: '100' } })
+    fireEvent.click(screen.getByText('Add'))
+    expect(onSubmit.mock.calls[0][1]).toEqual({ width: 240, height: 100 })
+  })
+
+  it('pre-fills width and height from initialDimensions', () => {
+    render(
+      <NodeModal
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        initial={{ label: 'Sized' }}
+        initialDimensions={{ width: 320, height: 160 }}
+      />
+    )
+    const numericInputs = screen.getAllByRole('spinbutton')
+    expect((numericInputs[0] as HTMLInputElement).value).toBe('320')
+    expect((numericInputs[1] as HTMLInputElement).value).toBe('160')
+  })
+
   it('submits check_target', () => {
     const { onSubmit } = renderModal({ initial: BASE })
     fireEvent.change(screen.getByPlaceholderText('http://...'), { target: { value: 'http://192.168.1.10:8080' } })

--- a/frontend/src/components/panels/Sidebar.tsx
+++ b/frontend/src/components/panels/Sidebar.tsx
@@ -1,11 +1,17 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
-import { Plus, Save, ScanLine, ChevronLeft, ChevronRight, LayoutDashboard, Clock, EyeOff, Trash2, RefreshCw, Loader2, Square, Eye, Settings, StopCircle, X } from 'lucide-react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import { Plus, Save, ScanLine, ChevronLeft, ChevronRight, LayoutDashboard, Clock, EyeOff, Trash2, RefreshCw, Loader2, Square, Eye, Settings, StopCircle, Activity, X } from 'lucide-react'
 import { Logo } from '@/components/ui/Logo'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { scanApi, settingsApi } from '@/api/client'
 import { toast } from 'sonner'
 import { PendingDeviceModal, type PendingDevice } from '@/components/modals/PendingDeviceModal'
+import { StatusTimelineModal } from '@/components/modals/StatusTimelineModal'
+import { COLOR_SWATCHES } from '@/utils/colorPalettes'
+import { useSettingsStore } from '@/stores/settingsStore'
+import { EDGE_TYPE_LABELS, NODE_TYPE_LABELS, type EdgeType, type NodeType } from '@/types'
+import { NODE_DEFAULT_COLORS } from '@/utils/nodeColors'
+import { EDGE_DEFAULT_COLORS } from '@/utils/edgeColors'
 
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 
@@ -29,6 +35,45 @@ interface ScanRun {
   error: string | null
 }
 
+function parseApiDate(value: string | null) {
+  if (!value) return Number.NaN
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T')
+  const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/i.test(normalized)
+  return Date.parse(hasTimezone ? normalized : `${normalized}Z`)
+}
+
+function formatDuration(ms: number) {
+  if (!Number.isFinite(ms) || ms <= 0) return '0s'
+  const totalSeconds = Math.floor(ms / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}
+
+function getRunSignature(run: ScanRun) {
+  return [...run.ranges].sort().join('|')
+}
+
+function getRunDurationMs(run: ScanRun, nowTs: number) {
+  const startedAt = parseApiDate(run.started_at)
+  if (!Number.isFinite(startedAt)) return null
+  const finishedAt = run.finished_at ? parseApiDate(run.finished_at) : nowTs
+  if (!Number.isFinite(finishedAt)) return null
+  return Math.max(0, finishedAt - startedAt)
+}
+
+function getMedian(values: number[]) {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+    : sorted[mid]
+}
+
 interface SidebarProps {
   onAddNode: () => void
   onAddGroupRect: () => void
@@ -42,11 +87,11 @@ interface SidebarProps {
 export function Sidebar({ onAddNode, onAddGroupRect, onScan, onSave, onNodeApproved, forceView, highlightPendingId }: SidebarProps) {
   const [_collapsed, setCollapsed] = useState(false)
   const [_activeView, setActiveView] = useState<SidebarView>('canvas')
+  const [statusTimelineOpen, setStatusTimelineOpen] = useState(false)
 
   // When forceView is set, override local state without useEffect
   const collapsed = forceView ? false : _collapsed
   const activeView = forceView ?? _activeView
-
   const { nodes, hasUnsavedChanges, hideIp, toggleHideIp } = useCanvasStore()
 
   const networkNodes = nodes.filter((n) => n.data.type !== 'groupRect')
@@ -127,6 +172,7 @@ export function Sidebar({ onAddNode, onAddGroupRect, onScan, onSave, onNodeAppro
         <SidebarItem icon={Plus} label="Add Node" collapsed={collapsed} onClick={onAddNode} />
         <SidebarItem icon={Square} label="Add Zone" collapsed={collapsed} onClick={onAddGroupRect} />
         {!STANDALONE && <SidebarItem icon={ScanLine} label="Scan Network" collapsed={collapsed} onClick={handleScan} />}
+        {!STANDALONE && <SidebarItem icon={Activity} label="Status Timeline" collapsed={collapsed} onClick={() => setStatusTimelineOpen(true)} />}
         <SidebarItem
           icon={hideIp ? EyeOff : Eye}
           label={hideIp ? 'Show IPs' : 'Hide IPs'}
@@ -152,6 +198,8 @@ export function Sidebar({ onAddNode, onAddGroupRect, onScan, onSave, onNodeAppro
           />
         )}
       </div>
+
+      {!STANDALONE && <StatusTimelineModal open={statusTimelineOpen} onClose={() => setStatusTimelineOpen(false)} />}
     </aside>
   )
 }
@@ -382,6 +430,7 @@ function HiddenDevicesPanel() {
 function ScanHistoryPanel() {
   const [runs, setRuns] = useState<ScanRun[]>([])
   const [loading, setLoading] = useState(false)
+  const [nowTs, setNowTs] = useState(() => Date.now())
   const prevRunsRef = useRef<ScanRun[]>([])
 
   const load = useCallback(async () => {
@@ -417,6 +466,13 @@ function ScanHistoryPanel() {
     return () => clearInterval(id)
   }, [runs, load])
 
+  useEffect(() => {
+    const hasRunning = runs.some((r) => r.status === 'running')
+    if (!hasRunning) return
+    const id = window.setInterval(() => setNowTs(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [runs])
+
   const [stopping, setStopping] = useState<string | null>(null)
 
   const handleStop = async (runId: string) => {
@@ -438,6 +494,31 @@ function ScanHistoryPanel() {
     : s === 'cancelled' ? '#8b949e'
     : '#8b949e'
 
+  const estimatedDurations = useMemo(() => {
+    const bySignature = new Map<string, number[]>()
+    const allDurations: number[] = []
+
+    for (const run of runs) {
+      if (!run.finished_at) continue
+      const durationMs = getRunDurationMs(run, nowTs)
+      if (durationMs == null) continue
+      allDurations.push(durationMs)
+      const signature = getRunSignature(run)
+      const existing = bySignature.get(signature) ?? []
+      existing.push(durationMs)
+      bySignature.set(signature, existing)
+    }
+
+    return {
+      bySignature: new Map(
+        [...bySignature.entries()]
+          .map(([signature, durations]) => [signature, getMedian(durations)] as const)
+          .filter((entry): entry is readonly [string, number] => entry[1] != null),
+      ),
+      global: getMedian(allDurations),
+    }
+  }, [runs, nowTs])
+
   return (
     <div className="p-2">
       <div className="flex items-center justify-between mb-2">
@@ -450,7 +531,13 @@ function ScanHistoryPanel() {
       {!loading && runs.length === 0 && (
         <p className="text-xs text-muted-foreground text-center py-4">No scans yet</p>
       )}
-      {runs.map((r) => (
+      {runs.map((r) => {
+        const durationMs = getRunDurationMs(r, nowTs)
+        const estimatedTotalMs = estimatedDurations.bySignature.get(getRunSignature(r)) ?? estimatedDurations.global
+        const remainingMs = r.status === 'running' && durationMs != null && estimatedTotalMs != null
+          ? Math.max(0, estimatedTotalMs - durationMs)
+          : null
+        return (
         <div key={r.id} className="mb-2 p-2 rounded-md bg-[#21262d] text-xs">
           <div className="flex items-center gap-1.5">
             <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: statusColor(r.status) }} />
@@ -459,18 +546,16 @@ function ScanHistoryPanel() {
             <span className="ml-auto text-muted-foreground font-mono">{r.devices_found} found</span>
             {r.status === 'running' && (
               <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    aria-label="Stop scan"
-                    onClick={() => handleStop(r.id)}
-                    disabled={stopping === r.id}
-                    className="p-0.5 text-[#f85149] hover:bg-[#f85149]/10 rounded transition-colors disabled:opacity-50"
-                  >
-                    {stopping === r.id
-                      ? <Loader2 size={11} className="animate-spin" />
-                      : <StopCircle size={11} />
-                    }
-                  </button>
+                <TooltipTrigger
+                  aria-label="Stop scan"
+                  onClick={() => handleStop(r.id)}
+                  disabled={stopping === r.id}
+                  className="p-0.5 text-[#f85149] hover:bg-[#f85149]/10 rounded transition-colors disabled:opacity-50"
+                >
+                  {stopping === r.id
+                    ? <Loader2 size={11} className="animate-spin" />
+                    : <StopCircle size={11} />
+                  }
                 </TooltipTrigger>
                 <TooltipContent side="left">Stop scan</TooltipContent>
               </Tooltip>
@@ -478,6 +563,12 @@ function ScanHistoryPanel() {
           </div>
           <div className="text-muted-foreground text-[10px] mt-0.5">
             {new Date(r.started_at.endsWith('Z') ? r.started_at : r.started_at + 'Z').toLocaleString()}
+          </div>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] font-mono">
+            <span className="text-[#dff9ff]">Duration {durationMs != null ? formatDuration(durationMs) : 'n/a'}</span>
+            {r.status === 'running' && (
+              <span className="text-[#e3b341]">Remaining {remainingMs != null ? formatDuration(remainingMs) : 'estimating...'}</span>
+            )}
           </div>
           {r.ranges.length > 0 && (
             <div className="text-[#8b949e] text-[10px] font-mono truncate">{r.ranges.join(', ')}</div>
@@ -488,25 +579,54 @@ function ScanHistoryPanel() {
             </div>
           )}
         </div>
-      ))}
+        )
+      })}
     </div>
   )
 }
 
 function SettingsPanel() {
   const [interval, setIntervalValue] = useState(60)
+  const [scanInterval, setScanInterval] = useState(3600)
+  const [defaultNodeColor, setDefaultNodeColor] = useState<string | null>(null)
+  const [defaultEdgeColor, setDefaultEdgeColor] = useState<string | null>(null)
+  const [nodeTypeColors, setNodeTypeColors] = useState<Record<string, string>>({})
+  const [edgeTypeColors, setEdgeTypeColors] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
+  const setAppSettings = useSettingsStore((s) => s.setSettings)
 
   useEffect(() => {
     settingsApi.get()
-      .then((res) => setIntervalValue(res.data.interval_seconds))
-      .catch(() => {/* use default */})
+      .then((res) => {
+        setIntervalValue(res.data.interval_seconds)
+        setScanInterval(res.data.scan_interval_seconds)
+        setDefaultNodeColor(res.data.default_node_color ?? null)
+        setDefaultEdgeColor(res.data.default_edge_color ?? null)
+        setNodeTypeColors(res.data.node_type_colors ?? {})
+        setEdgeTypeColors(res.data.edge_type_colors ?? {})
+      })
+      .catch(() => undefined)
   }, [])
 
   const handleSave = async () => {
     setSaving(true)
     try {
-      await settingsApi.save({ interval_seconds: interval })
+      await settingsApi.save({
+        interval_seconds: interval,
+        scan_interval_seconds: scanInterval,
+        default_node_color: defaultNodeColor,
+        default_edge_color: defaultEdgeColor,
+        node_type_colors: nodeTypeColors,
+        edge_type_colors: edgeTypeColors,
+      })
+      setAppSettings({
+        intervalSeconds: interval,
+        scanIntervalSeconds: scanInterval,
+        defaultNodeColor,
+        defaultEdgeColor,
+        nodeTypeColors,
+        edgeTypeColors,
+      })
       toast.success('Settings saved')
     } catch {
       toast.error('Failed to save settings')
@@ -532,9 +652,101 @@ function SettingsPanel() {
           />
           <span className="text-xs text-muted-foreground">seconds</span>
         </div>
-        <p className="text-[10px] text-muted-foreground leading-tight">
-          How often node health is polled (ping, HTTP, SSH…)
-        </p>
+        <p className="text-[10px] text-muted-foreground leading-tight">How often node health is polled.</p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-muted-foreground">Automatic scan interval (s)</label>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={0}
+            max={86400}
+            value={scanInterval}
+            onChange={(e) => setScanInterval(Number(e.target.value))}
+            className="w-24 px-2 py-1 rounded-md text-xs font-mono bg-[#0d1117] border border-border text-foreground focus:outline-none focus:border-[#00d4ff]"
+          />
+          <span className="text-xs text-muted-foreground">0 = disabled</span>
+        </div>
+        <p className="text-[10px] text-muted-foreground leading-tight">How often the network scan runs automatically.</p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-muted-foreground">Fallback node color</label>
+        <div className="flex flex-wrap gap-1.5">
+          {COLOR_SWATCHES.map((color) => (
+            <button
+              key={`fallback-node-${color}`}
+              type="button"
+              aria-label={`fallback node ${color}`}
+              onClick={() => setDefaultNodeColor(color)}
+              className="w-5 h-5 rounded-full border-2"
+              style={{ background: color, borderColor: defaultNodeColor === color ? '#ffffff' : 'transparent' }}
+            />
+          ))}
+          <button type="button" onClick={() => setDefaultNodeColor(null)} className="px-2 py-0.5 rounded border border-border text-[10px] text-muted-foreground">Auto</button>
+        </div>
+        <p className="text-[10px] text-muted-foreground leading-tight">Used only when a node type has no custom default below.</p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-xs text-muted-foreground">Default colors by node type</label>
+        <div className="space-y-2 rounded-lg border border-border bg-[#11161d] p-2">
+          {(Object.entries(NODE_TYPE_LABELS) as [NodeType, string][]).filter(([type]) => type !== 'group' && type !== 'groupRect').map(([type, label]) => (
+            <ColorTypeRow
+              key={`node-type-${type}`}
+              label={label}
+              value={nodeTypeColors[type] ?? ''}
+              effectiveColor={nodeTypeColors[type] ?? defaultNodeColor ?? NODE_DEFAULT_COLORS[type].border}
+              onPick={(color) => setNodeTypeColors((current) => ({ ...current, [type]: color }))}
+              onHexChange={(color) => setNodeTypeColors((current) => ({ ...current, [type]: color }))}
+              onReset={() => setNodeTypeColors((current) => {
+                const next = { ...current }
+                delete next[type]
+                return next
+              })}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-muted-foreground">Fallback edge color</label>
+        <div className="flex flex-wrap gap-1.5">
+          {COLOR_SWATCHES.map((color) => (
+            <button
+              key={`fallback-edge-${color}`}
+              type="button"
+              aria-label={`fallback edge ${color}`}
+              onClick={() => setDefaultEdgeColor(color)}
+              className="w-5 h-5 rounded-full border-2"
+              style={{ background: color, borderColor: defaultEdgeColor === color ? '#ffffff' : 'transparent' }}
+            />
+          ))}
+          <button type="button" onClick={() => setDefaultEdgeColor(null)} className="px-2 py-0.5 rounded border border-border text-[10px] text-muted-foreground">Auto</button>
+        </div>
+        <p className="text-[10px] text-muted-foreground leading-tight">Used only when a connection type has no custom default below.</p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-xs text-muted-foreground">Default colors by connection type</label>
+        <div className="space-y-2 rounded-lg border border-border bg-[#11161d] p-2">
+          {(Object.entries(EDGE_TYPE_LABELS) as [EdgeType, string][]).map(([type, label]) => (
+            <ColorTypeRow
+              key={`edge-type-${type}`}
+              label={label}
+              value={edgeTypeColors[type] ?? ''}
+              effectiveColor={edgeTypeColors[type] ?? defaultEdgeColor ?? EDGE_DEFAULT_COLORS[type]}
+              onPick={(color) => setEdgeTypeColors((current) => ({ ...current, [type]: color }))}
+              onHexChange={(color) => setEdgeTypeColors((current) => ({ ...current, [type]: color }))}
+              onReset={() => setEdgeTypeColors((current) => {
+                const next = { ...current }
+                delete next[type]
+                return next
+              })}
+            />
+          ))}
+        </div>
       </div>
 
       <button
@@ -542,8 +754,88 @@ function SettingsPanel() {
         disabled={saving}
         className="w-full py-1.5 rounded-md text-xs font-medium bg-[#00d4ff]/10 text-[#00d4ff] border border-[#00d4ff]/30 hover:bg-[#00d4ff]/20 transition-colors disabled:opacity-50"
       >
-        {saving ? 'Saving…' : 'Save'}
+        {saving ? 'Saving...' : 'Save'}
       </button>
+    </div>
+  )
+}
+
+function ColorTypeRow({
+  label,
+  value,
+  effectiveColor,
+  onPick,
+  onHexChange,
+  onReset,
+}: {
+  label: string
+  value: string
+  effectiveColor: string
+  onPick: (color: string) => void
+  onHexChange: (color: string) => void
+  onReset: () => void
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-[#0d1117] px-3 py-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className="h-5 w-5 shrink-0 rounded-full border border-white/15"
+            style={{ backgroundColor: effectiveColor }}
+          />
+          <div className="min-w-0">
+            <div className="truncate text-xs text-foreground">{label}</div>
+            <div className="text-[10px] font-mono text-muted-foreground">
+              {value ? `custom ${value}` : `current ${effectiveColor}`}
+            </div>
+          </div>
+        </div>
+        <button type="button" onClick={onReset} className="text-[10px] text-muted-foreground hover:text-foreground">
+          Reset
+        </button>
+      </div>
+      <div className="mb-2 flex items-center gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => {
+            const next = event.target.value.trim()
+            if (next === '') {
+              onReset()
+              return
+            }
+            if (/^#?[0-9a-fA-F]{0,6}$/.test(next)) {
+              const normalized = next.startsWith('#') ? next : `#${next}`
+              if (normalized.length === 7) onHexChange(normalized)
+            }
+          }}
+          placeholder={effectiveColor}
+          className="w-full rounded-md border border-border bg-[#111827] px-2 py-1 text-[11px] font-mono text-foreground"
+        />
+        <span
+          className="h-7 w-7 shrink-0 rounded-md border border-white/10"
+          style={{ backgroundColor: effectiveColor }}
+        />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {COLOR_SWATCHES.map((color) => (
+          <button
+            key={`${label}-${color}`}
+            type="button"
+            aria-label={`${label} ${color}`}
+            onClick={() => onPick(color)}
+            className="flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-mono transition-colors"
+            style={{
+              background: effectiveColor === color ? `${color}22` : '#111827',
+              borderColor: effectiveColor === color ? color : '#30363d',
+              color: effectiveColor === color ? '#ffffff' : '#8b949e',
+            }}
+          >
+            <span className="h-3 w-3 rounded-full border border-white/10" style={{ backgroundColor: color }} />
+            {color}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }
@@ -587,10 +879,8 @@ function ActionButton({ icon: Icon, label, color, onClick }: ActionButtonProps) 
     'text-muted-foreground hover:text-foreground hover:bg-[#30363d]'
   return (
     <Tooltip>
-      <TooltipTrigger>
-        <button onClick={onClick} className={`p-1 rounded ${colorClass} transition-colors`}>
-          <Icon size={11} />
-        </button>
+      <TooltipTrigger onClick={onClick} className={`p-1 rounded ${colorClass} transition-colors`}>
+        <Icon size={11} />
       </TooltipTrigger>
       <TooltipContent side="bottom">{label}</TooltipContent>
     </Tooltip>
@@ -608,33 +898,35 @@ interface SidebarItemProps {
 }
 
 function SidebarItem({ icon: Icon, label, collapsed, active, badge, accent, onClick }: SidebarItemProps) {
-  const btn = (
-    <button
-      onClick={onClick}
-      className={`relative flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-sm transition-colors ${
-        active
-          ? 'bg-[#00d4ff]/10 text-[#00d4ff]'
-          : accent
-          ? 'text-[#00d4ff] hover:bg-[#00d4ff]/10'
-          : 'text-muted-foreground hover:text-foreground hover:bg-[#21262d]'
-      }`}
-    >
-      <Icon size={16} className="shrink-0" />
-      {!collapsed && <span className="truncate">{label}</span>}
-      {badge && (
-        <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[#e3b341]" />
-      )}
-    </button>
-  )
+  const className = `relative flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-sm transition-colors ${
+    active
+      ? 'bg-[#00d4ff]/10 text-[#00d4ff]'
+      : accent
+      ? 'text-[#00d4ff] hover:bg-[#00d4ff]/10'
+      : 'text-muted-foreground hover:text-foreground hover:bg-[#21262d]'
+  }`
 
   if (collapsed) {
     return (
       <Tooltip>
-        <TooltipTrigger>{btn}</TooltipTrigger>
+        <TooltipTrigger onClick={onClick} className={className}>
+          <Icon size={16} className="shrink-0" />
+          {badge && (
+            <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[#e3b341]" />
+          )}
+        </TooltipTrigger>
         <TooltipContent side="right">{label}</TooltipContent>
       </Tooltip>
     )
   }
 
-  return btn
+  return (
+    <button onClick={onClick} className={className}>
+      <Icon size={16} className="shrink-0" />
+      <span className="truncate">{label}</span>
+      {badge && (
+        <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[#e3b341]" />
+      )}
+    </button>
+  )
 }

--- a/frontend/src/components/panels/__tests__/ScanHistoryPanel.test.tsx
+++ b/frontend/src/components/panels/__tests__/ScanHistoryPanel.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/api/client', () => ({
     getConfig: vi.fn().mockResolvedValue({ data: { ranges: [] } }),
   },
   settingsApi: { get: vi.fn(), save: vi.fn() },
+  nodeHistoryApi: { list: vi.fn().mockResolvedValue({ data: [] }) },
 }))
 
 import { scanApi } from '@/api/client'

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -51,7 +51,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface AppSettingsState {
+  intervalSeconds: number
+  setSettings: (settings: { intervalSeconds: number }) => void
+}
+
+export const useSettingsStore = create<AppSettingsState>((set) => ({
+  intervalSeconds: 60,
+  setSettings: ({ intervalSeconds }) => set({ intervalSeconds }),
+}))

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -87,6 +87,11 @@ export interface NodeData extends Record<string, unknown> {
 
 export type EdgePathStyle = 'bezier' | 'smooth'
 
+export interface Waypoint {
+  x: number
+  y: number
+}
+
 export interface EdgeData extends Record<string, unknown> {
   type: EdgeType
   label?: string
@@ -95,6 +100,12 @@ export interface EdgeData extends Record<string, unknown> {
   custom_color?: string
   path_style?: EdgePathStyle
   animated?: boolean | 'snake' | 'flow' | 'none'
+  waypoints?: Waypoint[]
+}
+
+export interface NodeDimensions {
+  width?: number
+  height?: number
 }
 
 export const NODE_TYPE_LABELS: Record<NodeType, string> = {


### PR DESCRIPTION
- Add StatusTimelineModal: full-screen 24h device status history browser
  - Day selection and device filters with manual refresh button
  - Hourly sectors (overview) and 15-minute sectors (per-device detail)
  - Hover/tap sector detail panel: time range, status, check time, response time
  - Single-device detail mode accessible from left sidebar device list
  - Synchronized highlighting between selected timeline sector and event card
  - Active sector state resets on pointer leave, filter change and view reset
- Add nodeHistoryApi.list() in api/client.ts (node_id, start_date, end_date, limit)
- Add Activity icon button in Sidebar to open the modal
- Add settingsStore (intervalSeconds), NodeDimensions type
- Update dialog.tsx, types/index.ts, App.tsx for modal wiring
- Update frontend tests (ScanHistoryPanel, NodeModal)