### PR TITLE
feat: add node/edge color palette settings with per-type color overrides

### DIFF
--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -4,17 +4,30 @@ from pydantic import BaseModel
 
 from app.api.deps import get_current_user
 from app.core.config import settings
+from app.core.scheduler import reschedule_auto_scan, reschedule_status_checks
 
 router = APIRouter()
 
 
 class AppSettings(BaseModel):
     interval_seconds: int
+    scan_interval_seconds: int
+    default_node_color: str | None = None
+    default_edge_color: str | None = None
+    node_type_colors: dict[str, str] = {}
+    edge_type_colors: dict[str, str] = {}
 
 
 @router.get("", response_model=AppSettings)
 async def get_settings(_: str = Depends(get_current_user)) -> AppSettings:
-    return AppSettings(interval_seconds=settings.status_checker_interval)
+    return AppSettings(
+        interval_seconds=settings.status_checker_interval,
+        scan_interval_seconds=settings.scan_interval_seconds,
+        default_node_color=settings.default_node_color,
+        default_edge_color=settings.default_edge_color,
+        node_type_colors=settings.node_type_colors,
+        edge_type_colors=settings.edge_type_colors,
+    )
 
 
 @router.post("", response_model=AppSettings)
@@ -23,7 +36,14 @@ async def update_settings(
 ) -> AppSettings:
     try:
         settings.status_checker_interval = payload.interval_seconds
+        settings.scan_interval_seconds = payload.scan_interval_seconds
+        settings.default_node_color = payload.default_node_color
+        settings.default_edge_color = payload.default_edge_color
+        settings.node_type_colors = payload.node_type_colors
+        settings.edge_type_colors = payload.edge_type_colors
         settings.save_overrides()
+        reschedule_status_checks(payload.interval_seconds)
+        reschedule_auto_scan(payload.scan_interval_seconds)
         return payload
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,14 +2,14 @@ import json
 import logging
 from pathlib import Path
 
-from pydantic import model_validator
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     secret_key: str  # Required — set SECRET_KEY in .env
     sqlite_path: str = "./data/homelab.db"
@@ -39,11 +39,16 @@ class Settings(BaseSettings):
 
     # Status checker
     status_checker_interval: int = 60
+    scan_interval_seconds: int = 3600
+    default_node_color: str | None = None
+    default_edge_color: str | None = None
+    node_type_colors: dict[str, str] = {}
+    edge_type_colors: dict[str, str] = {}
 
     # MCP service key — set MCP_SERVICE_KEY in .env
     # Used by the MCP server to authenticate against the backend without a user password.
     # Leave empty to disable MCP service key auth.
-    mcp_service_key: str = ""
+    mcp_service_key: str = Field(default="", validation_alias=AliasChoices("MCP_SERVICE_KEY", "MCP_API_KEY"))
 
     # Live view — optional read-only public canvas endpoint.
     # Set to a random secret string to enable /api/v1/liveview?key=<value>.
@@ -61,6 +66,16 @@ class Settings(BaseSettings):
                 self.scanner_ranges = data["scanner_ranges"]
             if "status_checker_interval" in data:
                 self.status_checker_interval = int(data["status_checker_interval"])
+            if "scan_interval_seconds" in data:
+                self.scan_interval_seconds = int(data["scan_interval_seconds"])
+            if "default_node_color" in data:
+                self.default_node_color = data["default_node_color"]
+            if "default_edge_color" in data:
+                self.default_edge_color = data["default_edge_color"]
+            if "node_type_colors" in data and isinstance(data["node_type_colors"], dict):
+                self.node_type_colors = {str(k): str(v) for k, v in data["node_type_colors"].items() if v}
+            if "edge_type_colors" in data and isinstance(data["edge_type_colors"], dict):
+                self.edge_type_colors = {str(k): str(v) for k, v in data["edge_type_colors"].items() if v}
         except Exception:
             pass
 
@@ -70,6 +85,11 @@ class Settings(BaseSettings):
         self._override_path().write_text(json.dumps({
             "scanner_ranges": self.scanner_ranges,
             "status_checker_interval": self.status_checker_interval,
+            "scan_interval_seconds": self.scan_interval_seconds,
+            "default_node_color": self.default_node_color,
+            "default_edge_color": self.default_edge_color,
+            "node_type_colors": self.node_type_colors,
+            "edge_type_colors": self.edge_type_colors,
         }))
 
 

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -8,7 +8,8 @@ from sqlalchemy import select
 
 from app.core.config import settings
 from app.db.database import AsyncSessionLocal
-from app.db.models import Node
+from app.db.models import Node, NodeStatusLog, ScanRun
+from app.services.scanner import run_scan
 from app.services.status_checker import check_node
 
 logger = logging.getLogger(__name__)
@@ -22,11 +23,7 @@ async def _check_single_node(
     check_target: str | None,
     ip: str | None,
 ) -> tuple[str, dict[str, object] | None]:
-    """Run a single node check; returns (node_id, result_or_None).
-
-    Accepts plain scalars — not an ORM object — so there is no risk of
-    DetachedInstanceError when the originating session has already closed.
-    """
+    """Run a single node check; returns (node_id, result_or_None)."""
     from app.api.routes.status import broadcast_status  # avoid circular import
 
     try:
@@ -39,6 +36,12 @@ async def _check_single_node(
                 n.response_time_ms = check_result["response_time_ms"]
                 if check_result["status"] == "online":
                     n.last_seen = now
+                db.add(NodeStatusLog(
+                    node_id=node_id,
+                    status=check_result["status"],
+                    response_time_ms=check_result["response_time_ms"],
+                    checked_at=now,
+                ))
                 await db.commit()
         await broadcast_status(
             node_id=node_id,
@@ -57,7 +60,6 @@ async def _run_status_checks() -> None:
     async with AsyncSessionLocal() as db:
         result = await db.execute(select(Node))
         nodes = result.scalars().all()
-        # Extract scalars while the session is open to avoid DetachedInstanceError
         checkable = [
             (n.id, n.check_method, n.check_target, n.ip)
             for n in nodes
@@ -71,6 +73,26 @@ async def _run_status_checks() -> None:
         _check_single_node(node_id, method, target, ip)
         for node_id, method, target, ip in checkable
     ])
+
+
+async def _run_scheduled_scan() -> None:
+    ranges = [cidr for cidr in settings.scanner_ranges if cidr]
+    if not ranges:
+        logger.warning("Automatic scan skipped: no CIDR ranges configured")
+        return
+
+    async with AsyncSessionLocal() as db:
+        running = await db.execute(select(ScanRun).where(ScanRun.status == "running").limit(1))
+        if running.scalar_one_or_none() is not None:
+            logger.info("Automatic scan skipped: another scan is already running")
+            return
+
+        run = ScanRun(status="running", ranges=ranges)
+        db.add(run)
+        await db.commit()
+        await db.refresh(run)
+
+        await run_scan(ranges, db, run.id)
 
 
 def start_scheduler() -> None:
@@ -89,8 +111,24 @@ def start_scheduler() -> None:
         max_instances=1,
         coalesce=True,
     )
+    if settings.scan_interval_seconds > 0:
+        scheduler.add_job(
+            _run_scheduled_scan,
+            "interval",
+            seconds=settings.scan_interval_seconds,
+            id="scheduled_scan",
+            max_instances=1,
+            coalesce=True,
+        )
     scheduler.start()
-    logger.info("Scheduler started — status checks every %ds", settings.status_checker_interval)
+    if settings.scan_interval_seconds > 0:
+        logger.info(
+            "Scheduler started: status checks every %ds, auto-scan every %ds",
+            settings.status_checker_interval,
+            settings.scan_interval_seconds,
+        )
+    else:
+        logger.info("Scheduler started: status checks every %ds, auto-scan disabled", settings.status_checker_interval)
 
 
 def reschedule_status_checks(interval_seconds: int) -> None:
@@ -102,6 +140,33 @@ def reschedule_status_checks(interval_seconds: int) -> None:
         return
     scheduler.reschedule_job("status_checks", trigger="interval", seconds=interval_seconds)
     logger.info("Status checks rescheduled to every %ds", interval_seconds)
+
+
+def reschedule_auto_scan(interval_seconds: int) -> None:
+    if interval_seconds < 0:
+        raise ValueError(f"interval_seconds must be >= 0, got {interval_seconds}")
+    if not scheduler.running:
+        logger.warning("Scheduler not running, skipping auto-scan reschedule")
+        return
+    if interval_seconds == 0:
+        try:
+            scheduler.remove_job("scheduled_scan")
+        except Exception:
+            pass
+        logger.info("Automatic scan disabled")
+        return
+    try:
+        scheduler.reschedule_job("scheduled_scan", trigger="interval", seconds=interval_seconds)
+    except Exception:
+        scheduler.add_job(
+            _run_scheduled_scan,
+            "interval",
+            seconds=interval_seconds,
+            id="scheduled_scan",
+            max_instances=1,
+            coalesce=True,
+        )
+    logger.info("Automatic scan rescheduled to every %ds", interval_seconds)
 
 
 def stop_scheduler() -> None:

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -42,6 +42,8 @@ async def init_db() -> None:
         with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE edges ADD COLUMN target_handle TEXT")
         with suppress(OperationalError):
+            await conn.exec_driver_sql("ALTER TABLE edges ADD COLUMN waypoints JSON")
+        with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE edges ADD COLUMN animated BOOLEAN NOT NULL DEFAULT 0")
         with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN cpu_count INTEGER")
@@ -61,6 +63,19 @@ async def init_db() -> None:
             await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN bottom_handles INTEGER NOT NULL DEFAULT 1")
         with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE pending_devices ADD COLUMN discovery_source TEXT")
+            await conn.exec_driver_sql(
+                "CREATE TABLE node_status_logs ("
+                "id TEXT PRIMARY KEY, "
+                "node_id TEXT NOT NULL, "
+                "status TEXT NOT NULL, "
+                "response_time_ms INTEGER, "
+                "checked_at DATETIME, "
+                "FOREIGN KEY(node_id) REFERENCES nodes (id) ON DELETE CASCADE)"
+            )
+        with suppress(OperationalError):
+            await conn.exec_driver_sql("CREATE INDEX ix_node_status_logs_node_id ON node_status_logs (node_id)")
+        with suppress(OperationalError):
+            await conn.exec_driver_sql("CREATE INDEX ix_node_status_logs_checked_at ON node_status_logs (checked_at)")
         # Migrate animated column from boolean (0/1) to string ('none'/'snake')
         with suppress(OperationalError):
             await conn.exec_driver_sql("UPDATE edges SET animated = 'snake' WHERE animated = '1' OR animated = 1")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -35,6 +35,7 @@ class Node(Base):
     pos_y: Mapped[float] = mapped_column(Float, default=0)
     parent_id: Mapped[str | None] = mapped_column(String, ForeignKey("nodes.id", ondelete="CASCADE"))
     container_mode: Mapped[bool] = mapped_column(Boolean, default=False)
+    isp_layout: Mapped[str] = mapped_column(String, nullable=False, default="single")
     custom_colors: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     custom_icon: Mapped[str | None] = mapped_column(String, nullable=True)
     cpu_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -69,6 +70,7 @@ class Edge(Base):
     animated: Mapped[str] = mapped_column(String, nullable=False, default='none')
     source_handle: Mapped[str | None] = mapped_column(String)
     target_handle: Mapped[str | None] = mapped_column(String)
+    waypoints: Mapped[list[dict[str, float]] | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
 
@@ -105,3 +107,13 @@ class ScanRun(Base):
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     error: Mapped[str | None] = mapped_column(Text)
+
+
+class NodeStatusLog(Base):
+    __tablename__ = "node_status_logs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    node_id: Mapped[str] = mapped_column(String, ForeignKey("nodes.id", ondelete="CASCADE"), index=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    response_time_ms: Mapped[int | None] = mapped_column(Integer)
+    checked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, index=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.routes import auth, canvas, edges, liveview, nodes, scan, status
+from app.api.routes import auth, canvas, edges, liveview, node_history, nodes, scan, status
 from app.api.routes import settings as settings_routes
 from app.core.config import settings
 from app.core.scheduler import start_scheduler, stop_scheduler
@@ -53,6 +53,7 @@ app.include_router(edges.router, prefix="/api/v1/edges", tags=["edges"])
 app.include_router(canvas.router, prefix="/api/v1/canvas", tags=["canvas"])
 app.include_router(scan.router, prefix="/api/v1/scan", tags=["scan"])
 app.include_router(status.router, prefix="/api/v1/status", tags=["status"])
+app.include_router(node_history.router, prefix="/api/v1/node-history", tags=["node-history"])
 app.include_router(settings_routes.router, prefix="/api/v1/settings", tags=["settings"])
 app.include_router(liveview.router, prefix="/api/v1/liveview", tags=["liveview"])
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,13 +1,20 @@
-"""Tests for background scheduler: _run_status_checks, lifecycle."""
+"""Tests for background scheduler: status checks, scheduled scans, lifecycle."""
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from app.core.scheduler import _run_status_checks, start_scheduler, stop_scheduler
+from app.core.scheduler import (
+    _run_scheduled_scan,
+    _run_status_checks,
+    reschedule_auto_scan,
+    start_scheduler,
+    stop_scheduler,
+)
 from app.db.database import Base
-from app.db.models import Node
+from app.db.models import Node, ScanRun
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -136,14 +143,18 @@ async def test_run_status_checks_handles_check_error_gracefully(mem_db):
 # ---------------------------------------------------------------------------
 
 def test_scheduler_uses_settings_interval():
-    """Scheduler registers the job with the interval from settings."""
+    """Scheduler registers the status-check job with the interval from settings."""
     mock_sched = MagicMock()
     with patch("app.core.scheduler.settings") as mock_settings, \
          patch("app.core.scheduler.AsyncIOScheduler", return_value=mock_sched):
         mock_settings.status_checker_interval = 45
+        mock_settings.scan_interval_seconds = 300
         start_scheduler()
-        _, kwargs = mock_sched.add_job.call_args
-        assert kwargs["seconds"] == 45
+        calls = mock_sched.add_job.call_args_list
+        assert calls[0].kwargs["seconds"] == 45
+        assert calls[0].kwargs["id"] == "status_checks"
+        assert calls[1].kwargs["seconds"] == 300
+        assert calls[1].kwargs["id"] == "scheduled_scan"
 
 
 def test_start_and_stop_scheduler():
@@ -152,6 +163,64 @@ def test_start_and_stop_scheduler():
     with patch("app.core.scheduler.AsyncIOScheduler", return_value=mock_sched):
         start_scheduler()
         stop_scheduler()
-        mock_sched.add_job.assert_called_once()
+        assert mock_sched.add_job.call_count == 2
         mock_sched.start.assert_called_once()
         mock_sched.shutdown.assert_called_once()
+
+
+def test_start_scheduler_skips_auto_scan_when_disabled():
+    mock_sched = MagicMock()
+    with patch("app.core.scheduler.settings") as mock_settings, \
+         patch("app.core.scheduler.AsyncIOScheduler", return_value=mock_sched):
+        mock_settings.status_checker_interval = 45
+        mock_settings.scan_interval_seconds = 0
+        start_scheduler()
+        assert mock_sched.add_job.call_count == 1
+        assert mock_sched.add_job.call_args.kwargs["id"] == "status_checks"
+
+
+def test_reschedule_auto_scan_disables_job():
+    mock_sched = MagicMock()
+    mock_sched.running = True
+    with patch("app.core.scheduler.scheduler", mock_sched):
+        reschedule_auto_scan(0)
+    mock_sched.remove_job.assert_called_once_with("scheduled_scan")
+
+
+def test_reschedule_auto_scan_updates_existing_job():
+    mock_sched = MagicMock()
+    mock_sched.running = True
+    with patch("app.core.scheduler.scheduler", mock_sched):
+        reschedule_auto_scan(120)
+    mock_sched.reschedule_job.assert_called_once_with("scheduled_scan", trigger="interval", seconds=120)
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_scan_creates_scan_run_and_calls_runner(mem_db):
+    with patch("app.core.scheduler.AsyncSessionLocal", mem_db), \
+         patch("app.core.scheduler.settings") as mock_settings, \
+         patch("app.core.scheduler.run_scan", new_callable=AsyncMock) as mock_run_scan:
+        mock_settings.scanner_ranges = ["192.168.1.0/24"]
+        await _run_scheduled_scan()
+
+    async with mem_db() as session:
+        runs = list((await session.execute(select(ScanRun))).scalars().all())
+        assert len(runs) == 1
+        assert runs[0].ranges == ["192.168.1.0/24"]
+
+    mock_run_scan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_scan_skips_when_another_scan_is_running(mem_db):
+    async with mem_db() as session:
+        session.add(ScanRun(id=str(uuid.uuid4()), status="running", ranges=["10.0.0.0/24"]))
+        await session.commit()
+
+    with patch("app.core.scheduler.AsyncSessionLocal", mem_db), \
+         patch("app.core.scheduler.settings") as mock_settings, \
+         patch("app.core.scheduler.run_scan", new_callable=AsyncMock) as mock_run_scan:
+        mock_settings.scanner_ranges = ["192.168.1.0/24"]
+        await _run_scheduled_scan()
+
+    mock_run_scan.assert_not_called()

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -24,21 +24,39 @@ async def test_get_settings_returns_interval(client: AsyncClient, headers):
     assert res.status_code == 200
     data = res.json()
     assert "interval_seconds" in data
+    assert "scan_interval_seconds" in data
+    assert "node_type_colors" in data
+    assert "edge_type_colors" in data
     assert isinstance(data["interval_seconds"], int)
 
 
 @pytest.mark.asyncio
 async def test_update_settings_saves_interval(client: AsyncClient, headers):
-    with patch("app.api.routes.settings.settings") as mock_settings:
+    with patch("app.api.routes.settings.settings") as mock_settings, \
+         patch("app.api.routes.settings.reschedule_status_checks") as mock_reschedule_status, \
+         patch("app.api.routes.settings.reschedule_auto_scan") as mock_reschedule_scan:
         mock_settings.status_checker_interval = 60
+        mock_settings.scan_interval_seconds = 300
+        mock_settings.node_type_colors = {}
+        mock_settings.edge_type_colors = {}
         mock_settings.save_overrides = lambda: None
         res = await client.post(
             "/api/v1/settings",
-            json={"interval_seconds": 120},
+            json={
+                "interval_seconds": 120,
+                "scan_interval_seconds": 600,
+                "node_type_colors": {"router": "#ff6e00"},
+                "edge_type_colors": {"wifi": "#39d353"},
+            },
             headers=headers,
         )
     assert res.status_code == 200
     assert res.json()["interval_seconds"] == 120
+    assert res.json()["scan_interval_seconds"] == 600
+    assert res.json()["node_type_colors"] == {"router": "#ff6e00"}
+    assert res.json()["edge_type_colors"] == {"wifi": "#39d353"}
+    mock_reschedule_status.assert_called_once_with(120)
+    mock_reschedule_scan.assert_called_once_with(600)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
-import { ReactFlowProvider, type Connection, type Edge } from '@xyflow/react'
+import { ReactFlowProvider, type Connection } from '@xyflow/react'
 import { type Node } from '@xyflow/react'
 import { applyDagreLayout } from '@/utils/layout'
 import { serializeNode, serializeEdge, deserializeApiNode, deserializeApiEdge, type ApiNode, type ApiEdge } from '@/utils/canvasSerializer'
@@ -26,19 +26,21 @@ import { ShortcutsModal } from '@/components/modals/ShortcutsModal'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { useAuthStore } from '@/stores/authStore'
 import { useThemeStore } from '@/stores/themeStore'
-import { canvasApi } from '@/api/client'
+import { canvasApi, settingsApi } from '@/api/client'
 import { demoNodes, demoEdges } from '@/utils/demoData'
 import { useStatusPolling } from '@/hooks/useStatusPolling'
-import type { NodeData, EdgeData } from '@/types'
+import type { NodeData, EdgeData, NodeDimensions } from '@/types'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 const STANDALONE_STORAGE_KEY = 'homelable_canvas'
 
 export default function App() {
-  const { loadCanvas, markSaved, markUnsaved, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, nodes, edges, snapshotHistory, undo, redo, copySelectedNodes, pasteNodes } = useCanvasStore()
+  const { loadCanvas, markSaved, markUnsaved, selectedNodeId, selectedNodeIds, addNode, updateNode, setNodeDimensions, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, nodes, edges, snapshotHistory, undo, redo, copySelectedNodes, pasteNodes } = useCanvasStore()
   const canvasRef = useRef<HTMLDivElement>(null)
   const { isAuthenticated } = useAuthStore()
   const { activeTheme, setTheme } = useThemeStore()
+  const setAppSettings = useSettingsStore((s) => s.setSettings)
 
   useStatusPolling()
 
@@ -78,6 +80,20 @@ export default function App() {
   useEffect(() => { handleSaveRef.current = handleSave }, [handleSave])
 
   // Load canvas on auth (or immediately in standalone mode)
+  useEffect(() => {
+    if (STANDALONE || !isAuthenticated) return
+    settingsApi.get()
+      .then((res) => setAppSettings({
+        intervalSeconds: res.data.interval_seconds,
+        scanIntervalSeconds: res.data.scan_interval_seconds,
+        defaultNodeColor: res.data.default_node_color ?? null,
+        defaultEdgeColor: res.data.default_edge_color ?? null,
+        nodeTypeColors: res.data.node_type_colors ?? {},
+        edgeTypeColors: res.data.edge_type_colors ?? {},
+      }))
+      .catch(() => undefined)
+  }, [isAuthenticated, setAppSettings])
+
   useEffect(() => {
     if (STANDALONE) {
       try {
@@ -147,7 +163,7 @@ export default function App() {
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
-  const handleAddNode = useCallback((data: Partial<NodeData>) => {
+  const handleAddNode = useCallback((data: Partial<NodeData>, dimensions?: NodeDimensions) => {
     snapshotHistory()
     const id = generateUUID()
     const isProxmox = data.type === 'proxmox'
@@ -163,7 +179,8 @@ export default function App() {
       position,
       data: { status: 'unknown', services: [], ...data } as NodeData,
       ...(data.parent_id ? { parentId: data.parent_id, extent: 'parent' as const } : {}),
-      ...(isProxmox ? { width: 300, height: 200 } : {}),
+      width: dimensions?.width ?? (isProxmox ? 300 : undefined),
+      height: dimensions?.height ?? (isProxmox ? 200 : undefined),
     }
     addNode(newNode)
     toast.success(`Added "${data.label}"`)
@@ -236,11 +253,14 @@ export default function App() {
     setEditNodeId(id)
   }, [])
 
-  const handleUpdateNode = useCallback((data: Partial<NodeData>) => {
+  const handleUpdateNode = useCallback((data: Partial<NodeData>, dimensions?: NodeDimensions) => {
     if (!editNodeId) return
     snapshotHistory()
     const existingNode = nodes.find((n) => n.id === editNodeId)
     updateNode(editNodeId, data)
+    if (dimensions) {
+      setNodeDimensions(editNodeId, dimensions.width, dimensions.height)
+    }
     // If proxmox container_mode changed, apply structural changes (children parentId, node dimensions)
     if (data.type === 'proxmox' && typeof data.container_mode === 'boolean') {
       setProxmoxContainerMode(editNodeId, data.container_mode)
@@ -271,7 +291,7 @@ export default function App() {
       }
     }
     setEditNodeId(null)
-  }, [editNodeId, updateNode, setProxmoxContainerMode, nodes, edges, deleteEdge, onConnect, snapshotHistory])
+  }, [editNodeId, updateNode, setNodeDimensions, setProxmoxContainerMode, nodes, edges, deleteEdge, onConnect, snapshotHistory])
 
   const handleAutoLayout = useCallback(() => {
     const laid = applyDagreLayout(nodes, edges)
@@ -339,8 +359,8 @@ export default function App() {
     setPendingConnection(null)
   }, [pendingConnection, onConnect, nodes, updateNode, snapshotHistory])
 
-  const handleEdgeDoubleClick = useCallback((edge: Edge<EdgeData>) => {
-    setEditEdgeId(edge.id)
+  const handleEdgeEditRequest = useCallback((edgeId: string) => {
+    setEditEdgeId(edgeId)
   }, [])
 
   const handleEdgeUpdate = useCallback((data: EdgeData) => {
@@ -359,6 +379,17 @@ export default function App() {
 
   const editNode = editNodeId ? nodes.find((n) => n.id === editNodeId) : null
   const editEdge = editEdgeId ? edges.find((e) => e.id === editEdgeId) : null
+
+  useEffect(() => {
+    const handleOpenEdgeEditor = (event: Event) => {
+      const detail = (event as CustomEvent<{ edgeId?: string }>).detail
+      if (detail?.edgeId) {
+        handleEdgeEditRequest(detail.edgeId)
+      }
+    }
+    window.addEventListener('homelable:edit-edge', handleOpenEdgeEditor)
+    return () => window.removeEventListener('homelable:edit-edge', handleOpenEdgeEditor)
+  }, [handleEdgeEditRequest])
 
   if (!STANDALONE && !isAuthenticated) return <LoginPage />
 
@@ -392,7 +423,6 @@ export default function App() {
               <div ref={canvasRef} className="flex-1 min-w-0 h-full">
                 <CanvasContainer
                   onConnect={handleEdgeConnect}
-                  onEdgeDoubleClick={handleEdgeDoubleClick}
                   onNodeDragStart={snapshotHistory}
                   onOpenPending={(deviceId) => {
                     setHighlightPendingId(undefined)
@@ -424,6 +454,7 @@ export default function App() {
           onClose={() => setEditNodeId(null)}
           onSubmit={handleUpdateNode}
           initial={editNode?.data}
+          initialDimensions={{ width: editNode?.width, height: editNode?.height }}
           title="Edit Node"
           proxmoxNodes={nodes.filter((n) => n.type === 'proxmox').map((n) => ({ id: n.id, label: n.data.label }))}
         />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -66,6 +66,32 @@ export const scanApi = {
 }
 
 export const settingsApi = {
-  get: () => api.get<{ interval_seconds: number }>('/settings'),
-  save: (data: { interval_seconds: number }) => api.post<{ interval_seconds: number }>('/settings', data),
+  get: () => api.get<{
+    interval_seconds: number
+    scan_interval_seconds: number
+    default_node_color: string | null
+    default_edge_color: string | null
+    node_type_colors: Record<string, string>
+    edge_type_colors: Record<string, string>
+  }>('/settings'),
+  save: (data: {
+    interval_seconds: number
+    scan_interval_seconds: number
+    default_node_color: string | null
+    default_edge_color: string | null
+    node_type_colors: Record<string, string>
+    edge_type_colors: Record<string, string>
+  }) =>
+    api.post<{
+      interval_seconds: number
+      scan_interval_seconds: number
+      default_node_color: string | null
+      default_edge_color: string | null
+      node_type_colors: Record<string, string>
+      edge_type_colors: Record<string, string>
+    }>('/settings', data),
+}
+
+export const nodeHistoryApi = {
+  list: (params?: { node_id?: string; start_date?: string; end_date?: string; limit?: number }) => api.get('/node-history', { params }),
 }

--- a/frontend/src/components/canvas/CanvasContainer.tsx
+++ b/frontend/src/components/canvas/CanvasContainer.tsx
@@ -9,7 +9,6 @@ import {
   SelectionMode,
   useReactFlow,
   type Node,
-  type Edge,
   type Connection,
 } from '@xyflow/react'
 import { MousePointer2, Hand } from 'lucide-react'
@@ -20,16 +19,15 @@ import { THEMES } from '@/utils/themes'
 import { nodeTypes } from './nodes/nodeTypes'
 import { edgeTypes } from './edges/edgeTypes'
 import { SearchBar } from './SearchBar'
-import type { NodeData, EdgeData } from '@/types'
+import type { NodeData } from '@/types'
 
 interface CanvasContainerProps {
   onConnect?: (connection: Connection) => void
-  onEdgeDoubleClick?: (edge: Edge<EdgeData>) => void
   onNodeDragStart?: () => void
   onOpenPending?: (deviceId: string) => void
 }
 
-export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, onNodeDragStart, onOpenPending }: CanvasContainerProps) {
+export function CanvasContainer({ onConnect: onConnectProp, onNodeDragStart, onOpenPending }: CanvasContainerProps) {
   const [lassoMode, setLassoMode] = useState(true)
   const {
     nodes, edges,
@@ -64,10 +62,6 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
     setSelectedNode(null)
   }, [setSelectedNode])
 
-  const handleEdgeDoubleClick = useCallback((_: React.MouseEvent, edge: Edge<EdgeData>) => {
-    onEdgeDoubleClick?.(edge)
-  }, [onEdgeDoubleClick])
-
   return (
     <div className="w-full h-full" style={{ background: theme.colors.canvasBackground }}>
       <ReactFlow
@@ -78,7 +72,6 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
         onConnect={onConnectProp}
         onNodeClick={onNodeClick}
         onPaneClick={onPaneClick}
-        onEdgeDoubleClick={handleEdgeDoubleClick}
         onNodeDragStart={onNodeDragStart}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}

--- a/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
@@ -6,7 +6,6 @@ import { useThemeStore } from '@/stores/themeStore'
 import type { Node, Edge } from '@xyflow/react'
 import type { NodeData, EdgeData } from '@/types'
 
-// Capture props passed to ReactFlow so we can test the callbacks
 let rfProps: Record<string, unknown> = {}
 
 vi.mock('@xyflow/react', () => ({
@@ -45,8 +44,6 @@ describe('CanvasContainer', () => {
     useThemeStore.setState({ activeTheme: 'default' })
   })
 
-  // ── Rendering ─────────────────────────────────────────────────────────────
-
   it('renders without crashing', () => {
     const { getByTestId } = render(<CanvasContainer />)
     expect(getByTestId('react-flow')).toBeDefined()
@@ -67,8 +64,6 @@ describe('CanvasContainer', () => {
     expect((rfProps.edges as Edge[]).length).toBe(1)
   })
 
-  // ── Node click → selection ────────────────────────────────────────────────
-
   it('calls setSelectedNode with node id on node click', () => {
     const node = makeNode('n1')
     useCanvasStore.setState({ nodes: [node] })
@@ -77,34 +72,12 @@ describe('CanvasContainer', () => {
     expect(useCanvasStore.getState().selectedNodeId).toBe('n1')
   })
 
-  // ── Pane click → deselect ─────────────────────────────────────────────────
-
   it('calls setSelectedNode(null) on pane click', () => {
     useCanvasStore.setState({ selectedNodeId: 'n1' })
     render(<CanvasContainer />)
     ;(rfProps.onPaneClick as (...args: unknown[]) => unknown)()
     expect(useCanvasStore.getState().selectedNodeId).toBeNull()
   })
-
-  // ── Edge double-click ─────────────────────────────────────────────────────
-
-  it('calls onEdgeDoubleClick prop when an edge is double-clicked', () => {
-    const onEdgeDoubleClick = vi.fn()
-    const edge = makeEdge('e1')
-    render(<CanvasContainer onEdgeDoubleClick={onEdgeDoubleClick} />)
-    ;(rfProps.onEdgeDoubleClick as (...args: unknown[]) => unknown)({} as MouseEvent, edge)
-    expect(onEdgeDoubleClick).toHaveBeenCalledWith(edge)
-  })
-
-  it('does not throw when onEdgeDoubleClick is not provided', () => {
-    const edge = makeEdge('e1')
-    render(<CanvasContainer />)
-    expect(() => {
-      ;(rfProps.onEdgeDoubleClick as (...args: unknown[]) => unknown)({} as MouseEvent, edge)
-    }).not.toThrow()
-  })
-
-  // ── Connection validation ─────────────────────────────────────────────────
 
   it('isValidConnection returns false for self-connections', () => {
     render(<CanvasContainer />)
@@ -118,8 +91,6 @@ describe('CanvasContainer', () => {
     expect(isValid({ source: 'n1', target: 'n2' })).toBe(true)
   })
 
-  // ── onConnect prop passthrough ────────────────────────────────────────────
-
   it('passes onConnect prop to ReactFlow', () => {
     const onConnect = vi.fn()
     render(<CanvasContainer onConnect={onConnect} />)
@@ -127,15 +98,11 @@ describe('CanvasContainer', () => {
     expect(onConnect).toHaveBeenCalledOnce()
   })
 
-  // ── onNodeDragStart prop passthrough ──────────────────────────────────────
-
   it('passes onNodeDragStart prop to ReactFlow', () => {
     const onNodeDragStart = vi.fn()
     render(<CanvasContainer onNodeDragStart={onNodeDragStart} />)
     expect(rfProps.onNodeDragStart).toBe(onNodeDragStart)
   })
-
-  // ── Canvas settings ───────────────────────────────────────────────────────
 
   it('enables snapToGrid', () => {
     render(<CanvasContainer />)
@@ -147,14 +114,10 @@ describe('CanvasContainer', () => {
     expect(rfProps.snapGrid).toEqual([16, 16])
   })
 
-  // ── Delete key ────────────────────────────────────────────────────────────
-
   it('sets deleteKeyCode to include both Backspace and Delete', () => {
     render(<CanvasContainer />)
     expect(rfProps.deleteKeyCode).toEqual(['Backspace', 'Delete'])
   })
-
-  // ── Lasso / multi-select ──────────────────────────────────────────────────
 
   it('enables selectionOnDrag for lasso selection', () => {
     render(<CanvasContainer />)
@@ -181,7 +144,7 @@ describe('CanvasContainer', () => {
     expect(rfProps.multiSelectionKeyCode).toEqual(['Meta', 'Control'])
   })
 
-  it('clears selectedNode (sets null) on Ctrl+click instead of selecting', () => {
+  it('clears selectedNode on Ctrl+click instead of selecting', () => {
     const node = makeNode('n1')
     useCanvasStore.setState({ nodes: [node], selectedNodeId: 'n1' })
     render(<CanvasContainer />)
@@ -192,7 +155,7 @@ describe('CanvasContainer', () => {
     expect(useCanvasStore.getState().selectedNodeId).toBeNull()
   })
 
-  it('clears selectedNode (sets null) on Cmd+click', () => {
+  it('clears selectedNode on Cmd+click', () => {
     const node = makeNode('n1')
     useCanvasStore.setState({ nodes: [node], selectedNodeId: 'n1' })
     render(<CanvasContainer />)
@@ -202,8 +165,6 @@ describe('CanvasContainer', () => {
     )
     expect(useCanvasStore.getState().selectedNodeId).toBeNull()
   })
-
-  // ── onBeforeDelete snapshot ───────────────────────────────────────────────
 
   it('onBeforeDelete calls snapshotHistory and returns true', async () => {
     const snapshotHistory = vi.fn()

--- a/frontend/src/components/canvas/edges/index.tsx
+++ b/frontend/src/components/canvas/edges/index.tsx
@@ -3,13 +3,16 @@ import {
   EdgeLabelRenderer,
   getBezierPath,
   getSmoothStepPath,
+  useReactFlow,
   useStore,
   type EdgeProps,
   type Edge,
 } from '@xyflow/react'
-import type { EdgeData, EdgeType } from '@/types'
+import { Pencil, Plus, RouteOff } from 'lucide-react'
+import type { EdgeData, EdgeType, Waypoint } from '@/types'
 import { useThemeStore } from '@/stores/themeStore'
 import { THEMES } from '@/utils/themes'
+import { useCanvasStore } from '@/stores/canvasStore'
 
 const VLAN_COLORS = ['#00d4ff', '#a855f7', '#39d353', '#ff6e00', '#e3b341', '#f85149']
 
@@ -18,28 +21,82 @@ function getVlanColor(vlanId?: number): string {
   return VLAN_COLORS[vlanId % VLAN_COLORS.length]
 }
 
-export function HomelableEdge({ id, source, target, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, data, selected }: EdgeProps<Edge<EdgeData>>) {
+function buildOrthogonalPoints(points: Waypoint[]): Waypoint[] {
+  if (points.length < 2) return points
+  const orthogonal: Waypoint[] = [points[0]]
+  for (let index = 1; index < points.length; index += 1) {
+    const next = points[index]
+    const previous = orthogonal[orthogonal.length - 1]
+    if (previous.x === next.x || previous.y === next.y) {
+      orthogonal.push(next)
+      continue
+    }
+    const beforePrevious = orthogonal.length > 1 ? orthogonal[orthogonal.length - 2] : null
+    const previousWasHorizontal = beforePrevious
+      ? beforePrevious.y === previous.y
+      : Math.abs(next.x - previous.x) >= Math.abs(next.y - previous.y)
+    const elbow = previousWasHorizontal
+      ? { x: previous.x, y: next.y }
+      : { x: next.x, y: previous.y }
+    orthogonal.push(elbow, next)
+  }
+  return orthogonal
+}
+
+function buildWaypointPath(points: Waypoint[], smooth: boolean): string {
+  if (points.length < 2) return ''
+  if (!smooth) {
+    return `M ${points[0].x},${points[0].y} ` + points.slice(1).map((p) => `L ${p.x},${p.y}`).join(' ')
+  }
+  const orthogonalPoints = buildOrthogonalPoints(points)
+  return `M ${orthogonalPoints[0].x},${orthogonalPoints[0].y} ` + orthogonalPoints.slice(1).map((p) => `L ${p.x},${p.y}`).join(' ')
+}
+
+export function HomelableEdge({
+  id,
+  source,
+  target,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  selected,
+}: EdgeProps<Edge<EdgeData>>) {
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const theme = THEMES[activeTheme]
+  const { screenToFlowPosition } = useReactFlow()
+  const updateEdge = useCanvasStore((s) => s.updateEdge)
+  const snapshotHistory = useCanvasStore((s) => s.snapshotHistory)
   const sourceType = useStore((s) => s.nodeLookup.get(source)?.type)
   const targetType = useStore((s) => s.nodeLookup.get(target)?.type)
   const isBidirectional = sourceType === 'proxmox' && targetType === 'proxmox'
+  const waypoints = (data?.waypoints ?? []) as Waypoint[]
+  const points: Waypoint[] = [{ x: sourceX, y: sourceY }, ...waypoints, { x: targetX, y: targetY }]
 
   const pathArgs = { sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition }
-  const [edgePath, labelX] = data?.path_style === 'smooth'
+  const [fallbackPath, fallbackLabelX, fallbackLabelY] = data?.path_style === 'smooth'
     ? getSmoothStepPath({ ...pathArgs, borderRadius: 8 })
     : getBezierPath(pathArgs)
+  const edgePath = waypoints.length > 0
+    ? buildWaypointPath(points, data?.path_style === 'smooth')
+    : fallbackPath
+  const waypointMidpoint = points[Math.floor(points.length / 2)]
+  const labelX = waypointMidpoint?.x ?? fallbackLabelX
+  const labelY = waypointMidpoint?.y ?? fallbackLabelY
 
   const edgeType: EdgeType = data?.type ?? 'ethernet'
   const edgeColors = theme.colors.edgeColors
 
   const BASE_STYLES: Record<EdgeType, React.CSSProperties> = {
     ethernet: { stroke: edgeColors.ethernet, strokeWidth: 2 },
-    wifi:     { stroke: edgeColors.wifi,     strokeWidth: 1.5, strokeDasharray: '6 3' },
-    iot:      { stroke: edgeColors.iot,      strokeWidth: 1.5, strokeDasharray: '2 4' },
-    vlan:     { strokeWidth: 2.5 },
-    virtual:  { stroke: edgeColors.virtual,  strokeWidth: 1,   strokeDasharray: '4 4' },
-    cluster:  { stroke: edgeColors.cluster,  strokeWidth: 2.5, strokeDasharray: '8 3' },
+    wifi: { stroke: edgeColors.wifi, strokeWidth: 1.5, strokeDasharray: '6 3' },
+    iot: { stroke: edgeColors.iot, strokeWidth: 1.5, strokeDasharray: '2 4' },
+    vlan: { strokeWidth: 2.5 },
+    virtual: { stroke: edgeColors.virtual, strokeWidth: 1, strokeDasharray: '4 4' },
+    cluster: { stroke: edgeColors.cluster, strokeWidth: 2.5, strokeDasharray: '8 3' },
   }
 
   const customColor = data?.custom_color as string | undefined
@@ -50,16 +107,81 @@ export function HomelableEdge({ id, source, target, sourceX, sourceY, targetX, t
     ...(selected ? { stroke: theme.colors.edgeSelectedColor, filter: `drop-shadow(0 0 4px ${theme.colors.edgeSelectedColor}88)` } : {}),
   }
 
-  // Normalize animated value — supports legacy boolean (true → 'snake')
   const animMode: 'none' | 'snake' | 'flow' =
     data?.animated === true || data?.animated === 'snake' ? 'snake' :
     data?.animated === 'flow' ? 'flow' : 'none'
 
-  const animColor = customColor ?? (edgeType === 'vlan' ? getVlanColor(data?.vlan_id as number | undefined) : edgeColors[edgeType as keyof typeof edgeColors] as string)
+  const animColor = customColor ?? (
+    edgeType === 'vlan'
+      ? getVlanColor(data?.vlan_id as number | undefined)
+      : edgeColors[edgeType as keyof typeof edgeColors] as string
+  )
+
+  const replaceWaypoint = (index: number, nextWaypoint: Waypoint) => {
+    const next = [...waypoints]
+    next[index] = nextWaypoint
+    updateEdge(id, { waypoints: next })
+  }
+
+  const addWaypoint = () => {
+    snapshotHistory()
+    if (points.length < 2) return
+    let segmentIndex = 0
+    let longestDistance = -1
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const a = points[index]
+      const b = points[index + 1]
+      const distance = Math.hypot(b.x - a.x, b.y - a.y)
+      if (distance > longestDistance) {
+        longestDistance = distance
+        segmentIndex = index
+      }
+    }
+    const start = points[segmentIndex]
+    const end = points[segmentIndex + 1]
+    const midpoint = {
+      x: (start.x + end.x) / 2,
+      y: (start.y + end.y) / 2,
+    }
+    const nextWaypoints = [...waypoints]
+    nextWaypoints.splice(segmentIndex, 0, midpoint)
+    updateEdge(id, { waypoints: nextWaypoints, path_style: 'smooth' })
+  }
+
+  const removeWaypoint = (index: number) => {
+    snapshotHistory()
+    updateEdge(id, { waypoints: waypoints.filter((_, waypointIndex) => waypointIndex !== index) })
+  }
+
+  const startDragWaypoint = (index: number, event: React.MouseEvent<SVGCircleElement>) => {
+    event.stopPropagation()
+    snapshotHistory()
+    const move = (moveEvent: MouseEvent) => {
+      const next = screenToFlowPosition({ x: moveEvent.clientX, y: moveEvent.clientY })
+      replaceWaypoint(index, { x: next.x, y: next.y })
+    }
+    const up = () => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
+
+  const clearWaypoints = () => {
+    if (waypoints.length === 0) return
+    snapshotHistory()
+    updateEdge(id, { waypoints: [] })
+  }
+
+  const openEdgeEditor = () => {
+    window.dispatchEvent(new CustomEvent('homelable:edit-edge', { detail: { edgeId: id } }))
+  }
 
   return (
     <>
       <BaseEdge id={id} path={edgePath} style={style} />
+      <path d={edgePath} fill="none" stroke="transparent" strokeWidth={20} />
       {animMode === 'snake' && (
         <path
           d={edgePath}
@@ -91,16 +213,93 @@ export function HomelableEdge({ id, source, target, sourceX, sourceY, targetX, t
           <animate attributeName="stroke-dashoffset" from="0" to="18" dur="1.2s" repeatCount="indefinite" />
         </path>
       )}
+      {selected && (
+        <EdgeLabelRenderer>
+          <div
+            className="absolute flex items-center gap-1 rounded-md border px-1.5 py-1 pointer-events-auto"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY - 28}px)`,
+              background: theme.colors.nodeCardBackground,
+              borderColor: theme.colors.edgeLabelBorder,
+              boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+            }}
+          >
+            <button
+              type="button"
+              onClick={openEdgeEditor}
+              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-foreground hover:bg-white/5"
+            >
+              <Pencil size={10} />
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={addWaypoint}
+              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-foreground hover:bg-white/5"
+            >
+              <Plus size={10} />
+              Point
+            </button>
+            <button
+              type="button"
+              onClick={clearWaypoints}
+              disabled={waypoints.length === 0}
+              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-foreground hover:bg-white/5 disabled:opacity-40"
+            >
+              <RouteOff size={10} />
+              Reset
+            </button>
+          </div>
+        </EdgeLabelRenderer>
+      )}
+      {selected && waypoints.map((waypoint, index) => (
+        <g key={`${id}-waypoint-${index}`}>
+          <circle
+            cx={waypoint.x}
+            cy={waypoint.y}
+            r={6}
+            fill={theme.colors.nodeCardBackground}
+            stroke={animColor}
+            strokeWidth={2}
+            onMouseDown={(event) => startDragWaypoint(index, event)}
+            onDoubleClick={() => removeWaypoint(index)}
+            style={{ cursor: 'grab', pointerEvents: 'all' }}
+          />
+          <circle
+            cx={waypoint.x + 9}
+            cy={waypoint.y - 9}
+            r={6}
+            fill={theme.colors.nodeCardBackground}
+            stroke={theme.colors.edgeLabelBorder}
+            strokeWidth={1.5}
+            onClick={(event) => {
+              event.stopPropagation()
+              removeWaypoint(index)
+            }}
+            style={{ cursor: 'pointer', pointerEvents: 'all' }}
+          />
+          <text
+            x={waypoint.x + 9}
+            y={waypoint.y - 5.5}
+            textAnchor="middle"
+            fontSize="10"
+            fill={theme.colors.nodeLabelColor}
+            style={{ pointerEvents: 'none', userSelect: 'none' }}
+          >
+            x
+          </text>
+        </g>
+      ))}
 
       {data?.label && (
         <EdgeLabelRenderer>
           <div
             className="absolute pointer-events-none font-mono text-[10px] px-1.5 py-0.5 rounded"
             style={{
-              transform: `translate(-50%, -50%) translate(${labelX}px, ${(sourceY + targetY) / 2}px)`,
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
               background: theme.colors.edgeLabelBackground,
-              color:      theme.colors.edgeLabelColor,
-              border:     `1px solid ${theme.colors.edgeLabelBorder}`,
+              color: theme.colors.edgeLabelColor,
+              border: `1px solid ${theme.colors.edgeLabelBorder}`,
             }}
           >
             {data.label as string}

--- a/frontend/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/canvas/nodes/BaseNode.tsx
@@ -12,17 +12,34 @@ import { BOTTOM_HANDLE_IDS, BOTTOM_HANDLE_POSITIONS } from '@/utils/handleUtils'
 
 interface BaseNodeProps extends NodeProps<Node<NodeData>> {
   icon: LucideIcon
+  topHandleIds?: string[]
+  bottomHandleIds?: string[]
+  leftHandleIds?: string[]
+  rightHandleIds?: string[]
 }
+
+const DEFAULT_TOP_HANDLE_IDS = ['top']
+const DEFAULT_BOTTOM_HANDLE_IDS = ['bottom']
 
 function formatStorage(gb: number): string {
   if (gb >= 1024) return `${(gb / 1024).toFixed(1).replace(/\.0$/, '')} TB`
   return `${gb} GB`
 }
 
-export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: BaseNodeProps) {
+export function BaseNode({
+  id,
+  data,
+  selected,
+  icon: typeIcon,
+  width,
+  height,
+  topHandleIds = DEFAULT_TOP_HANDLE_IDS,
+  bottomHandleIds = DEFAULT_BOTTOM_HANDLE_IDS,
+  leftHandleIds = [],
+  rightHandleIds = [],
+}: BaseNodeProps) {
   const updateNodeInternals = useUpdateNodeInternals()
   useEffect(() => { updateNodeInternals(id) }, [data.bottom_handles, id, updateNodeInternals])
-
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const hideIp = useCanvasStore((s) => s.hideIp)
   const theme = THEMES[activeTheme]
@@ -32,6 +49,38 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
   const statusColor = theme.colors.statusColors[data.status]
   const isOnline = data.status === 'online'
   const showHardware = data.show_hardware && (data.cpu_count != null || data.cpu_model || data.ram_gb != null || data.disk_gb != null)
+  const getOffsets = (count: number) => count > 1 ? 100 / (count + 1) : 50
+
+  const renderHandles = (handleIds: string[], side: 'top' | 'bottom' | 'left' | 'right') => {
+    const position = side === 'top'
+      ? Position.Top
+      : side === 'bottom'
+      ? Position.Bottom
+      : side === 'left'
+      ? Position.Left
+      : Position.Right
+    const offset = getOffsets(handleIds.length)
+    return handleIds.flatMap((handleId, index) => {
+      const positionPercent = `${offset * (index + 1)}%`
+      const coordinateStyle = side === 'top' || side === 'bottom' ? { left: positionPercent } : { top: positionPercent }
+      return [
+        <Handle
+          key={handleId}
+          type="source"
+          position={position}
+          id={handleId}
+          style={{ ...coordinateStyle, background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
+        />,
+        <Handle
+          key={`${handleId}-target`}
+          type="target"
+          position={position}
+          id={`${handleId}-t`}
+          style={{ ...coordinateStyle, opacity: 0, width: 12, height: 12 }}
+        />,
+      ]
+    })
+  }
 
   return (
     <div
@@ -58,13 +107,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
         lineStyle={{ borderColor: colors.border, borderWidth: 1 }}
         handleStyle={{ borderColor: colors.border, background: colors.border, width: 8, height: 8 }}
       />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="top"
-        style={{ background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
-      />
-      <Handle type="target" position={Position.Top} id="top-t" style={{ opacity: 0, width: 12, height: 12 }} />
+      {renderHandles(topHandleIds, 'top')}
 
       {/* Main row */}
       <div className="flex flex-row items-center gap-2.5 px-2.5 py-2">
@@ -145,26 +188,30 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
         title={data.status}
       />
 
-      {(BOTTOM_HANDLE_POSITIONS[data.bottom_handles ?? 1] ?? BOTTOM_HANDLE_POSITIONS[1]).map((leftPct, idx) => {
-        const sourceId = BOTTOM_HANDLE_IDS[idx]
-        const targetId = idx === 0 ? 'bottom-t' : `bottom-${idx + 1}-t`
-        return (
-          <span key={sourceId}>
-            <Handle
-              type="source"
-              position={Position.Bottom}
-              id={sourceId}
-              style={{ left: `${leftPct}%`, background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
-            />
-            <Handle
-              type="target"
-              position={Position.Bottom}
-              id={targetId}
-              style={{ left: `${leftPct}%`, opacity: 0, width: 12, height: 12 }}
-            />
-          </span>
-        )
-      })}
+      {renderHandles(leftHandleIds, 'left')}
+      {renderHandles(rightHandleIds, 'right')}
+      {bottomHandleIds === DEFAULT_BOTTOM_HANDLE_IDS
+        ? (BOTTOM_HANDLE_POSITIONS[data.bottom_handles ?? 1] ?? BOTTOM_HANDLE_POSITIONS[1]).map((leftPct, idx) => {
+            const sourceId = BOTTOM_HANDLE_IDS[idx]
+            const targetId = idx === 0 ? 'bottom-t' : `bottom-${idx + 1}-t`
+            return (
+              <span key={sourceId}>
+                <Handle
+                  type="source"
+                  position={Position.Bottom}
+                  id={sourceId}
+                  style={{ left: `${leftPct}%`, background: theme.colors.handleBackground, borderColor: theme.colors.handleBorder }}
+                />
+                <Handle
+                  type="target"
+                  position={Position.Bottom}
+                  id={targetId}
+                  style={{ left: `${leftPct}%`, opacity: 0, width: 12, height: 12 }}
+                />
+              </span>
+            )
+          })
+        : renderHandles(bottomHandleIds, 'bottom')}
     </div>
   )
 }

--- a/frontend/src/components/canvas/nodes/index.tsx
+++ b/frontend/src/components/canvas/nodes/index.tsx
@@ -8,8 +8,8 @@ import type { NodeData } from '@/types'
 
 type N = NodeProps<Node<NodeData>>
 
-export const IspNode     = (props: N) => <BaseNode {...props} icon={Globe} />
-export const RouterNode  = (props: N) => <BaseNode {...props} icon={Router} />
+export const IspNode     = (props: N) => <BaseNode {...props} icon={Globe} topHandleIds={['top-left', 'top', 'top-right']} bottomHandleIds={['bottom-1', 'bottom-2', 'bottom-3', 'bottom-4', 'bottom-5']} leftHandleIds={['left-1', 'left-2']} rightHandleIds={['right-1', 'right-2']} />
+export const RouterNode  = (props: N) => <BaseNode {...props} icon={Router} topHandleIds={['top-left', 'top-right']} bottomHandleIds={['bottom-1', 'bottom-2', 'bottom-3', 'bottom-4']} leftHandleIds={['left-1', 'left-2']} rightHandleIds={['right-1', 'right-2']} />
 export const SwitchNode  = (props: N) => <BaseNode {...props} icon={Network} />
 export const ServerNode  = (props: N) => <BaseNode {...props} icon={Server} />
 export const ProxmoxNode = (props: N) => <BaseNode {...props} icon={Layers} />

--- a/frontend/src/components/modals/EdgeModal.tsx
+++ b/frontend/src/components/modals/EdgeModal.tsx
@@ -7,6 +7,8 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { EDGE_TYPE_LABELS, type EdgeData, type EdgePathStyle, type EdgeType } from '@/types'
 import { EDGE_DEFAULT_COLORS } from '@/utils/edgeColors'
+import { COLOR_SWATCHES } from '@/utils/colorPalettes'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 const EDGE_TYPES = Object.entries(EDGE_TYPE_LABELS) as [EdgeType, string][]
 
@@ -28,14 +30,19 @@ interface EdgeModalProps {
 }
 
 export function EdgeModal({ open, onClose, onSubmit, onDelete, initial, title = 'Connect Nodes' }: EdgeModalProps) {
+  const defaultEdgeColor = useSettingsStore((s) => s.defaultEdgeColor)
+  const edgeTypeColors = useSettingsStore((s) => s.edgeTypeColors)
   const [type, setType] = useState<EdgeType>(initial?.type ?? 'ethernet')
   const [label, setLabel] = useState(initial?.label ?? '')
   const [vlanId, setVlanId] = useState(initial?.vlan_id?.toString() ?? '')
-  const [customColor, setCustomColor] = useState<string | undefined>(initial?.custom_color)
+  const initialType = initial?.type ?? 'ethernet'
+  const [customColor, setCustomColor] = useState<string | undefined>(
+    initial?.custom_color ?? edgeTypeColors[initialType] ?? defaultEdgeColor ?? undefined,
+  )
   const [pathStyle, setPathStyle] = useState<EdgePathStyle>(initial?.path_style ?? 'bezier')
   const [animation, setAnimation] = useState<AnimMode>(() => toAnimMode(initial?.animated))
 
-  const effectiveColor = customColor ?? EDGE_DEFAULT_COLORS[type]
+  const effectiveColor = customColor ?? edgeTypeColors[type] ?? defaultEdgeColor ?? EDGE_DEFAULT_COLORS[type]
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -173,6 +180,18 @@ export function EdgeModal({ open, onClose, onSubmit, onDelete, initial, title = 
               </span>
               {!customColor && <span className="text-[10px] text-muted-foreground/50 ml-auto">default</span>}
             </label>
+            <div className="flex flex-wrap gap-1">
+              {COLOR_SWATCHES.map((swatch) => (
+                <button
+                  key={swatch}
+                  type="button"
+                  aria-label={`color ${swatch}`}
+                  onClick={() => setCustomColor(swatch)}
+                  className="w-4 h-4 rounded-full border border-white/10"
+                  style={{ background: swatch }}
+                />
+              ))}
+            </div>
           </div>
 
           <div className="flex justify-between gap-2 pt-1">

--- a/frontend/src/components/modals/NodeModal.tsx
+++ b/frontend/src/components/modals/NodeModal.tsx
@@ -1,13 +1,15 @@
-import { createElement, useState } from 'react'
+import { Fragment, createElement, useEffect, useMemo, useState } from 'react'
 import { RotateCcw, ChevronDown } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { NODE_TYPE_LABELS, type NodeData, type NodeType, type CheckMethod } from '@/types'
+import { NODE_TYPE_LABELS, type NodeData, type NodeType, type CheckMethod, type NodeDimensions } from '@/types'
 import { resolveNodeColors } from '@/utils/nodeColors'
 import { ICON_REGISTRY, ICON_CATEGORIES, NODE_TYPE_DEFAULT_ICONS } from '@/utils/nodeIcons'
+import { COLOR_SWATCHES } from '@/utils/colorPalettes'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 const NODE_TYPE_GROUPS: { label: string; types: NodeType[] }[] = [
   { label: 'Hardware',       types: ['isp', 'router', 'switch', 'server', 'nas', 'ap', 'printer'] },
@@ -34,8 +36,9 @@ const DEFAULT_DATA: Partial<NodeData> = {
 interface NodeModalProps {
   open: boolean
   onClose: () => void
-  onSubmit: (data: Partial<NodeData>) => void
+  onSubmit: (data: Partial<NodeData>, dimensions?: NodeDimensions) => void
   initial?: Partial<NodeData>
+  initialDimensions?: NodeDimensions
   title?: string
   proxmoxNodes?: { id: string; label: string }[]
 }
@@ -44,8 +47,26 @@ const CHILD_TYPES: NodeType[] = ['vm', 'lxc']
 
 // NodeModal is always mounted with a key that changes on open/edit, so useState
 // initial value is enough — no need for a reset effect.
-export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node', proxmoxNodes = [] }: NodeModalProps) {
-  const [form, setForm] = useState<Partial<NodeData>>({ ...DEFAULT_DATA, ...initial })
+export function NodeModal({ open, onClose, onSubmit, initial, initialDimensions, title = 'Add Node', proxmoxNodes = [] }: NodeModalProps) {
+  const defaultNodeColor = useSettingsStore((s) => s.defaultNodeColor)
+  const nodeTypeColors = useSettingsStore((s) => s.nodeTypeColors)
+  const getDefaultColors = (type: NodeType | undefined) => {
+    const selectedColor = (type ? nodeTypeColors[type] : undefined) ?? defaultNodeColor
+    return selectedColor ? {
+      border: selectedColor,
+      icon: selectedColor,
+      background: `${selectedColor}1a`,
+    } : undefined
+  }
+  const [form, setForm] = useState<Partial<NodeData>>({
+    ...DEFAULT_DATA,
+    ...initial,
+    custom_colors: initial?.custom_colors ?? getDefaultColors(initial?.type ?? DEFAULT_DATA.type),
+  })
+  const [dimensions, setDimensions] = useState<NodeDimensions>({
+    width: initialDimensions?.width,
+    height: initialDimensions?.height,
+  })
   const [iconSearch, setIconSearch] = useState('')
   const [iconPickerOpen, setIconPickerOpen] = useState(false)
   const [labelError, setLabelError] = useState(false)
@@ -55,6 +76,21 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
   const set = (key: keyof NodeData, value: unknown) =>
     setForm((f) => ({ ...f, [key]: value }))
 
+  const defaultColors = useMemo(
+    () => getDefaultColors((form.type as NodeType | undefined) ?? DEFAULT_DATA.type),
+    [form.type, nodeTypeColors, defaultNodeColor],
+  )
+
+  useEffect(() => {
+    if (initial?.custom_colors) return
+    setForm((current) => {
+      if (current.custom_colors?.border || current.custom_colors?.background || current.custom_colors?.icon) {
+        return current
+      }
+      return { ...current, custom_colors: defaultColors }
+    })
+  }, [defaultColors, initial?.custom_colors])
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!form.label?.trim()) {
@@ -62,7 +98,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
       return
     }
     setLabelError(false)
-    onSubmit(form)
+    onSubmit(form, dimensions)
     onClose()
   }
 
@@ -84,9 +120,9 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                 </SelectTrigger>
                 <SelectContent className="bg-[#21262d] border-[#30363d]">
                   {NODE_TYPE_GROUPS.map((group, i) => (
-                    <>
+                    <Fragment key={group.label}>
                       {i > 0 && <SelectSeparator key={`sep-${group.label}`} className="bg-[#30363d]" />}
-                      <SelectGroup key={group.label}>
+                      <SelectGroup>
                         <SelectLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/50 px-2 py-1">
                           {group.label}
                         </SelectLabel>
@@ -96,7 +132,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                           </SelectItem>
                         ))}
                       </SelectGroup>
-                    </>
+                    </Fragment>
                   ))}
                 </SelectContent>
               </Select>
@@ -325,6 +361,18 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                         <div className="w-full h-full rounded-sm" style={{ background: currentValue }} />
                       </label>
                       <span className="text-[9px] text-muted-foreground/60 capitalize">{key}</span>
+                      <div className="flex flex-wrap justify-center gap-1 max-w-[82px]">
+                        {COLOR_SWATCHES.slice(0, 6).map((swatch) => (
+                          <button
+                            key={`${key}-${swatch}`}
+                            type="button"
+                            aria-label={`${key} ${swatch}`}
+                            onClick={() => set('custom_colors', { ...form.custom_colors, [key]: swatch })}
+                            className="w-3.5 h-3.5 rounded-full border border-white/10"
+                            style={{ background: swatch }}
+                          />
+                        ))}
+                      </div>
                     </div>
                   )
                 })}
@@ -333,6 +381,41 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                 <p className="text-[10px] text-muted-foreground/50">Using default colors for {NODE_TYPE_LABELS[form.type ?? 'generic']}. Click a swatch to customize.</p>
               )}
             </div>
+
+            {form.type !== 'groupRect' && (
+              <div className="flex flex-col gap-2 col-span-2">
+                <Label className="text-xs text-muted-foreground">Node Dimensions</Label>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <Label className="text-xs text-muted-foreground">Width</Label>
+                    <Input
+                      type="number"
+                      min={140}
+                      step={10}
+                      value={dimensions.width ?? ''}
+                      onChange={(e) => setDimensions((current) => ({ ...current, width: e.target.value ? Number(e.target.value) : undefined }))}
+                      placeholder="auto"
+                      className="bg-[#21262d] border-[#30363d] font-mono text-sm h-8"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label className="text-xs text-muted-foreground">Height</Label>
+                    <Input
+                      type="number"
+                      min={50}
+                      step={10}
+                      value={dimensions.height ?? ''}
+                      onChange={(e) => setDimensions((current) => ({ ...current, height: e.target.value ? Number(e.target.value) : undefined }))}
+                      placeholder="auto"
+                      className="bg-[#21262d] border-[#30363d] font-mono text-sm h-8"
+                    />
+                  </div>
+                </div>
+                <p className="text-[10px] text-muted-foreground/50">
+                  Leave empty to keep the default size. Resized nodes are saved automatically.
+                </p>
+              </div>
+            )}
 
             {/* Hardware specs (hidden for groupRect) */}
             {form.type !== 'groupRect' && (

--- a/frontend/src/components/panels/__tests__/SettingsPanel.test.tsx
+++ b/frontend/src/components/panels/__tests__/SettingsPanel.test.tsx
@@ -18,6 +18,9 @@ vi.mock('@/api/client', () => ({
     get: vi.fn(),
     save: vi.fn(),
   },
+  nodeHistoryApi: {
+    list: vi.fn(),
+  },
 }))
 
 import { settingsApi } from '@/api/client'
@@ -48,8 +51,26 @@ function renderSidebar() {
 
 describe('SettingsPanel', () => {
   beforeEach(() => {
-    vi.mocked(settingsApi.get).mockResolvedValue({ data: { interval_seconds: 60 } } as never)
-    vi.mocked(settingsApi.save).mockResolvedValue({ data: { interval_seconds: 60 } } as never)
+    vi.mocked(settingsApi.get).mockResolvedValue({
+      data: {
+        interval_seconds: 60,
+        scan_interval_seconds: 3600,
+        default_node_color: null,
+        default_edge_color: null,
+        node_type_colors: {},
+        edge_type_colors: {},
+      },
+    } as never)
+    vi.mocked(settingsApi.save).mockResolvedValue({
+      data: {
+        interval_seconds: 60,
+        scan_interval_seconds: 3600,
+        default_node_color: null,
+        default_edge_color: null,
+        node_type_colors: {},
+        edge_type_colors: {},
+      },
+    } as never)
     vi.mocked(toast.success).mockReset()
     vi.mocked(toast.error).mockReset()
   })
@@ -64,7 +85,16 @@ describe('SettingsPanel', () => {
   })
 
   it('displays interval loaded from API', async () => {
-    vi.mocked(settingsApi.get).mockResolvedValue({ data: { interval_seconds: 120 } } as never)
+    vi.mocked(settingsApi.get).mockResolvedValue({
+      data: {
+        interval_seconds: 120,
+        scan_interval_seconds: 3600,
+        default_node_color: null,
+        default_edge_color: null,
+        node_type_colors: {},
+        edge_type_colors: {},
+      },
+    } as never)
     renderSidebar()
     fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
     const input = await screen.findByDisplayValue('120')
@@ -78,7 +108,14 @@ describe('SettingsPanel', () => {
     fireEvent.change(input, { target: { value: '180' } })
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => {
-      expect(settingsApi.save).toHaveBeenCalledWith({ interval_seconds: 180 })
+      expect(settingsApi.save).toHaveBeenCalledWith({
+        interval_seconds: 180,
+        scan_interval_seconds: 3600,
+        default_node_color: null,
+        default_edge_color: null,
+        node_type_colors: {},
+        edge_type_colors: {},
+      })
       expect(toast.success).toHaveBeenCalledWith('Settings saved')
     })
   })

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -41,6 +41,7 @@ interface CanvasState {
   setSelectedNode: (id: string | null) => void
   addNode: (node: Node<NodeData>) => void
   updateNode: (id: string, data: Partial<NodeData>) => void
+  setNodeDimensions: (id: string, width?: number, height?: number) => void
   deleteNode: (id: string) => void
   updateEdge: (id: string, data: Partial<EdgeData>) => void
   deleteEdge: (id: string) => void
@@ -246,6 +247,12 @@ export const useCanvasStore = create<CanvasState>((set) => ({
 
       return { nodes, edges, hasUnsavedChanges: true }
     }),
+
+  setNodeDimensions: (id, width, height) =>
+    set((state) => ({
+      nodes: state.nodes.map((n) => n.id === id ? { ...n, width, height } : n),
+      hasUnsavedChanges: true,
+    })),
 
   deleteNode: (id) =>
     set((state) => {

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+
+interface AppSettingsState {
+  intervalSeconds: number
+  scanIntervalSeconds: number
+  defaultNodeColor: string | null
+  defaultEdgeColor: string | null
+  nodeTypeColors: Record<string, string>
+  edgeTypeColors: Record<string, string>
+  setSettings: (settings: {
+    intervalSeconds: number
+    scanIntervalSeconds: number
+    defaultNodeColor: string | null
+    defaultEdgeColor: string | null
+    nodeTypeColors: Record<string, string>
+    edgeTypeColors: Record<string, string>
+  }) => void
+}
+
+export const useSettingsStore = create<AppSettingsState>((set) => ({
+  intervalSeconds: 60,
+  scanIntervalSeconds: 3600,
+  defaultNodeColor: null,
+  defaultEdgeColor: null,
+  nodeTypeColors: {},
+  edgeTypeColors: {},
+  setSettings: ({ intervalSeconds, scanIntervalSeconds, defaultNodeColor, defaultEdgeColor, nodeTypeColors, edgeTypeColors }) =>
+    set({ intervalSeconds, scanIntervalSeconds, defaultNodeColor, defaultEdgeColor, nodeTypeColors, edgeTypeColors }),
+}))

--- a/frontend/src/utils/__tests__/canvasSerializer.test.ts
+++ b/frontend/src/utils/__tests__/canvasSerializer.test.ts
@@ -96,6 +96,16 @@ describe('serializeNode — regular node', () => {
     expect(result.height).toBe(120)
   })
 
+  it('prefers measured dimensions for regular nodes', () => {
+    const node: Node<NodeData> = {
+      ...makeRfNode({ width: 280, height: 120 }),
+      measured: { width: 312, height: 144 },
+    }
+    const result = serializeNode(node)
+    expect(result.width).toBe(312)
+    expect(result.height).toBe(144)
+  })
+
   it('serializes width/height as null when node has default size', () => {
     const result = serializeNode(makeRfNode())
     expect(result.width).toBeNull()

--- a/frontend/src/utils/canvasSerializer.ts
+++ b/frontend/src/utils/canvasSerializer.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge } from '@xyflow/react'
-import type { NodeData, EdgeData } from '@/types'
+import type { NodeData, EdgeData, Waypoint } from '@/types'
 import { normalizeHandle } from '@/utils/handleUtils'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -46,11 +46,14 @@ export interface ApiEdge {
   animated?: boolean | 'snake' | 'flow' | 'none'
   source_handle?: string | null
   target_handle?: string | null
+  waypoints?: Waypoint[] | null
 }
 
 // ── Serialization (RF node → API save payload) ───────────────────────────────
 
 export function serializeNode(n: Node<NodeData>): Record<string, unknown> {
+  const measuredWidth = n.measured?.width ?? n.width ?? null
+  const measuredHeight = n.measured?.height ?? n.height ?? null
   if (n.data.type === 'groupRect') {
     return {
       id: n.id,
@@ -72,8 +75,8 @@ export function serializeNode(n: Node<NodeData>): Record<string, unknown> {
       pos_y: n.position.y,
       custom_colors: {
         ...n.data.custom_colors,
-        width: n.measured?.width ?? n.width ?? 360,
-        height: n.measured?.height ?? n.height ?? 240,
+        width: measuredWidth ?? 360,
+        height: measuredHeight ?? 240,
       },
     }
   }
@@ -99,8 +102,8 @@ export function serializeNode(n: Node<NodeData>): Record<string, unknown> {
     ram_gb: n.data.ram_gb ?? null,
     disk_gb: n.data.disk_gb ?? null,
     show_hardware: n.data.show_hardware ?? false,
-    width: n.width ?? null,
-    height: n.height ?? null,
+    width: measuredWidth,
+    height: measuredHeight,
     bottom_handles: n.data.bottom_handles ?? 1,
     pos_x: n.position.x,
     pos_y: n.position.y,
@@ -121,6 +124,7 @@ export function serializeEdge(e: Edge<EdgeData>): Record<string, unknown> {
     animated: e.data?.animated ?? false,
     source_handle: normalizeHandle(e.sourceHandle),
     target_handle: normalizeHandle(e.targetHandle),
+    waypoints: e.data?.waypoints ?? null,
   }
 }
 

--- a/frontend/src/utils/colorPalettes.ts
+++ b/frontend/src/utils/colorPalettes.ts
@@ -1,0 +1,10 @@
+export const COLOR_SWATCHES = [
+  '#00d4ff',
+  '#39d353',
+  '#e3b341',
+  '#ff6e00',
+  '#f85149',
+  '#a855f7',
+  '#8b949e',
+  '#1f6feb',
+] as const


### PR DESCRIPTION
Frontend:
- Add colorPalettes.ts with COLOR_SWATCHES swatch palette definitions
- Extend settingsStore: defaultNodeColor, defaultEdgeColor, nodeTypeColors, edgeTypeColors, scanIntervalSeconds loaded from backend on login
- NodeModal: color swatch picker, apply settings default on type change, support NodeDimensions (width/height) passthrough
- EdgeModal: color swatch picker using edge settings defaults
- BaseNode: resolve custom_colors falling back to settingsStore defaults
- nodes/index.tsx, edges/index.tsx: propagate color resolution through
- CanvasContainer: replace onEdgeDoubleClick with homelable:edit-edge event
- canvasStore: add setNodeDimensions action
- canvasSerializer: serialize/deserialize isp_layout (Node) and waypoints (Edge)
- App.tsx: load all settings on auth, wire NodeDimensions in add/update handlers
- Extend settingsApi typings for new color/interval fields in client.ts
- Update CanvasContainer.test.tsx, canvasSerializer.test.ts, SettingsPanel.test.tsx

Backend:
- config.py: add scan_interval_seconds, default_node_color, default_edge_color, node_type_colors, edge_type_colors with load/save persistence
- settings.py: expose and persist all new fields; call reschedule_auto_scan
- scheduler.py: add _run_scheduled_scan, reschedule_auto_scan, auto-scan APScheduler job
- database.py: add waypoints column on edges, isp_layout column on nodes
- models.py: add isp_layout on Node, waypoints on Edge
- Update test_settings.py, test_scheduler.py