### PR TITLE
fix: reconcile stale scan runs and add active run tracking

### DIFF
--- a/backend/app/api/routes/scan.py
+++ b/backend/app/api/routes/scan.py
@@ -1,6 +1,7 @@
 import ipaddress
 import logging
 import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -14,7 +15,7 @@ from app.db.database import AsyncSessionLocal, get_db
 from app.db.models import Node, PendingDevice, ScanRun
 from app.schemas.nodes import NodeCreate
 from app.schemas.scan import PendingDeviceResponse, ScanRunResponse
-from app.services.scanner import request_cancel, run_scan
+from app.services.scanner import is_run_active, mark_run_active, run_scan, request_cancel
 
 
 class ScanConfig(BaseModel):
@@ -35,6 +36,45 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _serialize_run(run: ScanRun) -> ScanRunResponse:
+    return ScanRunResponse(
+        id=run.id,
+        status=run.status,
+        ranges=run.ranges,
+        devices_found=run.devices_found,
+        started_at=_ensure_utc(run.started_at),
+        finished_at=_ensure_utc(run.finished_at),
+        error=run.error,
+    )
+
+
+async def _reconcile_stale_runs(db: AsyncSession) -> None:
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=30)
+    result = await db.execute(select(ScanRun).where(ScanRun.status == "running"))
+    stale_runs = []
+    for run in result.scalars().all():
+        started_at = _ensure_utc(run.started_at)
+        if is_run_active(run.id):
+            continue
+        if started_at is not None and started_at > cutoff:
+            continue
+        run.status = "error"
+        run.finished_at = datetime.now(timezone.utc)
+        run.error = run.error or "Scan interrupted before completion"
+        stale_runs.append(run.id)
+    if stale_runs:
+        logger.warning("Reconciled stale scan runs: %s", ", ".join(stale_runs))
+        await db.commit()
+
+
 async def _background_scan(run_id: str, ranges: list[str]) -> None:
     async with AsyncSessionLocal() as db:
         await run_scan(ranges, db, run_id)
@@ -45,14 +85,15 @@ async def trigger_scan(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     _: str = Depends(get_current_user),
-) -> ScanRun:
+) -> ScanRunResponse:
     ranges = settings.scanner_ranges
     run = ScanRun(status="running", ranges=ranges)
     db.add(run)
     await db.commit()
     await db.refresh(run)
+    mark_run_active(run.id)
     background_tasks.add_task(_background_scan, run.id, ranges)
-    return run
+    return _serialize_run(run)
 
 
 @router.post("/{run_id}/stop", response_model=dict)
@@ -141,9 +182,10 @@ async def ignore_device(
 
 
 @router.get("/runs", response_model=list[ScanRunResponse])
-async def list_runs(db: AsyncSession = Depends(get_db), _: str = Depends(get_current_user)) -> list[ScanRun]:
+async def list_runs(db: AsyncSession = Depends(get_db), _: str = Depends(get_current_user)) -> list[ScanRunResponse]:
+    await _reconcile_stale_runs(db)
     result = await db.execute(select(ScanRun).order_by(ScanRun.started_at.desc()).limit(20))
-    return list(result.scalars().all())
+    return [_serialize_run(run) for run in result.scalars().all()]
 
 
 @router.get("/config", response_model=ScanConfig)

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # Run IDs that have been requested to cancel (thread-safe via lock)
 _cancelled_runs: set[str] = set()
 _cancelled_lock = threading.Lock()
+_active_runs: set[str] = set()
 
 # Port list for service detection (Phase 2)
 _EXTRA_PORTS = (
@@ -68,6 +69,18 @@ def request_cancel(run_id: str) -> None:
 def _is_cancelled(run_id: str) -> bool:
     with _cancelled_lock:
         return run_id in _cancelled_runs
+
+
+def mark_run_active(run_id: str) -> None:
+    _active_runs.add(run_id)
+
+
+def mark_run_inactive(run_id: str) -> None:
+    _active_runs.discard(run_id)
+
+
+def is_run_active(run_id: str) -> bool:
+    return run_id in _active_runs
 
 
 def _resolve_hostname(ip: str) -> str | None:
@@ -381,6 +394,7 @@ async def run_scan(ranges: list[str], db: AsyncSession, run_id: str) -> None:
 
     devices_found = 0
     mdns_task: asyncio.Task[list[dict[str, Any]]] | None = None
+    mark_run_active(run_id)
     try:
         # Validate all ranges are valid CIDRs before passing anything to nmap
         for r in ranges:
@@ -510,3 +524,4 @@ async def run_scan(ranges: list[str], db: AsyncSession, run_id: str) -> None:
     finally:
         with _cancelled_lock:
             _cancelled_runs.discard(run_id)
+        mark_run_inactive(run_id)

--- a/backend/tests/test_scan.py
+++ b/backend/tests/test_scan.py
@@ -101,6 +101,11 @@ async def test_approve_device(client: AsyncClient, headers, pending_device):
     assert data["approved"] is True
     assert "node_id" in data
 
+    node_res = await client.get(f"/api/v1/nodes/{data['node_id']}", headers=headers)
+    assert node_res.status_code == 200
+    assert node_res.json()["type"] == "server"
+    assert node_res.json()["label"] == "My Server"
+
     # Device should no longer appear in pending list
     pending_res = await client.get("/api/v1/scan/pending", headers=headers)
     assert pending_res.json() == []


### PR DESCRIPTION
- Add _active_runs set in scanner.py with mark_run_active/mark_run_inactive/is_run_active
- Mark runs active on trigger and inactive on completion in scanner and scan route
- Add _reconcile_stale_runs(): converts orphaned long-running DB rows to error status
- Add _serialize_run() to normalize UTC timestamps in ScanRunResponse
- GET /scan/runs reconciles stale runs before returning
- POST /scan returns serialized ScanRunResponse
- test_scan.py: verify approved device node has correct type and label