### PR TITLE
feat: add node status history API with UTC normalization and DB logging

### DIFF
--- a/backend/app/api/routes/node_history.py
+++ b/backend/app/api/routes/node_history.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.db.database import get_db
+from app.db.models import Node, NodeStatusLog
+
+router = APIRouter()
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+class NodeStatusHistoryItem(BaseModel):
+    id: str
+    node_id: str
+    node_label: str
+    status: str
+    response_time_ms: int | None = None
+    checked_at: datetime
+
+
+@router.get("", response_model=list[NodeStatusHistoryItem])
+async def get_node_status_history(
+    node_id: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    limit: int = 5000,
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(get_current_user),
+) -> list[NodeStatusHistoryItem]:
+    safe_limit = max(1, min(limit, 10000))
+    stmt = select(NodeStatusLog, Node.label).join(Node, Node.id == NodeStatusLog.node_id)
+    if node_id:
+        stmt = stmt.where(NodeStatusLog.node_id == node_id)
+    if start_date:
+        stmt = stmt.where(NodeStatusLog.checked_at >= start_date)
+    if end_date:
+        stmt = stmt.where(NodeStatusLog.checked_at <= end_date)
+    stmt = stmt.order_by(desc(NodeStatusLog.checked_at)).limit(safe_limit)
+
+    result = await db.execute(stmt)
+    logs = result.all()
+    return [
+        NodeStatusHistoryItem(
+            id=log.id,
+            node_id=log.node_id,
+            node_label=label,
+            status=log.status,
+            response_time_ms=log.response_time_ms,
+            checked_at=_ensure_utc(log.checked_at),
+        )
+        for log, label in logs
+    ]

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 
 from app.core.config import settings
 from app.db.database import AsyncSessionLocal
-from app.db.models import Node
+from app.db.models import Node, NodeStatusLog
 from app.services.status_checker import check_node
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,12 @@ async def _check_single_node(
                 n.response_time_ms = check_result["response_time_ms"]
                 if check_result["status"] == "online":
                     n.last_seen = now
+                db.add(NodeStatusLog(
+                    node_id=node_id,
+                    status=check_result["status"],
+                    response_time_ms=check_result["response_time_ms"],
+                    checked_at=now,
+                ))
                 await db.commit()
         await broadcast_status(
             node_id=node_id,

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -61,6 +61,20 @@ async def init_db() -> None:
             await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN bottom_handles INTEGER NOT NULL DEFAULT 1")
         with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE pending_devices ADD COLUMN discovery_source TEXT")
+        with suppress(OperationalError):
+            await conn.exec_driver_sql(
+                "CREATE TABLE node_status_logs ("
+                "id TEXT PRIMARY KEY, "
+                "node_id TEXT NOT NULL, "
+                "status TEXT NOT NULL, "
+                "response_time_ms INTEGER, "
+                "checked_at DATETIME, "
+                "FOREIGN KEY(node_id) REFERENCES nodes (id) ON DELETE CASCADE)"
+            )
+        with suppress(OperationalError):
+            await conn.exec_driver_sql("CREATE INDEX ix_node_status_logs_node_id ON node_status_logs (node_id)")
+        with suppress(OperationalError):
+            await conn.exec_driver_sql("CREATE INDEX ix_node_status_logs_checked_at ON node_status_logs (checked_at)")
         # Migrate animated column from boolean (0/1) to string ('none'/'snake')
         with suppress(OperationalError):
             await conn.exec_driver_sql("UPDATE edges SET animated = 'snake' WHERE animated = '1' OR animated = 1")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -105,3 +105,13 @@ class ScanRun(Base):
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     error: Mapped[str | None] = mapped_column(Text)
+
+
+class NodeStatusLog(Base):
+    __tablename__ = "node_status_logs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    node_id: Mapped[str] = mapped_column(String, ForeignKey("nodes.id", ondelete="CASCADE"), index=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    response_time_ms: Mapped[int | None] = mapped_column(Integer)
+    checked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, index=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.routes import auth, canvas, edges, liveview, nodes, scan, status
+from app.api.routes import auth, canvas, edges, liveview, node_history, nodes, scan, status
 from app.api.routes import settings as settings_routes
 from app.core.config import settings
 from app.core.scheduler import start_scheduler, stop_scheduler
@@ -54,6 +54,7 @@ app.include_router(canvas.router, prefix="/api/v1/canvas", tags=["canvas"])
 app.include_router(scan.router, prefix="/api/v1/scan", tags=["scan"])
 app.include_router(status.router, prefix="/api/v1/status", tags=["status"])
 app.include_router(settings_routes.router, prefix="/api/v1/settings", tags=["settings"])
+app.include_router(node_history.router, prefix="/api/v1/node-history", tags=["node-history"])
 app.include_router(liveview.router, prefix="/api/v1/liveview", tags=["liveview"])
 
 

--- a/backend/tests/test_node_history.py
+++ b/backend/tests/test_node_history.py
@@ -1,0 +1,45 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from app.db.models import Node, NodeStatusLog
+
+
+@pytest.fixture
+async def headers(client: AsyncClient):
+    res = await client.post("/api/v1/auth/login", json={"username": "admin", "password": "admin"})
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_node_history_filters_by_date(client: AsyncClient, db_session, headers):
+    node = Node(
+        id=str(uuid.uuid4()),
+        type="server",
+        label="NAS",
+        status="online",
+        services=[],
+        pos_x=0,
+        pos_y=0,
+    )
+    db_session.add(node)
+    await db_session.commit()
+
+    old_time = datetime.now(timezone.utc) - timedelta(days=3)
+    new_time = datetime.now(timezone.utc)
+    db_session.add_all([
+        NodeStatusLog(node_id=node.id, status="offline", checked_at=old_time),
+        NodeStatusLog(node_id=node.id, status="online", checked_at=new_time),
+    ])
+    await db_session.commit()
+
+    start_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    res = await client.get("/api/v1/node-history", headers=headers, params={"start_date": start_date})
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["node_label"] == "NAS"
+    assert data[0]["status"] == "online"

--- a/backend/tests/test_status_checker.py
+++ b/backend/tests/test_status_checker.py
@@ -1,4 +1,5 @@
 """Tests for status_checker service: each check method."""
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -218,3 +219,39 @@ async def test_tcp_connect_os_error():
     with patch("asyncio.open_connection", new_callable=AsyncMock, side_effect=OSError("refused")):
         result = await _tcp_connect("192.168.1.1", 9999)
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ping_uses_windows_flags():
+    proc = MagicMock()
+    proc.wait = AsyncMock()
+    proc.returncode = 0
+    with (
+        patch("app.services.status_checker.platform.system", return_value="Windows"),
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc) as mock_exec,
+    ):
+        result = await _ping("192.168.1.1")
+    assert result is True
+    mock_exec.assert_awaited_once_with(
+        "ping", "-n", "1", "-w", "1000", "192.168.1.1",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ping_uses_unix_flags():
+    proc = MagicMock()
+    proc.wait = AsyncMock()
+    proc.returncode = 0
+    with (
+        patch("app.services.status_checker.platform.system", return_value="Linux"),
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc) as mock_exec,
+    ):
+        result = await _ping("192.168.1.1")
+    assert result is True
+    mock_exec.assert_awaited_once_with(
+        "ping", "-c", "1", "-W", "1", "192.168.1.1",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )


### PR DESCRIPTION
- Add NodeStatusLog model in models.py for per-check status persistence
- Create node_status_logs table + indexes in database.py migration
- Add backend/app/api/routes/node_history.py: GET /api/v1/node-history supports node_id, start_date, end_date, limit (bounded 1-10000) filters
- Normalize all checked_at timestamps to explicit UTC before serialization
- Register node_history router in main.py at /api/v1/node-history
- Write NodeStatusLog entry on each status check cycle in scheduler.py
- Add backend/tests/test_node_history.py with filter-by-date assertions
- Update test_status_checker.py