### PR TITLE
feat: double-click node to open edit modal

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ pydantic-settings==2.5.2
 python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
-python-multipart==0.0.22
+python-multipart==0.0.26
 apscheduler==3.10.4
 python-nmap==0.7.1
 pyyaml==6.0.2
@@ -21,6 +21,6 @@ zeroconf==0.131.0
 # Dev
 ruff==0.6.9
 mypy==1.11.2
-pytest==8.3.3
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==0.26.0
 pytest-cov==5.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,5 +22,5 @@ zeroconf==0.131.0
 ruff==0.6.9
 mypy==1.11.2
 pytest==9.0.3
-pytest-asyncio==0.26.0
+pytest-asyncio==1.0.0
 pytest-cov==5.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,5 +22,5 @@ zeroconf==0.131.0
 ruff==0.6.9
 mypy==1.11.2
 pytest==9.0.3
-pytest-asyncio==1.0.0
+pytest-asyncio==1.3.0
 pytest-cov==5.0.0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -343,6 +343,10 @@ export default function App() {
     setEditEdgeId(edge.id)
   }, [])
 
+  const handleNodeDoubleClick = useCallback((node: Node<NodeData>) => {
+    handleEditNode(node.id)
+  }, [handleEditNode])
+
   const handleEdgeUpdate = useCallback((data: EdgeData) => {
     if (!editEdgeId) return
     snapshotHistory()
@@ -400,7 +404,7 @@ export default function App() {
                 <CanvasContainer
                   onConnect={handleEdgeConnect}
                   onEdgeDoubleClick={handleEdgeDoubleClick}
-                  onNodeDoubleClick={(node) => handleEditNode(node.id)}
+                  onNodeDoubleClick={handleNodeDoubleClick}
                   onNodeDragStart={snapshotHistory}
                   onOpenPending={(deviceId) => {
                     setHighlightPendingId(undefined)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -400,6 +400,7 @@ export default function App() {
                 <CanvasContainer
                   onConnect={handleEdgeConnect}
                   onEdgeDoubleClick={handleEdgeDoubleClick}
+                  onNodeDoubleClick={(node) => handleEditNode(node.id)}
                   onNodeDragStart={snapshotHistory}
                   onOpenPending={(deviceId) => {
                     setHighlightPendingId(undefined)

--- a/frontend/src/components/canvas/CanvasContainer.tsx
+++ b/frontend/src/components/canvas/CanvasContainer.tsx
@@ -25,11 +25,12 @@ import type { NodeData, EdgeData } from '@/types'
 interface CanvasContainerProps {
   onConnect?: (connection: Connection) => void
   onEdgeDoubleClick?: (edge: Edge<EdgeData>) => void
+  onNodeDoubleClick?: (node: Node<NodeData>) => void
   onNodeDragStart?: () => void
   onOpenPending?: (deviceId: string) => void
 }
 
-export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, onNodeDragStart, onOpenPending }: CanvasContainerProps) {
+export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, onNodeDoubleClick, onNodeDragStart, onOpenPending }: CanvasContainerProps) {
   const [lassoMode, setLassoMode] = useState(true)
   const {
     nodes, edges,
@@ -68,6 +69,10 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
     onEdgeDoubleClick?.(edge)
   }, [onEdgeDoubleClick])
 
+  const handleNodeDoubleClick = useCallback((_: React.MouseEvent, node: Node<NodeData>) => {
+    onNodeDoubleClick?.(node)
+  }, [onNodeDoubleClick])
+
   return (
     <div className="w-full h-full" style={{ background: theme.colors.canvasBackground }}>
       <ReactFlow
@@ -79,6 +84,7 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
         onNodeClick={onNodeClick}
         onPaneClick={onPaneClick}
         onEdgeDoubleClick={handleEdgeDoubleClick}
+        onNodeDoubleClick={handleNodeDoubleClick}
         onNodeDragStart={onNodeDragStart}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}

--- a/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
@@ -104,6 +104,24 @@ describe('CanvasContainer', () => {
     }).not.toThrow()
   })
 
+  // ── Node double-click ─────────────────────────────────────────────────────
+
+  it('calls onNodeDoubleClick prop when a node is double-clicked', () => {
+    const onNodeDoubleClick = vi.fn()
+    const node = makeNode('n1')
+    render(<CanvasContainer onNodeDoubleClick={onNodeDoubleClick} />)
+    ;(rfProps.onNodeDoubleClick as (...args: unknown[]) => unknown)({} as MouseEvent, node)
+    expect(onNodeDoubleClick).toHaveBeenCalledWith(node)
+  })
+
+  it('does not throw when onNodeDoubleClick is not provided', () => {
+    const node = makeNode('n1')
+    render(<CanvasContainer />)
+    expect(() => {
+      ;(rfProps.onNodeDoubleClick as (...args: unknown[]) => unknown)({} as MouseEvent, node)
+    }).not.toThrow()
+  })
+
   // ── Connection validation ─────────────────────────────────────────────────
 
   it('isValidConnection returns false for self-connections', () => {


### PR DESCRIPTION
## Summary
- Adds `onNodeDoubleClick` prop to `CanvasContainer`, wired via `useCallback` to React Flow's `onNodeDoubleClick`
- Extracts handler in `App.tsx` as named `useCallback` (fixes inline arrow creating new ref each render)
- Adds 2 tests in `CanvasContainer.test.tsx` covering callback fire and no-op when prop omitted

Based on #65 by @findthelorax with fixes applied.

## Test plan
- [x] `cd frontend && npm test` — 643 tests pass
- [x] Double-click any node → edit modal opens
- [x] No-op when `onNodeDoubleClick` not provided