### PR TITLE
fix: add curl to backend image to support the default healthcheck

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -2,8 +2,8 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-# Install nmap for network scanning + iputils-ping for ping-based status checks
-RUN apt-get update && apt-get install -y --no-install-recommends nmap iputils-ping && rm -rf /var/lib/apt/lists/*
+# Install nmap for network scanning + iputils-ping for ping-based status checks + curl for the health check
+RUN apt-get update && apt-get install -y --no-install-recommends nmap iputils-ping curl && rm -rf /var/lib/apt/lists/*
 
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
In spite of the default docker compose within the repository containing "curl" for health check purposes, the backend image does not in fact install curl, thus rendering the health check in a permanently failing state.

Hopefully the naming scheme of the commit and the additional comment are in line with your expectations for this repository's standards - tried to do my best basing on previous ones and what I found inside as there's no contributing.md.