### PR TITLE
fix: drag from title

### DIFF
--- a/frontend/src/components/canvas/__tests__/GroupNode.test.tsx
+++ b/frontend/src/components/canvas/__tests__/GroupNode.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { GroupNode } from '../nodes/GroupNode'
 import * as canvasStore from '@/stores/canvasStore'
 import type { Node } from '@xyflow/react'
@@ -100,6 +100,19 @@ describe('GroupNode', () => {
       />,
     )
     expect(screen.getByTestId('node-resizer').getAttribute('data-visible')).toBe('true')
+  })
+
+  it('allows dragging from the header while keeping rename controls nodrag', () => {
+    renderGroupNode({ selected: true })
+
+    expect(screen.getByText('My Group').closest('div')).not.toHaveClass('nodrag')
+
+    const renameButton = screen.getByTitle('Rename group')
+    expect(renameButton).toHaveClass('nodrag')
+
+    fireEvent.click(renameButton)
+
+    expect(screen.getByDisplayValue('My Group')).toHaveClass('nodrag')
   })
 
   it('shows online/offline status summary from children', () => {

--- a/frontend/src/components/canvas/nodes/GroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupNode.tsx
@@ -66,13 +66,13 @@ export function GroupNode({ id, data, selected }: NodeProps<Node<NodeData>>) {
             borderBottom: isVisible ? `1px solid ${borderColor}40` : 'none',
             pointerEvents: 'auto',
           }}
-          className="nodrag"
         >
           <Layers size={12} style={{ color: '#00d4ff', flexShrink: 0 }} />
 
           {editing ? (
             <input
               autoFocus
+              className="nodrag"
               value={labelDraft}
               onChange={(e) => setLabelDraft(e.target.value)}
               onKeyDown={(e) => {
@@ -97,11 +97,12 @@ export function GroupNode({ id, data, selected }: NodeProps<Node<NodeData>>) {
 
           {editing ? (
             <>
-              <button onClick={handleRename} style={{ color: '#39d353', background: 'none', border: 'none', cursor: 'pointer', padding: 1 }}><Check size={11} /></button>
-              <button onClick={() => { setLabelDraft(data.label); setEditing(false) }} style={{ color: '#f85149', background: 'none', border: 'none', cursor: 'pointer', padding: 1 }}><X size={11} /></button>
+              <button className="nodrag" onClick={handleRename} style={{ color: '#39d353', background: 'none', border: 'none', cursor: 'pointer', padding: 1 }}><Check size={11} /></button>
+              <button className="nodrag" onClick={() => { setLabelDraft(data.label); setEditing(false) }} style={{ color: '#f85149', background: 'none', border: 'none', cursor: 'pointer', padding: 1 }}><X size={11} /></button>
             </>
           ) : (
             <button
+              className="nodrag"
               onClick={() => { setLabelDraft(data.label); setEditing(true) }}
               style={{ color: '#8b949e', background: 'none', border: 'none', cursor: 'pointer', padding: 1, opacity: selected ? 1 : 0 }}
               title="Rename group"


### PR DESCRIPTION
Fix - Maybe a feature
- Allows group nodes to be dragged from the title bar as well as from the body of the node.