### PR TITLE
fix(mcp): mount session manager via Starlette Mount to avoid double response.start

### DIFF
--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -1,7 +1,8 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from mcp.server import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.routing import Mount
 
 from .auth import ApiKeyMiddleware
 from .backend_client import backend
@@ -28,13 +29,18 @@ async def lifespan(app: FastAPI):
     await backend.stop()
 
 
-app = FastAPI(title="Homelable MCP", lifespan=lifespan)
+# Mount the session manager as an ASGI sub-app instead of wrapping it in a
+# FastAPI @app.api_route handler. Wrapping it in a route handler causes
+# FastAPI to send http.response.start after the session manager has already
+# started the response, raising `RuntimeError: Unexpected ASGI message
+# 'http.response.start' sent, after response already completed` on every
+# POST /mcp — which makes the server unreachable from any MCP client.
+app = FastAPI(
+    title="Homelable MCP",
+    lifespan=lifespan,
+    routes=[Mount("/mcp", app=session_manager.handle_request)],
+)
 app.add_middleware(ApiKeyMiddleware)
-
-
-@app.api_route("/mcp", methods=["GET", "POST", "DELETE"])
-async def mcp_endpoint(request: Request):
-    await session_manager.handle_request(request.scope, request.receive, request._send)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary

Every `POST /mcp` against the MCP server raises, making the server unreachable from any MCP client. This PR fixes it by mounting the `StreamableHTTPSessionManager` as a Starlette `Mount` instead of wrapping it inside a FastAPI route handler.

## The bug

`mcp/app/main.py` currently does:

```python
@app.api_route("/mcp", methods=["GET", "POST", "DELETE"])
async def mcp_endpoint(request: Request):
    await session_manager.handle_request(request.scope, request.receive, request._send)
```

`StreamableHTTPSessionManager.handle_request(scope, receive, send)` is itself an ASGI callable — it sends its own `http.response.start` and `http.response.body` messages through the scope/receive/send triple it's handed. Wrapping it inside a FastAPI `@app.api_route` handler means FastAPI also tries to finalize the response after the handler returns, emitting a **second** `http.response.start`. uvicorn rejects this:

```
RuntimeError: Unexpected ASGI message 'http.response.start' sent,
after response already completed.
```

The traceback shows it bubbling up through FastAPI's route → `starlette.responses.Response.__call__` → uvicorn's `httptools_impl.py`. Every POST to `/mcp` fails this way, so MCP clients can establish the initial GET (which upstream streams but never sends a session-initialization event into) and then fail on the very first `initialize` JSON-RPC message. Claude Code reports "Failed to connect"; Claude Desktop and Open WebUI would see the same.

Reproduced against the current `main` (v1.11.0) with `mcp==1.27.0`, running `docker compose up -d mcp` and testing with Claude Code 2.x.

## The fix

Mount the session manager as an ASGI sub-app:

```python
app = FastAPI(
    title="Homelable MCP",
    lifespan=lifespan,
    routes=[Mount("/mcp", app=session_manager.handle_request)],
)
```

The session manager now owns the response cycle directly. FastAPI's route handler machinery is no longer in the path. `ApiKeyMiddleware` still protects `/mcp` because `app.add_middleware(...)` attaches middleware at the app level — it wraps all mounted sub-apps, including this one.

The `Request` import is no longer needed and is removed in the same commit.

## Verification

- Patched file parses (`ast.parse` OK).
- Deployed the patched image (`mcp==1.27.0`, FastAPI `>=0.115`, uvicorn `>=0.30`) behind Traefik; `claude mcp add --transport http` registers as `✓ Connected`.
- Pod logs show clean `POST /mcp/ → 202 Accepted` and `GET /mcp/ → 200 OK text/event-stream` with no exceptions.
- `/health` still returns `200 {"status":"ok"}` and still bypasses the API key gate (middleware `_BYPASS_PATHS` unchanged).

## Notes

- `--transport http` is the correct flag for Streamable HTTP; the README currently shows `--transport sse` which is the legacy SSE transport. Might be worth updating separately.
- The server already runs in `stateless=True` + `json_response=False` mode. No changes to those semantics.