### PR TITLE
fix: resizer style

### DIFF
--- a/frontend/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/canvas/nodes/BaseNode.tsx
@@ -73,7 +73,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
         minWidth={140}
         minHeight={50}
         lineStyle={{ borderColor: 'transparent' }}
-        handleStyle={{ borderColor: colors.border, background: colors.border, width: 10, height: 10 }}
+        handleStyle={{ borderColor: colors.border, background: colors.border, width: 12, height: 12 }}
       />
       <Handle
         type="source"

--- a/frontend/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/canvas/nodes/BaseNode.tsx
@@ -49,7 +49,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
 
   return (
     <div
-      className="relative flex flex-col rounded-lg border transition-all duration-200 overflow-hidden"
+      className="relative flex flex-col rounded-lg border transition-all duration-200"
       style={{
         background: colors.background,
         borderColor: colors.border,
@@ -73,7 +73,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
         minWidth={140}
         minHeight={50}
         lineStyle={{ borderColor: 'transparent' }}
-        handleStyle={{ borderColor: colors.border, background: colors.border, width: 16, height: 16 }}
+        handleStyle={{ borderColor: colors.border, background: colors.border, width: 10, height: 10 }}
       />
       <Handle
         type="source"

--- a/frontend/src/components/canvas/nodes/GroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupNode.tsx
@@ -51,7 +51,7 @@ export function GroupNode({ id, data, selected }: NodeProps<Node<NodeData>>) {
         minWidth={120}
         minHeight={80}
         lineStyle={{ stroke: '#00d4ff', strokeWidth: 1 }}
-        handleStyle={{ fill: '#00d4ff', stroke: '#0d1117', width: 10, height: 10 }}
+        handleStyle={{ fill: '#00d4ff', stroke: '#0d1117', width: 12, height: 12 }}
       />
 
       {/* 4 snap-point handles — one per side. Source + invisible target overlay for each. */}

--- a/frontend/src/components/canvas/nodes/GroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupNode.tsx
@@ -51,7 +51,7 @@ export function GroupNode({ id, data, selected }: NodeProps<Node<NodeData>>) {
         minWidth={120}
         minHeight={80}
         lineStyle={{ stroke: '#00d4ff', strokeWidth: 1 }}
-        handleStyle={{ fill: '#00d4ff', stroke: '#0d1117', width: 8, height: 8, borderRadius: 2 }}
+        handleStyle={{ fill: '#00d4ff', stroke: '#0d1117', width: 10, height: 10 }}
       />
 
       {/* 4 snap-point handles — one per side. Source + invisible target overlay for each. */}

--- a/frontend/src/components/canvas/nodes/GroupRectNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupRectNode.tsx
@@ -98,9 +98,8 @@ export function GroupRectNode({ id, data, selected }: NodeProps<Node<NodeData>>)
         minWidth={80}
         minHeight={60}
         handleStyle={{
-          width: 8,
-          height: 8,
-          borderRadius: 2,
+          width: 12,
+          height: 12,
           background: '#00d4ff',
           border: '1px solid #0d1117',
         }}

--- a/frontend/src/components/canvas/nodes/GroupRectNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupRectNode.tsx
@@ -82,8 +82,8 @@ export function GroupRectNode({ id, data, selected }: NodeProps<Node<NodeData>>)
   }
 
   const handleStyle: React.CSSProperties = {
-    width: 10,
-    height: 10,
+    width: 12,
+    height: 12,
     background: borderColor,
     border: '2px solid #0d1117',
     borderRadius: '50%',

--- a/frontend/src/components/canvas/nodes/GroupRectNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupRectNode.tsx
@@ -4,6 +4,8 @@ import { ChevronDown } from 'lucide-react'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { getZoneSpatialChildren } from '@/utils/collapseFilter'
 import type { NodeData, TextPosition } from '@/types'
+import { resolveNodeColors } from '@/utils/nodeColors'
+import { useThemeStore } from '@/stores/themeStore'
 
 const FONT_FAMILIES: Record<string, string> = {
   inter: 'Inter, sans-serif',
@@ -61,6 +63,9 @@ export function GroupRectNode({ id, data, selected }: NodeProps<Node<NodeData>>)
   const childrenCount = selfNode
     ? getZoneSpatialChildren(selfNode, nodes ?? []).length
     : 0
+  const activeTheme = useThemeStore((s) => s.activeTheme)
+  const colors = resolveNodeColors(data, activeTheme)
+  const glow = colors.border
 
   const outsideJustify = textPos.includes('right') ? 'flex-end'
     : (textPos.includes('center') || textPos === 'center') ? 'center'
@@ -97,13 +102,8 @@ export function GroupRectNode({ id, data, selected }: NodeProps<Node<NodeData>>)
         isVisible={selected}
         minWidth={80}
         minHeight={60}
-        handleStyle={{
-          width: 12,
-          height: 12,
-          background: '#00d4ff',
-          border: '1px solid #0d1117',
-        }}
         lineStyle={{ borderColor: 'transparent' }}
+        handleStyle={{ borderColor: glow, backgroundColor: colors.border, width: 12, height: 12 }}
       />
 
       {HANDLE_SIDES.map(({ id: hid, position }) => (

--- a/frontend/src/components/canvas/nodes/GroupRectNode.tsx
+++ b/frontend/src/components/canvas/nodes/GroupRectNode.tsx
@@ -56,7 +56,6 @@ export function GroupRectNode({ id, data, selected }: NodeProps<Node<NodeData>>)
   const fontFamily = FONT_FAMILIES[rc.font ?? 'inter'] ?? FONT_FAMILIES.inter
   const textPos = (rc.text_position ?? 'top-left') as TextPosition
   const posStyle = POSITION_STYLES[textPos]
-
   // Count children for collapse badge — groupRect zones don't parent their
   // contents via React Flow parentId, so we hit-test by spatial containment.
   const selfNode = (nodes ?? []).find((n) => n.id === id)

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -65,7 +65,7 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
 
       {/* Group border */}
       <div
-        className="w-full h-full rounded-lg border-2 flex flex-col overflow-hidden"
+        className="w-full h-full rounded-xl border-2 flex flex-col overflow-hidden"
         style={{
           borderColor: selected ? glow : `${glow}88`,
           background: isOnline ? `${colors.background}cc` : `${colors.background}aa`,

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -59,13 +59,13 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
         minWidth={220}
         minHeight={160}
         isVisible={selected}
-        lineStyle={{ borderColor: glow, opacity: 0.6 }}
-        handleStyle={{ borderColor: glow, backgroundColor: theme.colors.nodeCardBackground, width: 6, height: 6 }}
+        lineStyle={{ borderColor: 'transparent' }}
+        handleStyle={{ borderColor: glow, backgroundColor: colors.border, width: 10, height: 10 }}
       />
 
       {/* Group border */}
       <div
-        className="w-full h-full rounded-xl border-2 flex flex-col overflow-hidden"
+        className="w-full h-full rounded-lg border-2 flex flex-col overflow-hidden"
         style={{
           borderColor: selected ? glow : `${glow}88`,
           background: isOnline ? `${colors.background}cc` : `${colors.background}aa`,
@@ -85,7 +85,7 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
           }}
         >
           <div
-            className="flex items-center justify-center w-5 h-5 rounded-md shrink-0"
+            className="flex items-center justify-center w-7 h-7 rounded-md shrink-0"
             style={{
               color: isOnline ? colors.icon : theme.colors.nodeSubtextColor,
               background: theme.colors.nodeIconBackground,
@@ -93,23 +93,24 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
           >
             {isBrandIconKey(data.custom_icon)
               ? <NodeIcon typeIcon={Layers} customIconKey={data.custom_icon} size={12} />
-              : createElement(resolvedIcon, { size: 12 })}
+              : createElement(resolvedIcon, { size: 15 })}
           </div>
-          <div className="flex flex-col min-w-0 flex-1">
-            <span
-              className="text-[11px] font-semibold leading-tight truncate"
+          <div className="flex flex-col min-w-0">
+            <div
+              className="text-xs font-semibold leading-tight truncate"
               style={{ color: isOnline ? glow : theme.colors.nodeLabelColor }}
+              title={data.label}
             >
               {data.label}
-            </span>
+            </div>
             {data.ip && splitIps(data.ip).map((ip) => (
-              <span
+              <div
                 key={ip}
                 className="font-mono text-[9px] truncate"
                 style={{ color: theme.colors.nodeSubtextColor }}
               >
                 {hideIp ? maskIp(ip) : ip}
-              </span>
+              </div>
             ))}
           </div>
           {/* Status dot */}

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -60,7 +60,7 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
         minHeight={160}
         isVisible={selected}
         lineStyle={{ borderColor: 'transparent' }}
-        handleStyle={{ borderColor: glow, backgroundColor: colors.border, width: 10, height: 10 }}
+        handleStyle={{ borderColor: glow, backgroundColor: colors.border, width: 12, height: 12 }}
       />
 
       {/* Group border */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,6 +135,27 @@
     background-color: var(--surface-card) !important;
 }
 
+/* Resize controls */
+.react-flow__resize-control {
+    border-radius: 30% !important;
+}
+
+.react-flow__resize-control.top.left {
+    transform: translate(2px, 2px) !important;
+}
+
+.react-flow__resize-control.top.right {
+    transform: translate(-2px, 2px) !important;
+}
+
+.react-flow__resize-control.bottom.left {
+    transform: translate(2px, -2px) !important;
+}
+
+.react-flow__resize-control.bottom.right {
+    transform: translate(-2px, -2px) !important;
+}
+
 /* Transparent wrapper for container node types */
 .react-flow__node-proxmox,
 .react-flow__node-group {


### PR DESCRIPTION
This PR fixes the node resizer styling of the base node, proxmox group node and group nodes.

Changes:
Removed overflow-hidden on main div which hid the connection handle dot.
Pushed in the resizer control handles with some custom css.
Made height and width consistent between all nodes.
Increased the icon size from 12 to 15
