### PR TITLE
fix(deps): bump zeroconf to 0.149.7 for CVE fixes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ pyyaml==6.0.2
 types-PyYAML==6.0.12.20240917
 websockets==13.1
 httpx==0.27.2
-zeroconf==0.131.0
+zeroconf==0.149.7
 aiomqtt==2.3.0
 
 # Dev


### PR DESCRIPTION
## Problem
Security workflow (`pip-audit`) fails on `main` — `zeroconf==0.131.0` has 3 known CVEs:

| ID | Fix version |
|---|---|
| CVE-2026-47180 | 0.149.5 |
| CVE-2026-47183 | 0.149.6 |
| CVE-2026-47184 | 0.149.7 |

## Fix
Bump `backend/requirements.txt` → `zeroconf==0.149.7`.

## Verification
- Scanner mDNS API (`AsyncServiceBrowser`, `AsyncServiceInfo`, `async_request`) unchanged — imports OK
- Scan tests pass, full pre-commit suite green
- `pip-audit` local: **No known vulnerabilities found**

ha-relevant: no (HACS uses HA's own zeroconf)