### PR TITLE
fix(canvas): Save button no-op due to leaked click event

### DIFF
--- a/frontend/src/components/panels/Sidebar.tsx
+++ b/frontend/src/components/panels/Sidebar.tsx
@@ -257,7 +257,7 @@ export function Sidebar({ onAddNode, onAddGroupRect, onAddText, onScan, onZigbee
           icon={Save}
           label="Save Canvas"
           collapsed={collapsed}
-          onClick={onSave}
+          onClick={() => onSave()}
           badge={hasUnsavedChanges}
           accent
         />

--- a/frontend/src/components/panels/Toolbar.tsx
+++ b/frontend/src/components/panels/Toolbar.tsx
@@ -95,7 +95,7 @@ export function Toolbar({ onSave, onAutoLayout, onExport, onChangeStyle, onUndo,
           background: hasUnsavedChanges ? '#00d4ff' : undefined,
           color: hasUnsavedChanges ? '#0d1117' : undefined,
         }}
-        onClick={onSave}
+        onClick={() => onSave()}
       >
         {hasUnsavedChanges && (
           <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-[#e3b341] border border-[#161b22]" />

--- a/frontend/src/components/panels/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/panels/__tests__/Sidebar.test.tsx
@@ -188,6 +188,15 @@ describe('Sidebar', () => {
     expect(defaultProps.onSave).toHaveBeenCalledOnce()
   })
 
+  // Regression (#186): the click handler must not forward the MouseEvent as an
+  // argument — handleSave treats its first arg as a designIdOverride, so leaking
+  // the event corrupts design_id and the save silently fails.
+  it('calls onSave with no arguments (does not leak the click event)', () => {
+    render(<Sidebar {...defaultProps} />)
+    fireEvent.click(screen.getByText('Save Canvas'))
+    expect(defaultProps.onSave).toHaveBeenCalledWith()
+  })
+
   it('calls onOpenSettings when Settings is clicked', () => {
     render(<Sidebar {...defaultProps} />)
     fireEvent.click(screen.getByText('Settings'))

--- a/frontend/src/components/panels/__tests__/Toolbar.test.tsx
+++ b/frontend/src/components/panels/__tests__/Toolbar.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Toolbar } from '../Toolbar'
+import { useCanvasStore } from '@/stores/canvasStore'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/stores/canvasStore')
+
+vi.mock('@/components/ui/Logo', () => ({
+  Logo: () => <div data-testid="logo" />,
+}))
+
+function mockStore(overrides: Partial<ReturnType<typeof useCanvasStore>> = {}) {
+  vi.mocked(useCanvasStore).mockReturnValue({
+    hasUnsavedChanges: false,
+    past: [],
+    future: [],
+    ...overrides,
+  } as ReturnType<typeof useCanvasStore>)
+}
+
+const defaultProps = {
+  onSave: vi.fn(),
+  onAutoLayout: vi.fn(),
+  onExport: vi.fn(),
+  onChangeStyle: vi.fn(),
+  onUndo: vi.fn(),
+  onRedo: vi.fn(),
+  onShortcuts: vi.fn(),
+  onExportMd: vi.fn(),
+  onExportYaml: vi.fn(),
+  onImportYaml: vi.fn(),
+  onViewOnly: vi.fn(),
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Toolbar', () => {
+  beforeEach(() => {
+    mockStore()
+    vi.clearAllMocks()
+  })
+
+  it('calls onSave when Save is clicked', () => {
+    render(<Toolbar {...defaultProps} />)
+    fireEvent.click(screen.getByText('Save'))
+    expect(defaultProps.onSave).toHaveBeenCalledOnce()
+  })
+
+  // Regression (#186): the click handler must not forward the MouseEvent as an
+  // argument — handleSave treats its first arg as a designIdOverride, so leaking
+  // the event corrupts design_id and the save silently fails.
+  it('calls onSave with no arguments (does not leak the click event)', () => {
+    render(<Toolbar {...defaultProps} />)
+    fireEvent.click(screen.getByText('Save'))
+    expect(defaultProps.onSave).toHaveBeenCalledWith()
+  })
+})


### PR DESCRIPTION
## Problem

On a fresh install, **Ctrl+S saves the canvas but clicking the Save button (Toolbar) or "Save Canvas" (Sidebar) does nothing.** Reported in #186.

## Root cause

Both buttons wired the handler directly:

```tsx
onClick={onSave}
```

React passes the `MouseEvent` as the first argument, and `handleSave` treats its first arg as a `designIdOverride`:

```ts
const handleSave = async (designIdOverride?: string) => {
  const saveDesignId = designIdOverride ?? activeDesignId   // = the event object!
  await canvasApi.save({ ..., design_id: saveDesignId })
}
```

So `design_id` got a serialized event instead of a string → the save silently failed. Ctrl+S worked because it calls `handleSaveRef.current()` with **no argument**.

The prop type `onSave: () => void` masked the leaked arg from the type checker.

## Fix

Wrap both call sites so no event leaks through:

```tsx
onClick={() => onSave()}
```

- `Toolbar.tsx`
- `Sidebar.tsx`

## Tests

- New `Toolbar.test.tsx` and strengthened `Sidebar.test.tsx` regression tests assert `onSave` is called with **zero arguments** on click (`toHaveBeenCalledWith()`), which would fail with the old `onClick={onSave}` wiring.

> Note: this is a **separate** bug from the reverse-proxy / 401 case discussed earlier in #186. This PR fixes only the button no-op (Ctrl+S vs button discrepancy).


