### PR TITLE
fix(nodes): persist show_port_numbers across reloads

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -92,6 +92,8 @@ async def init_db() -> None:
         with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN show_hardware BOOLEAN NOT NULL DEFAULT 0")
         with suppress(OperationalError):
+            await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN show_port_numbers BOOLEAN NOT NULL DEFAULT 0")
+        with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN width REAL")
         with suppress(OperationalError):
             await conn.exec_driver_sql("ALTER TABLE nodes ADD COLUMN height REAL")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -54,6 +54,7 @@ class Node(Base):
     ram_gb: Mapped[float | None] = mapped_column(Float, nullable=True)
     disk_gb: Mapped[float | None] = mapped_column(Float, nullable=True)
     show_hardware: Mapped[bool] = mapped_column(Boolean, default=False)
+    show_port_numbers: Mapped[bool] = mapped_column(Boolean, default=False)
     properties: Mapped[list[Any]] = mapped_column(JSON, default=list)
     width: Mapped[float | None] = mapped_column(Float, nullable=True)
     height: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/schemas/canvas.py
+++ b/backend/app/schemas/canvas.py
@@ -29,6 +29,7 @@ class NodeSave(BaseModel):
     ram_gb: float | None = None
     disk_gb: float | None = None
     show_hardware: bool = False
+    show_port_numbers: bool = False
     properties: list[Any] = []
     width: float | None = None
     height: float | None = None

--- a/backend/app/schemas/nodes.py
+++ b/backend/app/schemas/nodes.py
@@ -27,6 +27,7 @@ class NodeBase(BaseModel):
     ram_gb: float | None = None
     disk_gb: float | None = None
     show_hardware: bool = False
+    show_port_numbers: bool = False
     properties: list[dict[str, Any]] = []
     width: float | None = None
     height: float | None = None
@@ -60,6 +61,7 @@ class NodeUpdate(BaseModel):
     ram_gb: float | None = None
     disk_gb: float | None = None
     show_hardware: bool | None = None
+    show_port_numbers: bool | None = None
     properties: list[dict[str, Any]] | None = None
     width: float | None = None
     height: float | None = None

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -199,6 +199,24 @@ async def test_save_canvas_show_hardware_defaults_false(client: AsyncClient, hea
     assert canvas["nodes"][0]["show_hardware"] is False
 
 
+# Regression (#184): show_port_numbers was dropped by the save schema, so the
+# toggle reset on every reload.
+async def test_save_canvas_persists_show_port_numbers(client: AsyncClient, headers: dict):
+    n1 = node_payload(show_port_numbers=True)
+    await client.post("/api/v1/canvas/save", json={"nodes": [n1], "edges": [], "viewport": {}}, headers=headers)
+
+    canvas = (await client.get("/api/v1/canvas", headers=headers)).json()
+    assert canvas["nodes"][0]["show_port_numbers"] is True
+
+
+async def test_save_canvas_show_port_numbers_defaults_false(client: AsyncClient, headers: dict):
+    n1 = node_payload()
+    await client.post("/api/v1/canvas/save", json={"nodes": [n1], "edges": [], "viewport": {}}, headers=headers)
+
+    canvas = (await client.get("/api/v1/canvas", headers=headers)).json()
+    assert canvas["nodes"][0]["show_port_numbers"] is False
+
+
 async def test_save_canvas_hardware_fields_cleared_on_update(client: AsyncClient, headers: dict):
     n1 = node_payload(cpu_count=8, ram_gb=32.0)
     await client.post("/api/v1/canvas/save", json={"nodes": [n1], "edges": [], "viewport": {}}, headers=headers)


### PR DESCRIPTION
## Problem

Enabling **Show Port Numbers** on a node and saving the canvas works visually, but the toggle resets after a page reload (#184).

## Root cause

The flag was never persisted by the backend:

- The `nodes` table / `Node` model had no `show_port_numbers` column.
- `NodeSave` (the `POST /canvas/save` schema), `NodeBase`, and `NodeUpdate` did **not** declare the field, so Pydantic silently dropped it before it ever reached the DB.

The frontend already serializes (`canvasSerializer.ts:118`) and deserializes it, so once the backend stores and returns it, the round-trip works end-to-end — no frontend change needed.

## Fix

- Add `show_port_numbers` boolean column to the `Node` model + idempotent migration in `init_db` (mirrors the existing `show_hardware` migration).
- Add the field to `NodeBase`, `NodeUpdate`, and `NodeSave` schemas so it round-trips through save/load.

## Tests

- `test_save_canvas_persists_show_port_numbers` — save with `True`, reload, assert it sticks.
- `test_save_canvas_show_port_numbers_defaults_false` — default case.

Full backend suite green (ruff + pytest).

> Note: the second feature request in the issue (uplink port placement at the top of the node) is out of scope for this fix; this PR only addresses the persistence bug.

Closes #184
