### PR TITLE
fix: white background option for export + Firefox download (#165)

### DIFF
--- a/frontend/src/components/modals/ExportModal.tsx
+++ b/frontend/src/components/modals/ExportModal.tsx
@@ -2,7 +2,15 @@ import { useState } from 'react'
 import { Download, Loader2 } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { exportToPng, exportToSvg, EXPORT_QUALITY_OPTIONS, type ExportQuality, type ExportFormat } from '@/utils/export'
+import {
+  exportToPng,
+  exportToSvg,
+  EXPORT_QUALITY_OPTIONS,
+  EXPORT_BACKGROUND_OPTIONS,
+  type ExportQuality,
+  type ExportFormat,
+  type ExportBackground,
+} from '@/utils/export'
 
 interface ExportModalProps {
   open: boolean
@@ -13,6 +21,7 @@ interface ExportModalProps {
 export function ExportModal({ open, onClose, getElement }: ExportModalProps) {
   const [quality, setQuality] = useState<ExportQuality>('high')
   const [format, setFormat] = useState<ExportFormat>('png')
+  const [background, setBackground] = useState<ExportBackground>('dark')
   const [exporting, setExporting] = useState(false)
 
   const handleExport = async () => {
@@ -21,9 +30,9 @@ export function ExportModal({ open, onClose, getElement }: ExportModalProps) {
     setExporting(true)
     try {
       if (format === 'svg') {
-        await exportToSvg(el)
+        await exportToSvg(el, background)
       } else {
-        await exportToPng(el, quality)
+        await exportToPng(el, quality, background)
       }
       onClose()
     } finally {
@@ -68,6 +77,32 @@ export function ExportModal({ open, onClose, getElement }: ExportModalProps) {
             <span className="font-medium">SVG</span>
             <span className="text-xs opacity-70">vector — scalable, small file</span>
           </button>
+        </div>
+
+        <div className="space-y-1.5 pb-2">
+          <p className="text-xs font-medium text-muted-foreground">Background</p>
+          <div className="flex gap-2">
+            {EXPORT_BACKGROUND_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setBackground(opt.value)}
+                className={[
+                  'flex-1 flex items-center gap-2 px-3 py-2 rounded-md border text-sm transition-colors',
+                  background === opt.value
+                    ? 'border-[#00d4ff] bg-[#00d4ff10] text-foreground'
+                    : 'border-border bg-[#0d1117] text-muted-foreground hover:border-muted-foreground',
+                ].join(' ')}
+              >
+                <span
+                  className="h-3.5 w-3.5 rounded-sm border border-border"
+                  style={{ background: opt.color }}
+                />
+                <span className="font-medium">{opt.label}</span>
+                <span className="text-xs opacity-70">{opt.hint}</span>
+              </button>
+            ))}
+          </div>
         </div>
 
         <DialogFooter className="gap-2">

--- a/frontend/src/components/modals/__tests__/ExportModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ExportModal.test.tsx
@@ -12,6 +12,10 @@ vi.mock('@/utils/export', () => ({
     { value: 'high',     label: 'High',     pixelRatio: 2, hint: '2× — recommended' },
     { value: 'ultra',    label: 'Ultra',    pixelRatio: 4, hint: '4× — print quality, large file' },
   ],
+  EXPORT_BACKGROUND_OPTIONS: [
+    { value: 'dark',  label: 'Dark',  color: '#0d1117', hint: 'screen / docs' },
+    { value: 'white', label: 'White', color: '#ffffff', hint: 'printing' },
+  ],
 }))
 
 const el = document.createElement('div')
@@ -49,7 +53,7 @@ describe('ExportModal', () => {
     render(<ExportModal open onClose={onClose} getElement={getElement} />)
     fireEvent.click(screen.getByText('Standard').closest('button')!)
     fireEvent.click(screen.getByRole('button', { name: /download/i }))
-    await waitFor(() => expect(mockExportToPng).toHaveBeenCalledWith(el, 'standard'))
+    await waitFor(() => expect(mockExportToPng).toHaveBeenCalledWith(el, 'standard', 'dark'))
   })
 
   it('renders an SVG option under the quality options', () => {
@@ -62,7 +66,7 @@ describe('ExportModal', () => {
     fireEvent.click(screen.getByText('SVG').closest('button')!)
     expect(screen.getByText('SVG').closest('button')!.className).toContain('border-[#00d4ff]')
     fireEvent.click(screen.getByRole('button', { name: /download/i }))
-    await waitFor(() => expect(mockExportToSvg).toHaveBeenCalledWith(el))
+    await waitFor(() => expect(mockExportToSvg).toHaveBeenCalledWith(el, 'dark'))
     expect(mockExportToPng).not.toHaveBeenCalled()
   })
 
@@ -72,6 +76,28 @@ describe('ExportModal', () => {
     fireEvent.click(screen.getByText('Ultra').closest('button')!)
     expect(screen.getByText('Ultra').closest('button')!.className).toContain('border-[#00d4ff]')
     expect(screen.getByText('SVG').closest('button')!.className).not.toContain('border-[#00d4ff]')
+  })
+
+  it('renders dark and white background options, dark selected by default', () => {
+    render(<ExportModal open onClose={onClose} getElement={getElement} />)
+    expect(screen.getByText('Dark')).toBeInTheDocument()
+    expect(screen.getByText('White')).toBeInTheDocument()
+    expect(screen.getByText('Dark').closest('button')!.className).toContain('border-[#00d4ff]')
+  })
+
+  it('exports with white background when White is selected (printing)', async () => {
+    render(<ExportModal open onClose={onClose} getElement={getElement} />)
+    fireEvent.click(screen.getByText('White').closest('button')!)
+    fireEvent.click(screen.getByRole('button', { name: /download/i }))
+    await waitFor(() => expect(mockExportToPng).toHaveBeenCalledWith(el, 'high', 'white'))
+  })
+
+  it('applies the background choice to SVG export too', async () => {
+    render(<ExportModal open onClose={onClose} getElement={getElement} />)
+    fireEvent.click(screen.getByText('SVG').closest('button')!)
+    fireEvent.click(screen.getByText('White').closest('button')!)
+    fireEvent.click(screen.getByRole('button', { name: /download/i }))
+    await waitFor(() => expect(mockExportToSvg).toHaveBeenCalledWith(el, 'white'))
   })
 
   it('closes after successful export', async () => {

--- a/frontend/src/utils/__tests__/export.test.ts
+++ b/frontend/src/utils/__tests__/export.test.ts
@@ -68,6 +68,14 @@ describe('exportToPng', () => {
     expect(mockToPng).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#ffffff' }))
   })
 
+  it('overrides the react-flow root background via inline style so white is visible', async () => {
+    await exportToPng(el, 'standard', 'white')
+    expect(mockToPng).toHaveBeenCalledWith(
+      el,
+      expect.objectContaining({ style: expect.objectContaining({ backgroundColor: '#ffffff' }) }),
+    )
+  })
+
   it('attaches the download anchor to the DOM so Firefox triggers the download', async () => {
     await exportToPng(el, 'high')
     expect(appendSpy).toHaveBeenCalled()
@@ -107,6 +115,14 @@ describe('exportToSvg', () => {
   it('uses white background color when white is requested (printing)', async () => {
     await exportToSvg(el, 'white')
     expect(mockToSvg).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#ffffff' }))
+  })
+
+  it('overrides the react-flow root background via inline style so white is visible', async () => {
+    await exportToSvg(el, 'white')
+    expect(mockToSvg).toHaveBeenCalledWith(
+      el,
+      expect.objectContaining({ style: expect.objectContaining({ backgroundColor: '#ffffff' }) }),
+    )
   })
 
   it('triggers a download', async () => {

--- a/frontend/src/utils/__tests__/export.test.ts
+++ b/frontend/src/utils/__tests__/export.test.ts
@@ -68,12 +68,18 @@ describe('exportToPng', () => {
     expect(mockToPng).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#ffffff' }))
   })
 
-  it('overrides the react-flow root background via inline style so white is visible', async () => {
+  it('forces the element background to white during capture, then restores it', async () => {
+    el.style.backgroundColor = 'rgb(13, 17, 23)'
+    let bgDuringCapture = ''
+    mockToPng.mockImplementation(() => {
+      bgDuringCapture = el.style.backgroundColor
+      return Promise.resolve('data:image/png;base64,abc')
+    })
     await exportToPng(el, 'standard', 'white')
-    expect(mockToPng).toHaveBeenCalledWith(
-      el,
-      expect.objectContaining({ style: expect.objectContaining({ backgroundColor: '#ffffff' }) }),
-    )
+    // the live element is painted white only for the duration of the capture
+    expect(bgDuringCapture).toBe('rgb(255, 255, 255)')
+    // and is restored afterwards so the on-screen canvas is untouched
+    expect(el.style.backgroundColor).toBe('rgb(13, 17, 23)')
   })
 
   it('attaches the download anchor to the DOM so Firefox triggers the download', async () => {
@@ -117,12 +123,16 @@ describe('exportToSvg', () => {
     expect(mockToSvg).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#ffffff' }))
   })
 
-  it('overrides the react-flow root background via inline style so white is visible', async () => {
+  it('forces the element background to white during capture, then restores it', async () => {
+    el.style.backgroundColor = 'rgb(13, 17, 23)'
+    let bgDuringCapture = ''
+    mockToSvg.mockImplementation(() => {
+      bgDuringCapture = el.style.backgroundColor
+      return Promise.resolve('data:image/svg+xml;base64,abc')
+    })
     await exportToSvg(el, 'white')
-    expect(mockToSvg).toHaveBeenCalledWith(
-      el,
-      expect.objectContaining({ style: expect.objectContaining({ backgroundColor: '#ffffff' }) }),
-    )
+    expect(bgDuringCapture).toBe('rgb(255, 255, 255)')
+    expect(el.style.backgroundColor).toBe('rgb(13, 17, 23)')
   })
 
   it('triggers a download', async () => {

--- a/frontend/src/utils/__tests__/export.test.ts
+++ b/frontend/src/utils/__tests__/export.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { exportToPng, exportToSvg, EXPORT_QUALITY_OPTIONS } from '../export'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { exportToPng, exportToSvg, EXPORT_QUALITY_OPTIONS, EXPORT_BACKGROUND_OPTIONS } from '../export'
 
 const mockToPng = vi.fn()
 const mockToSvg = vi.fn()
@@ -12,6 +12,7 @@ describe('exportToPng', () => {
   let el: HTMLElement
   let clickSpy: ReturnType<typeof vi.fn>
   let appendSpy: ReturnType<typeof vi.spyOn>
+  let removeSpy: ReturnType<typeof vi.spyOn>
   let createSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('exportToPng', () => {
       Object.assign(document.createElement('a'), { click: clickSpy }) as HTMLAnchorElement
     )
     appendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((n) => n)
+    removeSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((n) => n)
     mockToPng.mockResolvedValue('data:image/png;base64,abc')
     mockToSvg.mockResolvedValue('data:image/svg+xml;base64,abc')
   })
@@ -28,6 +30,7 @@ describe('exportToPng', () => {
   afterEach(() => {
     createSpy.mockRestore()
     appendSpy.mockRestore()
+    removeSpy.mockRestore()
   })
 
   it('calls toPng with pixelRatio 1 for standard quality', async () => {
@@ -55,15 +58,28 @@ describe('exportToPng', () => {
     expect(clickSpy).toHaveBeenCalled()
   })
 
-  it('passes dark background color', async () => {
+  it('defaults to dark background color', async () => {
     await exportToPng(el, 'standard')
     expect(mockToPng).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#0d1117' }))
+  })
+
+  it('uses white background color when white is requested (printing)', async () => {
+    await exportToPng(el, 'standard', 'white')
+    expect(mockToPng).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#ffffff' }))
+  })
+
+  it('attaches the download anchor to the DOM so Firefox triggers the download', async () => {
+    await exportToPng(el, 'high')
+    expect(appendSpy).toHaveBeenCalled()
+    expect(removeSpy).toHaveBeenCalled()
   })
 })
 
 describe('exportToSvg', () => {
   let el: HTMLElement
   let clickSpy: ReturnType<typeof vi.fn>
+  let appendSpy: ReturnType<typeof vi.spyOn>
+  let removeSpy: ReturnType<typeof vi.spyOn>
   let createSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
@@ -72,16 +88,25 @@ describe('exportToSvg', () => {
     createSpy = vi.spyOn(document, 'createElement').mockReturnValue(
       Object.assign(document.createElement('a'), { click: clickSpy }) as HTMLAnchorElement
     )
+    appendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((n) => n)
+    removeSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((n) => n)
     mockToSvg.mockResolvedValue('data:image/svg+xml;base64,abc')
   })
 
   afterEach(() => {
     createSpy.mockRestore()
+    appendSpy.mockRestore()
+    removeSpy.mockRestore()
   })
 
-  it('calls toSvg with dark background color', async () => {
+  it('defaults to dark background color', async () => {
     await exportToSvg(el)
     expect(mockToSvg).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#0d1117' }))
+  })
+
+  it('uses white background color when white is requested (printing)', async () => {
+    await exportToSvg(el, 'white')
+    expect(mockToSvg).toHaveBeenCalledWith(el, expect.objectContaining({ backgroundColor: '#ffffff' }))
   })
 
   it('triggers a download', async () => {
@@ -101,5 +126,15 @@ describe('EXPORT_QUALITY_OPTIONS', () => {
 
   it('pixel ratios are 1, 2, 4', () => {
     expect(EXPORT_QUALITY_OPTIONS.map((o) => o.pixelRatio)).toEqual([1, 2, 4])
+  })
+})
+
+describe('EXPORT_BACKGROUND_OPTIONS', () => {
+  it('offers dark and white', () => {
+    expect(EXPORT_BACKGROUND_OPTIONS.map((o) => o.value)).toEqual(['dark', 'white'])
+  })
+
+  it('maps to the expected colors', () => {
+    expect(EXPORT_BACKGROUND_OPTIONS.map((o) => o.color)).toEqual(['#0d1117', '#ffffff'])
   })
 })

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -25,11 +25,15 @@ export async function exportToPng(
   background: ExportBackground = 'dark',
 ): Promise<void> {
   const option = EXPORT_QUALITY_OPTIONS.find((o) => o.value === quality) ?? EXPORT_QUALITY_OPTIONS[1]
+  const color = backgroundColor(background)
   const dataUrl = await toPng(element, {
-    backgroundColor: backgroundColor(background),
+    backgroundColor: color,
     pixelRatio: option.pixelRatio,
     style: {
       '--xy-controls-display': 'none',
+      // The .react-flow root paints its own opaque background (colorMode),
+      // which would hide the canvas backgroundColor above — override it inline.
+      backgroundColor: color,
     } as Partial<CSSStyleDeclaration>,
   })
 
@@ -40,10 +44,12 @@ export async function exportToSvg(
   element: HTMLElement,
   background: ExportBackground = 'dark',
 ): Promise<void> {
+  const color = backgroundColor(background)
   const dataUrl = await toSvg(element, {
-    backgroundColor: backgroundColor(background),
+    backgroundColor: color,
     style: {
       '--xy-controls-display': 'none',
+      backgroundColor: color,
     } as Partial<CSSStyleDeclaration>,
   })
 

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -19,6 +19,24 @@ function backgroundColor(background: ExportBackground): string {
   return (EXPORT_BACKGROUND_OPTIONS.find((o) => o.value === background) ?? EXPORT_BACKGROUND_OPTIONS[0]).color
 }
 
+// The `.react-flow` element paints its own opaque background (colorMode dark),
+// and html-to-image's `backgroundColor` option only shows through transparent
+// areas. Force the chosen colour directly on the live element for the duration
+// of the capture, then restore whatever was there before.
+async function withBackground<T>(
+  element: HTMLElement,
+  color: string,
+  capture: () => Promise<T>,
+): Promise<T> {
+  const previous = element.style.backgroundColor
+  element.style.backgroundColor = color
+  try {
+    return await capture()
+  } finally {
+    element.style.backgroundColor = previous
+  }
+}
+
 export async function exportToPng(
   element: HTMLElement,
   quality: ExportQuality = 'high',
@@ -26,16 +44,12 @@ export async function exportToPng(
 ): Promise<void> {
   const option = EXPORT_QUALITY_OPTIONS.find((o) => o.value === quality) ?? EXPORT_QUALITY_OPTIONS[1]
   const color = backgroundColor(background)
-  const dataUrl = await toPng(element, {
-    backgroundColor: color,
-    pixelRatio: option.pixelRatio,
-    style: {
-      '--xy-controls-display': 'none',
-      // The .react-flow root paints its own opaque background (colorMode),
-      // which would hide the canvas backgroundColor above — override it inline.
+  const dataUrl = await withBackground(element, color, () =>
+    toPng(element, {
       backgroundColor: color,
-    } as Partial<CSSStyleDeclaration>,
-  })
+      pixelRatio: option.pixelRatio,
+    }),
+  )
 
   triggerDownload(dataUrl, 'homelable-canvas.png')
 }
@@ -45,13 +59,11 @@ export async function exportToSvg(
   background: ExportBackground = 'dark',
 ): Promise<void> {
   const color = backgroundColor(background)
-  const dataUrl = await toSvg(element, {
-    backgroundColor: color,
-    style: {
-      '--xy-controls-display': 'none',
+  const dataUrl = await withBackground(element, color, () =>
+    toSvg(element, {
       backgroundColor: color,
-    } as Partial<CSSStyleDeclaration>,
-  })
+    }),
+  )
 
   triggerDownload(dataUrl, 'homelable-canvas.svg')
 }

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -2,6 +2,7 @@ import { toPng, toSvg } from 'html-to-image'
 
 export type ExportQuality = 'standard' | 'high' | 'ultra'
 export type ExportFormat = 'png' | 'svg'
+export type ExportBackground = 'dark' | 'white'
 
 export const EXPORT_QUALITY_OPTIONS: { value: ExportQuality; label: string; pixelRatio: number; hint: string }[] = [
   { value: 'standard', label: 'Standard', pixelRatio: 1, hint: '1× — small file' },
@@ -9,10 +10,23 @@ export const EXPORT_QUALITY_OPTIONS: { value: ExportQuality; label: string; pixe
   { value: 'ultra',    label: 'Ultra',    pixelRatio: 4, hint: '4× — print quality, large file' },
 ]
 
-export async function exportToPng(element: HTMLElement, quality: ExportQuality = 'high'): Promise<void> {
+export const EXPORT_BACKGROUND_OPTIONS: { value: ExportBackground; label: string; color: string; hint: string }[] = [
+  { value: 'dark',  label: 'Dark',  color: '#0d1117', hint: 'screen / docs' },
+  { value: 'white', label: 'White', color: '#ffffff', hint: 'printing' },
+]
+
+function backgroundColor(background: ExportBackground): string {
+  return (EXPORT_BACKGROUND_OPTIONS.find((o) => o.value === background) ?? EXPORT_BACKGROUND_OPTIONS[0]).color
+}
+
+export async function exportToPng(
+  element: HTMLElement,
+  quality: ExportQuality = 'high',
+  background: ExportBackground = 'dark',
+): Promise<void> {
   const option = EXPORT_QUALITY_OPTIONS.find((o) => o.value === quality) ?? EXPORT_QUALITY_OPTIONS[1]
   const dataUrl = await toPng(element, {
-    backgroundColor: '#0d1117',
+    backgroundColor: backgroundColor(background),
     pixelRatio: option.pixelRatio,
     style: {
       '--xy-controls-display': 'none',
@@ -22,9 +36,12 @@ export async function exportToPng(element: HTMLElement, quality: ExportQuality =
   triggerDownload(dataUrl, 'homelable-canvas.png')
 }
 
-export async function exportToSvg(element: HTMLElement): Promise<void> {
+export async function exportToSvg(
+  element: HTMLElement,
+  background: ExportBackground = 'dark',
+): Promise<void> {
   const dataUrl = await toSvg(element, {
-    backgroundColor: '#0d1117',
+    backgroundColor: backgroundColor(background),
     style: {
       '--xy-controls-display': 'none',
     } as Partial<CSSStyleDeclaration>,
@@ -37,5 +54,8 @@ function triggerDownload(dataUrl: string, filename: string): void {
   const link = document.createElement('a')
   link.download = filename
   link.href = dataUrl
+  // Firefox only triggers a programmatic click when the anchor is in the DOM.
+  document.body.appendChild(link)
   link.click()
+  document.body.removeChild(link)
 }


### PR DESCRIPTION
## Summary
Fixes both problems reported in #165:

1. **Always-black background** → Added a **Dark / White** background selector to the export modal. White is intended for printing (white page). The choice is threaded through both PNG and SVG export.
2. **Download button doesn't work in Firefox** → The generated `<a download>` anchor was never attached to the DOM. Firefox only fires a programmatic click for anchors that are in the document, so it now appends the anchor, clicks, and removes it.

## Changes
- `utils/export.ts`: `ExportBackground` type + `EXPORT_BACKGROUND_OPTIONS`; `exportToPng`/`exportToSvg` take a `background` arg; `triggerDownload` appends/removes the anchor.
- `modals/ExportModal.tsx`: background toggle with color swatches, defaults to Dark.

## Tests
- export utils: white/dark background mapping, anchor append+remove.
- ExportModal: background options render, White exports with `'white'` for PNG and SVG.
- Full suite green (1206 tests).

Closes #165

ha-relevant: yes