### PR TITLE
build: typecheck with tsc -b to match the production build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
The `typecheck` script ran `tsc --noEmit` against the root tsconfig, which has `files: []` and only project references — so without `-b` it checked nothing in src and let real type errors (e.g. theme_id) reach Docker CI. Switch to `tsc -b` (same as the build) so pre-commit and the Quality job catch them locally.

ha-relevant: no