### PR TITLE
docs: fix MCP client transport to http (was sse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ docker compose up -d mcp
 
 **Claude Code** — run this command in your terminal:
 ```bash
-claude mcp add --transport sse homelable http://<your-homelab-ip>:8001/mcp \
+claude mcp add --transport http homelable http://<your-homelab-ip>:8001/mcp/ \
   --header "X-API-Key: mcp_sk_yourkey"
 ```
 
@@ -326,8 +326,8 @@ Or add it manually to `~/.claude.json`:
 {
   "mcpServers": {
     "homelable": {
-      "type": "sse",
-      "url": "http://<your-homelab-ip>:8001/mcp",
+      "type": "http",
+      "url": "http://<your-homelab-ip>:8001/mcp/",
       "headers": {
         "X-API-Key": "mcp_sk_yourkey"
       }
@@ -341,8 +341,8 @@ Or add it manually to `~/.claude.json`:
 {
   "mcpServers": {
     "homelable": {
-      "type": "sse",
-      "url": "http://<your-homelab-ip>:8001/mcp",
+      "type": "http",
+      "url": "http://<your-homelab-ip>:8001/mcp/",
       "headers": {
         "X-API-Key": "mcp_sk_yourkey"
       }


### PR DESCRIPTION
## What
Fix the MCP client setup docs in the README. The server uses the modern Streamable HTTP transport, but the README told users to register the client with legacy SSE, causing Claude Code to report "Failed to connect" despite a healthy container.

## Root cause
`mcp/app/main.py` builds the server with `StreamableHTTPSessionManager` mounted at `/mcp`. A legacy SSE client opens a GET stream and waits for an initial `endpoint` event that Streamable HTTP never emits, so the client hangs. The container looks healthy (`curl` gets a 200) while the MCP client silently fails.

## Changes
- `README.md` — Claude Code CLI command: `--transport sse` -> `--transport http`
- `README.md` — Claude Code manual `~/.claude.json` snippet: `"type": "sse"` -> `"type": "http"`
- `README.md` — Claude Desktop `claude_desktop_config.json` snippet: `"type": "sse"` -> `"type": "http"`
- All URLs point at the trailing-slash `/mcp/` to avoid the 307 redirect that can drop the auth header

Docs-only, no code change.

Fixes #274

ha-relevant: no