### PR TITLE
feat: Proxmox import container mode (nest VMs/LXCs inside host containers)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import type { ZigbeeNode, ZigbeeEdge } from '@/components/zigbee/types'
 import type { ZwaveNode, ZwaveEdge } from '@/components/zwave/types'
 import type { ProxmoxNode, ProxmoxEdge } from '@/components/proxmox/types'
 import { buildProxmoxClusterEdges } from '@/components/proxmox/clusterEdges'
+import { containerDims, childRelPos } from '@/utils/proxmoxLayout'
 
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 
@@ -655,7 +656,7 @@ export default function App() {
     markUnsaved()
   }, [addNode, onConnect, snapshotHistory, markUnsaved])
 
-  const handleProxmoxAddToCanvas = useCallback((pmNodes: ProxmoxNode[], pmEdges: ProxmoxEdge[], containerMode: boolean) => {
+  const handleProxmoxAddToCanvas = useCallback((pmNodes: ProxmoxNode[], pmEdges: ProxmoxEdge[], containerMode: boolean, columns: number) => {
     snapshotHistory()
     const clusterEdges = buildProxmoxClusterEdges(pmNodes)
     const cluster = clusterEdges.length > 0
@@ -701,9 +702,6 @@ export default function App() {
       })
     } else {
       // Container mode — nest each VM/LXC inside its host container
-      const CONTAINER_W = 300
-      const CHILD_H = 70
-      const HEADER_H = 60
       const CONTAINER_GAP = 50
 
       const hostNodes = pmNodes.filter((pn) => pn.type === 'proxmox')
@@ -717,18 +715,23 @@ export default function App() {
           }
         })
 
-      const totalWidth =
-        hostNodes.length * CONTAINER_W + Math.max(0, hostNodes.length - 1) * CONTAINER_GAP
+      const safeCols = Math.max(1, Math.min(columns, 6))
       const maxContainerH = hostNodes.reduce((max, h) => {
         const childCount = (guestsByHost.get(h.id) ?? []).length
-        return Math.max(max, HEADER_H + childCount * CHILD_H + 10)
+        const { height } = containerDims(childCount, safeCols)
+        return Math.max(max, height)
       }, 200)
+      const totalWidth = hostNodes.reduce((sum, h) => {
+        const childCount = (guestsByHost.get(h.id) ?? []).length
+        const { width } = containerDims(childCount, safeCols)
+        return sum + width
+      }, 0) + Math.max(0, hostNodes.length - 1) * CONTAINER_GAP
       const origin = getCenteredPosition(totalWidth, maxContainerH)
 
       let cursorX = origin.x
       hostNodes.forEach((hostNode) => {
         const children = guestsByHost.get(hostNode.id) ?? []
-        const containerH = Math.max(200, HEADER_H + children.length * CHILD_H + 10)
+        const { width: containerW, height: containerH } = containerDims(children.length, safeCols)
         const containerPos = { x: cursorX, y: origin.y }
 
         // Add host as a container node
@@ -736,7 +739,7 @@ export default function App() {
           id: hostNode.id,
           type: hostNode.type,
           position: containerPos,
-          width: CONTAINER_W,
+          width: containerW,
           height: containerH,
           data: {
             label: hostNode.label,
@@ -744,20 +747,22 @@ export default function App() {
             status: (hostNode.status === 'online' ? 'online' : 'unknown') as NodeData['status'],
             services: [],
             container_mode: true,
+            container_columns: safeCols,
             ...(hostNode.ip ? { ip: hostNode.ip } : {}),
             ...(hostNode.hostname ? { hostname: hostNode.hostname } : {}),
             ...(cluster ? { left_handles: 1, right_handles: 1 } : {}),
           },
         } as import('@xyflow/react').Node<NodeData>)
 
-        // Add children with absolute canvas positions; store converts to parent-relative
+        // Add children using absolute canvas positions; store converts to parent-relative
         children.forEach((child, i) => {
+          const rel = childRelPos(i, safeCols)
           addNode({
             id: child.id,
             type: child.type,
             position: {
-              x: containerPos.x + 20,
-              y: containerPos.y + HEADER_H + i * CHILD_H,
+              x: containerPos.x + rel.x,
+              y: containerPos.y + rel.y,
             },
             data: {
               label: child.label,
@@ -771,7 +776,7 @@ export default function App() {
           } as import('@xyflow/react').Node<NodeData>)
         })
 
-        cursorX += CONTAINER_W + CONTAINER_GAP
+        cursorX += containerW + CONTAINER_GAP
       })
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -655,51 +655,127 @@ export default function App() {
     markUnsaved()
   }, [addNode, onConnect, snapshotHistory, markUnsaved])
 
-  const handleProxmoxAddToCanvas = useCallback((pmNodes: ProxmoxNode[], pmEdges: ProxmoxEdge[]) => {
+  const handleProxmoxAddToCanvas = useCallback((pmNodes: ProxmoxNode[], pmEdges: ProxmoxEdge[], containerMode: boolean) => {
     snapshotHistory()
-    const COLS = 4
-    const SPACING_X = 190
-    const SPACING_Y = 110
-    const cols = Math.min(COLS, pmNodes.length)
-    const rows = Math.ceil(pmNodes.length / COLS)
-    const origin = getCenteredPosition(cols * SPACING_X, rows * SPACING_Y)
-    // Multiple hosts from one import = a cluster → chain them via left/right
-    // 'cluster' edges. Those endpoints need one left + one right handle each
-    // (both default to 0), so grant them to the host nodes up front.
     const clusterEdges = buildProxmoxClusterEdges(pmNodes)
     const cluster = clusterEdges.length > 0
-    pmNodes.forEach((pn, i) => {
-      const col = i % COLS
-      const row = Math.floor(i / COLS)
-      const position = { x: origin.x + col * SPACING_X, y: origin.y + row * SPACING_Y }
-      const isClusterHost = cluster && pn.type === 'proxmox'
-      const newNode: import('@xyflow/react').Node<NodeData> = {
-        id: pn.id,
-        type: pn.type,
-        position,
-        data: {
-          label: pn.label,
-          type: pn.type as NodeData['type'],
-          status: (pn.status === 'online' ? 'online' : 'unknown') as NodeData['status'],
-          services: [],
-          ...(pn.ip ? { ip: pn.ip } : {}),
-          ...(pn.hostname ? { hostname: pn.hostname } : {}),
-          ...(isClusterHost ? { left_handles: 1, right_handles: 1 } : {}),
-        },
-      }
-      addNode(newNode)
-    })
-    // Host → guest links render as 'virtual' edges (VM/LXC ↔ host).
-    pmEdges.forEach((pe) => {
-      onConnect({
-        source: pe.source,
-        sourceHandle: 'bottom',
-        target: pe.target,
-        targetHandle: 'top-t',
-        type: 'virtual',
-      } as unknown as import('@xyflow/react').Connection)
-    })
-    // Host ↔ host links render as 'cluster' edges (left → right chain).
+
+    if (!containerMode) {
+      // Flat grid layout — original behaviour
+      const COLS = 4
+      const SPACING_X = 190
+      const SPACING_Y = 110
+      const cols = Math.min(COLS, pmNodes.length)
+      const rows = Math.ceil(pmNodes.length / COLS)
+      const origin = getCenteredPosition(cols * SPACING_X, rows * SPACING_Y)
+      pmNodes.forEach((pn, i) => {
+        const col = i % COLS
+        const row = Math.floor(i / COLS)
+        const position = { x: origin.x + col * SPACING_X, y: origin.y + row * SPACING_Y }
+        const isClusterHost = cluster && pn.type === 'proxmox'
+        const newNode: import('@xyflow/react').Node<NodeData> = {
+          id: pn.id,
+          type: pn.type,
+          position,
+          data: {
+            label: pn.label,
+            type: pn.type as NodeData['type'],
+            status: (pn.status === 'online' ? 'online' : 'unknown') as NodeData['status'],
+            services: [],
+            ...(pn.ip ? { ip: pn.ip } : {}),
+            ...(pn.hostname ? { hostname: pn.hostname } : {}),
+            ...(isClusterHost ? { left_handles: 1, right_handles: 1 } : {}),
+          },
+        }
+        addNode(newNode)
+      })
+      // Host → guest links
+      pmEdges.forEach((pe) => {
+        onConnect({
+          source: pe.source,
+          sourceHandle: 'bottom',
+          target: pe.target,
+          targetHandle: 'top-t',
+          type: 'virtual',
+        } as unknown as import('@xyflow/react').Connection)
+      })
+    } else {
+      // Container mode — nest each VM/LXC inside its host container
+      const CONTAINER_W = 300
+      const CHILD_H = 70
+      const HEADER_H = 60
+      const CONTAINER_GAP = 50
+
+      const hostNodes = pmNodes.filter((pn) => pn.type === 'proxmox')
+      const guestsByHost = new Map<string, ProxmoxNode[]>()
+      hostNodes.forEach((h) => guestsByHost.set(h.id, []))
+      pmNodes
+        .filter((pn) => pn.type !== 'proxmox')
+        .forEach((pn) => {
+          if (pn.parent_ieee && guestsByHost.has(pn.parent_ieee)) {
+            guestsByHost.get(pn.parent_ieee)!.push(pn)
+          }
+        })
+
+      const totalWidth =
+        hostNodes.length * CONTAINER_W + Math.max(0, hostNodes.length - 1) * CONTAINER_GAP
+      const maxContainerH = hostNodes.reduce((max, h) => {
+        const childCount = (guestsByHost.get(h.id) ?? []).length
+        return Math.max(max, HEADER_H + childCount * CHILD_H + 10)
+      }, 200)
+      const origin = getCenteredPosition(totalWidth, maxContainerH)
+
+      let cursorX = origin.x
+      hostNodes.forEach((hostNode) => {
+        const children = guestsByHost.get(hostNode.id) ?? []
+        const containerH = Math.max(200, HEADER_H + children.length * CHILD_H + 10)
+        const containerPos = { x: cursorX, y: origin.y }
+
+        // Add host as a container node
+        addNode({
+          id: hostNode.id,
+          type: hostNode.type,
+          position: containerPos,
+          width: CONTAINER_W,
+          height: containerH,
+          data: {
+            label: hostNode.label,
+            type: hostNode.type as NodeData['type'],
+            status: (hostNode.status === 'online' ? 'online' : 'unknown') as NodeData['status'],
+            services: [],
+            container_mode: true,
+            ...(hostNode.ip ? { ip: hostNode.ip } : {}),
+            ...(hostNode.hostname ? { hostname: hostNode.hostname } : {}),
+            ...(cluster ? { left_handles: 1, right_handles: 1 } : {}),
+          },
+        } as import('@xyflow/react').Node<NodeData>)
+
+        // Add children with absolute canvas positions; store converts to parent-relative
+        children.forEach((child, i) => {
+          addNode({
+            id: child.id,
+            type: child.type,
+            position: {
+              x: containerPos.x + 20,
+              y: containerPos.y + HEADER_H + i * CHILD_H,
+            },
+            data: {
+              label: child.label,
+              type: child.type as NodeData['type'],
+              status: (child.status === 'online' ? 'online' : 'unknown') as NodeData['status'],
+              services: [],
+              parent_id: hostNode.id,
+              ...(child.ip ? { ip: child.ip } : {}),
+              ...(child.hostname ? { hostname: child.hostname } : {}),
+            },
+          } as import('@xyflow/react').Node<NodeData>)
+        })
+
+        cursorX += CONTAINER_W + CONTAINER_GAP
+      })
+    }
+
+    // Host ↔ host cluster edges (both layout modes)
     clusterEdges.forEach((ce) => {
       onConnect({
         source: ce.source,

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -13,6 +13,8 @@ import { THEMES } from '@/utils/themes'
 import { BaseNode } from './BaseNode'
 import { SideHandles } from './SideHandles'
 
+const COLUMN_OPTIONS = [1, 2, 3, 4] as const
+
 export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
   const { id, data, selected } = props
   const updateNodeInternals = useUpdateNodeInternals()
@@ -20,6 +22,8 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
 
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const hideIp = useCanvasStore((s) => s.hideIp)
+  const reflowContainerChildren = useCanvasStore((s) => s.reflowContainerChildren)
+  const snapshotHistory = useCanvasStore((s) => s.snapshotHistory)
   const theme = THEMES[activeTheme]
   const colors = resolveNodeColors(data, activeTheme)
 
@@ -96,9 +100,39 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
               </span>
             ))}
           </div>
+          {/* Column selector — nodrag so clicks don't start a canvas drag */}
+          {selected && (
+            <div
+              className="nodrag flex items-center gap-0.5 ml-1 shrink-0"
+              onPointerDown={(e) => e.stopPropagation()}
+              title="Reflow children into N columns"
+            >
+              {COLUMN_OPTIONS.map((n) => {
+                const active = (data.container_columns ?? 1) === n
+                return (
+                  <button
+                    key={n}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      snapshotHistory()
+                      reflowContainerChildren(id, n)
+                    }}
+                    className="nodrag w-4 h-4 rounded text-[9px] font-bold leading-none flex items-center justify-center transition-colors"
+                    style={{
+                      background: active ? glow : `${glow}22`,
+                      color: active ? theme.colors.nodeCardBackground : glow,
+                      border: `1px solid ${glow}55`,
+                    }}
+                  >
+                    {n}
+                  </button>
+                )
+              })}
+            </div>
+          )}
           {/* Status dot */}
           <div
-            className="ml-auto w-1.5 h-1.5 rounded-full shrink-0"
+            className="w-1.5 h-1.5 rounded-full shrink-0"
             style={{ backgroundColor: statusColor }}
             title={data.status}
           />

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -13,8 +13,6 @@ import { THEMES } from '@/utils/themes'
 import { BaseNode } from './BaseNode'
 import { SideHandles } from './SideHandles'
 
-const COLUMN_OPTIONS = [1, 2, 3, 4] as const
-
 export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
   const { id, data, selected } = props
   const updateNodeInternals = useUpdateNodeInternals()
@@ -100,34 +98,27 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
               </span>
             ))}
           </div>
-          {/* Column selector — nodrag so clicks don't start a canvas drag */}
+          {/* Column spinner — nodrag so clicks don't start a canvas drag */}
           {selected && (
             <div
-              className="nodrag flex items-center gap-0.5 ml-1 shrink-0"
+              className="nodrag flex items-center gap-1 ml-1 shrink-0"
               onPointerDown={(e) => e.stopPropagation()}
               title="Reflow children into N columns"
             >
-              {COLUMN_OPTIONS.map((n) => {
-                const active = (data.container_columns ?? 1) === n
-                return (
-                  <button
-                    key={n}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      snapshotHistory()
-                      reflowContainerChildren(id, n)
-                    }}
-                    className="nodrag w-4 h-4 rounded text-[9px] font-bold leading-none flex items-center justify-center transition-colors"
-                    style={{
-                      background: active ? glow : `${glow}22`,
-                      color: active ? theme.colors.nodeCardBackground : glow,
-                      border: `1px solid ${glow}55`,
-                    }}
-                  >
-                    {n}
-                  </button>
-                )
-              })}
+              <span className="text-[9px]" style={{ color: theme.colors.nodeSubtextColor }}>cols</span>
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={data.container_columns ?? 1}
+                onChange={(e) => {
+                  const n = Math.max(1, Math.min(10, Number(e.target.value) || 1))
+                  snapshotHistory()
+                  reflowContainerChildren(id, n)
+                }}
+                className="nodrag w-8 h-4 rounded text-[9px] text-center font-mono bg-transparent border leading-none"
+                style={{ borderColor: `${glow}55`, color: glow, colorScheme: 'dark' }}
+              />
             </div>
           )}
           {/* Status dot */}

--- a/frontend/src/components/proxmox/ProxmoxImportModal.tsx
+++ b/frontend/src/components/proxmox/ProxmoxImportModal.tsx
@@ -11,7 +11,7 @@ import type { ProxmoxNode, ProxmoxEdge, ProxmoxNodeType } from './types'
 interface ProxmoxImportModalProps {
   open: boolean
   onClose: () => void
-  onAddToCanvas: (nodes: ProxmoxNode[], edges: ProxmoxEdge[], containerMode: boolean) => void
+  onAddToCanvas: (nodes: ProxmoxNode[], edges: ProxmoxEdge[], containerMode: boolean, columns: number) => void
   onPendingImported?: () => void
 }
 
@@ -63,6 +63,7 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
   const [checked, setChecked] = useState<Set<string>>(new Set())
   const [importMode, setImportMode] = useState<ImportMode>('pending')
   const [containerMode, setContainerMode] = useState(false)
+  const [columns, setColumns] = useState(2)
 
   const updateField = (field: keyof ConnectionForm, value: string) =>
     setForm((f) => ({ ...f, [field]: value }))
@@ -137,7 +138,7 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
     const selectedDevices = devices.filter((d) => checked.has(d.id))
     const selectedIds = new Set(selectedDevices.map((d) => d.id))
     const selectedEdges = edges.filter((e) => selectedIds.has(e.source) && selectedIds.has(e.target))
-    onAddToCanvas(selectedDevices, selectedEdges, containerMode)
+    onAddToCanvas(selectedDevices, selectedEdges, containerMode, columns)
     toast.success(`Added ${selectedDevices.length} device${selectedDevices.length !== 1 ? 's' : ''} to canvas`)
     onClose()
   }
@@ -150,6 +151,7 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
     setConnectionMsg('')
     setImportMode('pending')
     setContainerMode(false)
+    setColumns(2)
     onClose()
   }
 
@@ -266,16 +268,40 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
               </label>
             </div>
             {importMode === 'canvas' && (
-              <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={containerMode}
-                  onChange={(e) => setContainerMode(e.target.checked)}
-                  className="w-3 h-3 cursor-pointer"
-                  style={{ accentColor: ACCENT }}
-                />
-                Nest VMs &amp; LXCs within host containers
-              </label>
+              <div className="flex flex-col gap-1.5">
+                <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={containerMode}
+                    onChange={(e) => setContainerMode(e.target.checked)}
+                    className="w-3 h-3 cursor-pointer"
+                    style={{ accentColor: ACCENT }}
+                  />
+                  Nest VMs &amp; LXCs within host containers
+                </label>
+                {containerMode && (
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground pl-4">
+                    Columns per host:
+                    <div className="flex items-center gap-1">
+                      {([1, 2, 3, 4] as const).map((n) => (
+                        <button
+                          key={n}
+                          type="button"
+                          onClick={() => setColumns(n)}
+                          className="w-5 h-5 rounded text-[10px] font-bold leading-none flex items-center justify-center transition-colors border"
+                          style={{
+                            background: columns === n ? ACCENT : 'transparent',
+                            color: columns === n ? '#0d1117' : ACCENT,
+                            borderColor: `${ACCENT}66`,
+                          }}
+                        >
+                          {n}
+                        </button>
+                      ))}
+                    </div>
+                  </label>
+                )}
+              </div>
             )}
             <div className="flex gap-2">
               <Button

--- a/frontend/src/components/proxmox/ProxmoxImportModal.tsx
+++ b/frontend/src/components/proxmox/ProxmoxImportModal.tsx
@@ -11,7 +11,7 @@ import type { ProxmoxNode, ProxmoxEdge, ProxmoxNodeType } from './types'
 interface ProxmoxImportModalProps {
   open: boolean
   onClose: () => void
-  onAddToCanvas: (nodes: ProxmoxNode[], edges: ProxmoxEdge[]) => void
+  onAddToCanvas: (nodes: ProxmoxNode[], edges: ProxmoxEdge[], containerMode: boolean) => void
   onPendingImported?: () => void
 }
 
@@ -62,6 +62,7 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
   const [edges, setEdges] = useState<ProxmoxEdge[]>([])
   const [checked, setChecked] = useState<Set<string>>(new Set())
   const [importMode, setImportMode] = useState<ImportMode>('pending')
+  const [containerMode, setContainerMode] = useState(false)
 
   const updateField = (field: keyof ConnectionForm, value: string) =>
     setForm((f) => ({ ...f, [field]: value }))
@@ -136,7 +137,7 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
     const selectedDevices = devices.filter((d) => checked.has(d.id))
     const selectedIds = new Set(selectedDevices.map((d) => d.id))
     const selectedEdges = edges.filter((e) => selectedIds.has(e.source) && selectedIds.has(e.target))
-    onAddToCanvas(selectedDevices, selectedEdges)
+    onAddToCanvas(selectedDevices, selectedEdges, containerMode)
     toast.success(`Added ${selectedDevices.length} device${selectedDevices.length !== 1 ? 's' : ''} to canvas`)
     onClose()
   }
@@ -148,6 +149,7 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
     setConnectionStatus('idle')
     setConnectionMsg('')
     setImportMode('pending')
+    setContainerMode(false)
     onClose()
   }
 
@@ -263,6 +265,18 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
                 Canvas directly
               </label>
             </div>
+            {importMode === 'canvas' && (
+              <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={containerMode}
+                  onChange={(e) => setContainerMode(e.target.checked)}
+                  className="w-3 h-3 cursor-pointer"
+                  style={{ accentColor: ACCENT }}
+                />
+                Nest VMs &amp; LXCs within host containers
+              </label>
+            )}
             <div className="flex gap-2">
               <Button
                 size="sm"

--- a/frontend/src/components/proxmox/ProxmoxImportModal.tsx
+++ b/frontend/src/components/proxmox/ProxmoxImportModal.tsx
@@ -282,23 +282,15 @@ export function ProxmoxImportModal({ open, onClose, onAddToCanvas, onPendingImpo
                 {containerMode && (
                   <label className="flex items-center gap-2 text-xs text-muted-foreground pl-4">
                     Columns per host:
-                    <div className="flex items-center gap-1">
-                      {([1, 2, 3, 4] as const).map((n) => (
-                        <button
-                          key={n}
-                          type="button"
-                          onClick={() => setColumns(n)}
-                          className="w-5 h-5 rounded text-[10px] font-bold leading-none flex items-center justify-center transition-colors border"
-                          style={{
-                            background: columns === n ? ACCENT : 'transparent',
-                            color: columns === n ? '#0d1117' : ACCENT,
-                            borderColor: `${ACCENT}66`,
-                          }}
-                        >
-                          {n}
-                        </button>
-                      ))}
-                    </div>
+                    <input
+                      type="number"
+                      min={1}
+                      max={10}
+                      value={columns}
+                      onChange={(e) => setColumns(Math.max(1, Math.min(10, Number(e.target.value) || 1)))}
+                      className="w-14 h-6 rounded px-1.5 text-xs font-mono bg-[#0d1117] border border-border text-foreground"
+                      style={{ accentColor: ACCENT }}
+                    />
                   </label>
                 )}
               </div>

--- a/frontend/src/components/proxmox/__tests__/ProxmoxImportModal.test.tsx
+++ b/frontend/src/components/proxmox/__tests__/ProxmoxImportModal.test.tsx
@@ -104,6 +104,48 @@ describe('ProxmoxImportModal', () => {
     expect(toast.success).toHaveBeenCalledWith('Found 2 devices')
   })
 
+  it('shows container mode checkbox only in canvas mode', () => {
+    render(<ProxmoxImportModal {...defaultProps} />)
+    expect(screen.queryByLabelText(/nest vms/i)).toBeNull()
+    fireEvent.click(screen.getByRole('radio', { name: /canvas directly/i }))
+    expect(screen.getByLabelText(/nest vms/i)).toBeDefined()
+  })
+
+  it('passes containerMode=false to onAddToCanvas by default', async () => {
+    vi.mocked(proxmoxApi.importNetwork).mockResolvedValue({
+      data: { nodes: sampleNodes, edges: [{ source: 'pve-node-pve1', target: 'pve-pve1-101' }], device_count: 2 },
+    } as never)
+    render(<ProxmoxImportModal {...defaultProps} />)
+    fireEvent.click(screen.getByRole('radio', { name: /canvas directly/i }))
+    fireEvent.change(screen.getByPlaceholderText('192.168.1.x or pve.local'), { target: { value: 'pve' } })
+    fireEvent.click(screen.getByRole('button', { name: /fetch inventory/i }))
+    await waitFor(() => expect(screen.getByText('pve1')).toBeDefined())
+    fireEvent.click(screen.getByRole('button', { name: /add .* to canvas/i }))
+    expect(defaultProps.onAddToCanvas).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      false,
+    )
+  })
+
+  it('passes containerMode=true when the nest checkbox is checked', async () => {
+    vi.mocked(proxmoxApi.importNetwork).mockResolvedValue({
+      data: { nodes: sampleNodes, edges: [{ source: 'pve-node-pve1', target: 'pve-pve1-101' }], device_count: 2 },
+    } as never)
+    render(<ProxmoxImportModal {...defaultProps} />)
+    fireEvent.click(screen.getByRole('radio', { name: /canvas directly/i }))
+    fireEvent.change(screen.getByPlaceholderText('192.168.1.x or pve.local'), { target: { value: 'pve' } })
+    fireEvent.click(screen.getByRole('button', { name: /fetch inventory/i }))
+    await waitFor(() => expect(screen.getByText('pve1')).toBeDefined())
+    fireEvent.click(screen.getByLabelText(/nest vms/i))
+    fireEvent.click(screen.getByRole('button', { name: /add .* to canvas/i }))
+    expect(defaultProps.onAddToCanvas).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      true,
+    )
+  })
+
   it('sends the token from the form in the payload', async () => {
     vi.mocked(proxmoxApi.importNetwork).mockResolvedValue({
       data: { nodes: [], edges: [], device_count: 0 },

--- a/frontend/src/components/proxmox/__tests__/ProxmoxImportModal.test.tsx
+++ b/frontend/src/components/proxmox/__tests__/ProxmoxImportModal.test.tsx
@@ -125,6 +125,7 @@ describe('ProxmoxImportModal', () => {
       expect.any(Array),
       expect.any(Array),
       false,
+      expect.any(Number),
     )
   })
 
@@ -143,6 +144,7 @@ describe('ProxmoxImportModal', () => {
       expect.any(Array),
       expect.any(Array),
       true,
+      expect.any(Number),
     )
   })
 

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -13,6 +13,7 @@ import { generateUUID } from '@/utils/uuid'
 import { normalizeHandle, removedHandleIds, handleCountField, sideDefault, handleId, SIDES } from '@/utils/handleUtils'
 import { applyOpacity } from '@/utils/colorUtils'
 import { readHideIp, writeHideIp } from '@/utils/ipDisplay'
+import { containerDims, childRelPos } from '@/utils/proxmoxLayout'
 
 type HistoryEntry = { nodes: Node<NodeData>[]; edges: Edge<EdgeData>[] }
 type Clipboard = { nodes: Node<NodeData>[]; edges: Edge<EdgeData>[] }
@@ -67,6 +68,7 @@ interface CanvasState {
   reconnectEdge: (id: string, connection: Connection) => void
   deleteEdge: (id: string) => void
   setProxmoxContainerMode: (proxmoxId: string, enabled: boolean) => void
+  reflowContainerChildren: (containerId: string, columns: number) => void
   setNodeZIndex: (id: string, zIndex: number) => void
   setNodeSize: (id: string, size: { width?: number; height?: number }) => void
   editingGroupRectId: string | null
@@ -481,6 +483,34 @@ export const useCanvasStore = create<CanvasState>((set) => ({
         const children = nodes.filter((n) => !!n.parentId)
         nodes = [...parents, ...children]
       }
+      return { nodes, hasUnsavedChanges: true }
+    }),
+
+  reflowContainerChildren: (containerId, columns) =>
+    set((state) => {
+      const container = state.nodes.find((n) => n.id === containerId)
+      if (!container || container.data.container_mode !== true) return state
+      const children = state.nodes.filter((n) => n.parentId === containerId)
+      if (children.length === 0) return state
+
+      const safeCols = Math.max(1, Math.min(columns, children.length))
+      const { width, height } = containerDims(children.length, safeCols)
+
+      const nodes = state.nodes.map((n) => {
+        if (n.id === containerId) {
+          return {
+            ...n,
+            width,
+            height,
+            data: { ...n.data, container_columns: safeCols },
+          }
+        }
+        const idx = children.findIndex((c) => c.id === n.id)
+        if (idx >= 0) {
+          return { ...n, position: childRelPos(idx, safeCols) }
+        }
+        return n
+      })
       return { nodes, hasUnsavedChanges: true }
     }),
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -119,6 +119,7 @@ export interface NodeData extends Record<string, unknown> {
   properties?: NodeProperty[]
   parent_id?: string
   container_mode?: boolean
+  container_columns?: number
   custom_colors?: {
     border?: string
     background?: string

--- a/frontend/src/utils/proxmoxLayout.ts
+++ b/frontend/src/utils/proxmoxLayout.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared layout constants and helpers for Proxmox container-mode node grids.
+ *
+ * Used by both the import handler (App.tsx) and the store reflow action
+ * (canvasStore.ts) so the two code paths stay in sync.
+ */
+
+/** Horizontal space allocated per child column (px, relative to parent). */
+export const CHILD_SLOT_W = 160
+/** Vertical space allocated per child row (px). */
+export const CHILD_SLOT_H = 68
+/** Horizontal gap between columns (px). */
+export const COL_GAP = 8
+/** Vertical gap between rows (px). */
+export const ROW_GAP = 4
+/** Container inner padding on all sides (px). */
+export const CONTAINER_PADDING = 10
+/** Height of the container's header bar (px). */
+export const CONTAINER_HEADER_H = 52
+
+/**
+ * Compute container width and height to exactly fit `childCount` children
+ * arranged in `cols` columns.
+ */
+export function containerDims(childCount: number, cols: number): { width: number; height: number } {
+  const safeCols = Math.max(1, Math.min(cols, Math.max(1, childCount)))
+  const rows = Math.ceil(childCount / safeCols)
+  const width = Math.max(
+    220,
+    CONTAINER_PADDING * 2 + safeCols * CHILD_SLOT_W + (safeCols - 1) * COL_GAP,
+  )
+  const height = Math.max(
+    200,
+    CONTAINER_HEADER_H + CONTAINER_PADDING + rows * CHILD_SLOT_H + (rows - 1) * ROW_GAP + CONTAINER_PADDING,
+  )
+  return { width, height }
+}
+
+/**
+ * Return the **parent-relative** position for the i-th child in a grid with
+ * `cols` columns.
+ */
+export function childRelPos(i: number, cols: number): { x: number; y: number } {
+  const safeCols = Math.max(1, cols)
+  const col = i % safeCols
+  const row = Math.floor(i / safeCols)
+  return {
+    x: CONTAINER_PADDING + col * (CHILD_SLOT_W + COL_GAP),
+    y: CONTAINER_HEADER_H + CONTAINER_PADDING + row * (CHILD_SLOT_H + ROW_GAP),
+  }
+}


### PR DESCRIPTION
## Summary
Adds an optional "container mode" to the Proxmox Import modal (canvas mode only) so imported infrastructure can be grouped visually instead of scattered in a flat grid.

- **Container mode** — a "Nest VMs & LXCs within host containers" checkbox. When on, each Proxmox host becomes a `container_mode` container and its guests are nested inside it (via `parent_id`), instead of the flat 4-column grid.
- **Multi-column reflow** — container children can be laid out in multiple columns, both at import time and live from the container node's header (auto-resizes the container). Shared helpers live in `utils/proxmoxLayout.ts`.
- **Column control** — a compact number spinner (1–10 columns) on both surfaces.

## Backward compatibility
Default (checkbox off) is the existing flat-grid behavior with virtual edges.

## Tests
Adds `ProxmoxImportModal` tests (checkbox visibility per mode + `containerMode` passthrough).