### PR TITLE
fix: apply the status check interval to the running scheduler

### DIFF
--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -4,13 +4,19 @@ from pydantic import BaseModel, Field
 
 from app.api.deps import get_current_user
 from app.core.config import settings
-from app.core.scheduler import reschedule_service_checks, set_service_checks_enabled
+from app.core.scheduler import (
+    reschedule_service_checks,
+    reschedule_status_checks,
+    set_service_checks_enabled,
+)
 
 router = APIRouter()
 
 
 class AppSettings(BaseModel):
-    interval_seconds: int
+    # Mirrors the floor enforced by reschedule_status_checks(): rejecting here
+    # returns 422 instead of persisting the value and then failing with a 500.
+    interval_seconds: int = Field(ge=10)
     service_check_enabled: bool = False
     service_check_interval: int = Field(default=300, ge=30)
 
@@ -33,6 +39,10 @@ async def update_settings(
         settings.service_check_enabled = payload.service_check_enabled
         settings.service_check_interval = payload.service_check_interval
         settings.save_overrides()
+        # Apply the status-check schedule live. Without this the new interval is
+        # persisted and shown in the UI, but the running job keeps the old one
+        # until the backend restarts.
+        reschedule_status_checks(payload.interval_seconds)
         # Apply the service-check schedule live.
         set_service_checks_enabled(payload.service_check_enabled)
         if payload.service_check_enabled:

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -38,6 +38,33 @@ async def test_update_settings_saves_interval(client: AsyncClient, headers):
 
 
 @pytest.mark.asyncio
+async def test_update_settings_reschedules_status_checks(client: AsyncClient, headers):
+    """The new interval must reach the running scheduler, not just the config
+    file: otherwise the UI and scan_config.json show the new value while the
+    job keeps firing at the old one until the backend restarts."""
+    with patch("app.api.routes.settings.settings") as mock_settings, \
+            patch("app.api.routes.settings.reschedule_status_checks") as mock_reschedule:
+        mock_settings.save_overrides = lambda: None
+        res = await client.post(
+            "/api/v1/settings",
+            json={"interval_seconds": 120},
+            headers=headers,
+        )
+    assert res.status_code == 200
+    mock_reschedule.assert_called_once_with(120)
+
+
+@pytest.mark.asyncio
+async def test_update_settings_rejects_too_short_status_interval(client: AsyncClient, headers):
+    res = await client.post(
+        "/api/v1/settings",
+        json={"interval_seconds": 5},
+        headers=headers,
+    )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_update_settings_requires_auth(client: AsyncClient):
     res = await client.post("/api/v1/settings", json={"interval_seconds": 30})
     assert res.status_code == 401


### PR DESCRIPTION
## What

`POST /api/v1/settings` persists the new status check interval and echoes it back, but never applies it to the running scheduler. `reschedule_status_checks()` is defined in `app/core/scheduler.py` — complete, with its own validation and `scheduler.running` guard — but has no caller anywhere in the codebase. Its sibling `reschedule_service_checks()` is called two lines below.

Result: the UI and `scan_config.json` show the new interval while the job keeps firing at the old one, until the backend is restarted.

## Why it matters

It is silent. Every visible surface reports the value you set. On our install a 3600s interval was configured on 2026-07-12 but 30s stayed in effect until today — ~120 nodes pinged 120x more often than intended for three weeks, with no error, no log, and nothing wrong in the config file.

## Changes

- Import and call `reschedule_status_checks(payload.interval_seconds)` in `update_settings`, right after `save_overrides()` and next to the existing service-check reschedule.
- `interval_seconds: int = Field(ge=10)`, mirroring the floor already enforced inside `reschedule_status_checks()`. Without it, a value below 10 is written to `scan_config.json` *before* the `ValueError` is raised, so it surfaces as a 500 and the invalid value is reloaded on the next boot. This also aligns the field with its neighbour `service_check_interval: Field(ge=30)`.
- Two tests in `backend/tests/test_settings.py`.

## Testing

`ruff check .` clean, full backend suite: **717 passed, 8 skipped**.

Both new tests fail without the fix:

- `test_update_settings_reschedules_status_checks` → `AttributeError: <module 'app.api.routes.settings'> does not have the attribute 'reschedule_status_checks'`
- `test_update_settings_rejects_too_short_status_interval` → `assert 200 == 422`

Found while upgrading a Proxmox LXC deployment from v3.0.0 to v3.1.2. Thanks for Homelable — it is the only view of our homelab we could not get anywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
