### PR TITLE
feat: allow 0 connection points on top and bottom

### DIFF
--- a/frontend/src/components/modals/CustomStyleModal.tsx
+++ b/frontend/src/components/modals/CustomStyleModal.tsx
@@ -10,7 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Button } from '@/components/ui/button'
 import { useThemeStore } from '@/stores/themeStore'
 import { useCanvasStore } from '@/stores/canvasStore'
-import { clampHandles, sideDefault } from '@/utils/handleUtils'
+import { MIN_HANDLES, clampHandles, sideDefault } from '@/utils/handleUtils'
 import { THEMES } from '@/utils/themes'
 import { applyOpacity } from '@/utils/colorUtils'
 import type {
@@ -229,7 +229,7 @@ function NodeEditor({ nodeType, style, onChange, onApplyToExisting }: NodeEditor
               <span className="text-xs text-[#8b949e] w-12">{label}</span>
               <input
                 type="number"
-                min={sideDefault(side)}
+                min={MIN_HANDLES}
                 max={64}
                 step={1}
                 value={style[key] ?? sideDefault(side)}

--- a/frontend/src/components/modals/NodeModal.tsx
+++ b/frontend/src/components/modals/NodeModal.tsx
@@ -12,7 +12,7 @@ import { useThemeStore } from '@/stores/themeStore'
 import { resolveNodeColors } from '@/utils/nodeColors'
 import { ICON_REGISTRY, NODE_TYPE_DEFAULT_ICONS, isBrandIconKey, brandIconSlug, brandIconUrl } from '@/utils/nodeIcons'
 import { IconPickerPanel } from './IconPickerPanel'
-import { MAX_HANDLES, clampHandles, sideDefault, handleCountField, type Side } from '@/utils/handleUtils'
+import { MAX_HANDLES, MIN_HANDLES, clampHandles, sideDefault, handleCountField, type Side } from '@/utils/handleUtils'
 import { getValidParentTypes } from '@/utils/virtualEdgeParent'
 
 const NODE_TYPE_GROUPS: { label: string; types: NodeType[] }[] = [
@@ -44,7 +44,7 @@ function CPStepper({ label, side, value, onChange }: {
   value: number
   onChange: (v: number) => void
 }) {
-  const min = sideDefault(side)
+  const min = MIN_HANDLES
   const labelEl = <span className="text-[10px] text-muted-foreground/80 leading-none">{label}</span>
   const belowLabel = side === 'bottom'
   const btn = 'w-6 h-full flex items-center justify-center text-sm text-muted-foreground hover:text-foreground hover:bg-[#21262d] disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default'

--- a/frontend/src/components/modals/__tests__/NodeModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModal.test.tsx
@@ -507,15 +507,29 @@ describe('NodeModal', () => {
     expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).right_handles).toBe(2)
   })
 
-  it('disables the − button at the side minimum (0 for left/right, 1 for top/bottom)', () => {
+  it('disables the − button at 0, the minimum for every side', () => {
     renderModal({ initial: BASE })
     expect((screen.getByRole('button', { name: 'Decrease Left connection points' }) as HTMLButtonElement).disabled).toBe(true)
+    // Top starts at its default of 1, so it can still go down to 0.
+    expect((screen.getByRole('button', { name: 'Decrease Top connection points' }) as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(screen.getByRole('button', { name: 'Decrease Top connection points' }))
     expect((screen.getByRole('button', { name: 'Decrease Top connection points' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
-  it('left/right min is 0, top/bottom min is 1; max is 64 everywhere', () => {
+  it('takes top/bottom down to 0 connection points', () => {
+    const { onSubmit } = renderModal({ initial: BASE })
+    fireEvent.change(screen.getByLabelText('Top connection points'), { target: { value: '0' } })
+    fireEvent.change(screen.getByLabelText('Bottom connection points'), { target: { value: '0' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    const submitted = onSubmit.mock.calls[0][0] as Partial<NodeData>
+    expect(submitted.top_handles).toBe(0)
+    expect(submitted.bottom_handles).toBe(0)
+  })
+
+  it('min is 0 on every side; max is 64 everywhere', () => {
     renderModal({ initial: BASE })
-    expect((screen.getByLabelText('Bottom connection points') as HTMLInputElement).min).toBe('1')
+    expect((screen.getByLabelText('Bottom connection points') as HTMLInputElement).min).toBe('0')
+    expect((screen.getByLabelText('Top connection points') as HTMLInputElement).min).toBe('0')
     expect((screen.getByLabelText('Left connection points') as HTMLInputElement).min).toBe('0')
     for (const label of ['Top', 'Right', 'Bottom', 'Left']) {
       expect((screen.getByLabelText(`${label} connection points`) as HTMLInputElement).max).toBe('64')

--- a/frontend/src/utils/__tests__/handleUtils.test.ts
+++ b/frontend/src/utils/__tests__/handleUtils.test.ts
@@ -3,6 +3,8 @@ import {
   MIN_BOTTOM_HANDLES,
   MAX_BOTTOM_HANDLES,
   MAX_HANDLES,
+  MIN_HANDLES,
+  sideHandleCount,
   bottomHandleId,
   bottomHandlePositions,
   clampBottomHandles,
@@ -36,6 +38,7 @@ describe('clampBottomHandles', () => {
   it('clamps below MIN to MIN', () => {
     expect(clampBottomHandles(0)).toBe(MIN_BOTTOM_HANDLES)
     expect(clampBottomHandles(-5)).toBe(MIN_BOTTOM_HANDLES)
+    expect(MIN_BOTTOM_HANDLES).toBe(0)
   })
 
   it('supports at least 52 ports (issue #20 — Cisco 48+4 SFP)', () => {
@@ -47,11 +50,11 @@ describe('clampBottomHandles', () => {
     expect(clampBottomHandles(9999)).toBe(MAX_BOTTOM_HANDLES)
   })
 
-  it('returns MIN for non-finite or non-number', () => {
-    expect(clampBottomHandles(NaN)).toBe(MIN_BOTTOM_HANDLES)
-    expect(clampBottomHandles(Infinity)).toBe(MIN_BOTTOM_HANDLES)
-    expect(clampBottomHandles('4' as unknown)).toBe(MIN_BOTTOM_HANDLES)
-    expect(clampBottomHandles(undefined)).toBe(MIN_BOTTOM_HANDLES)
+  it('returns the side default for non-finite or non-number', () => {
+    expect(clampBottomHandles(NaN)).toBe(1)
+    expect(clampBottomHandles(Infinity)).toBe(1)
+    expect(clampBottomHandles('4' as unknown)).toBe(1)
+    expect(clampBottomHandles(undefined)).toBe(1)
   })
 
   it('floors fractional values', () => {
@@ -113,7 +116,8 @@ describe('bottomHandlePositions — uniform spacing for ≥5', () => {
   })
 
   it('clamps out-of-range counts before computing', () => {
-    expect(bottomHandlePositions(0)).toEqual([50])
+    expect(bottomHandlePositions(0)).toEqual([])
+    expect(bottomHandlePositions(-2)).toEqual([])
     expect(bottomHandlePositions(99)).toHaveLength(MAX_BOTTOM_HANDLES)
   })
 })
@@ -226,9 +230,11 @@ describe('handleId', () => {
 })
 
 describe('clampHandles', () => {
-  it('min is the side default (0 for L/R, 1 for T/B)', () => {
-    expect(clampHandles('top', 0)).toBe(1)
-    expect(clampHandles('bottom', -3)).toBe(1)
+  it('min is 0 for every side, top/bottom included', () => {
+    expect(clampHandles('top', 0)).toBe(0)
+    expect(clampHandles('bottom', 0)).toBe(0)
+    expect(clampHandles('top', -3)).toBe(0)
+    expect(clampHandles('bottom', -3)).toBe(0)
     expect(clampHandles('left', -3)).toBe(0)
     expect(clampHandles('right', 0)).toBe(0)
   })
@@ -236,9 +242,10 @@ describe('clampHandles', () => {
     expect(clampHandles('top', 9999)).toBe(MAX_HANDLES)
     expect(clampHandles('left', 65)).toBe(64)
   })
-  it('non-finite / non-number falls back to side min', () => {
+  it('non-finite / non-number falls back to the side default', () => {
     expect(clampHandles('left', NaN)).toBe(0)
     expect(clampHandles('top', undefined)).toBe(1)
+    expect(clampHandles('bottom', NaN)).toBe(1)
     expect(clampHandles('right', '4' as unknown)).toBe(0)
   })
   it('floors fractional values', () => {
@@ -259,9 +266,9 @@ describe('handlePositions', () => {
     expect(handlePositions('left', 0)).toEqual([])
     expect(handlePositions('right', 0)).toEqual([])
   })
-  it('top/bottom clamp 0 up to 1 (never empty)', () => {
-    expect(handlePositions('top', 0)).toEqual([50])
-    expect(handlePositions('bottom', 0)).toEqual([50])
+  it('top/bottom accept 0 and render nothing', () => {
+    expect(handlePositions('top', 0)).toEqual([])
+    expect(handlePositions('bottom', 0)).toEqual([])
   })
 })
 
@@ -305,5 +312,32 @@ describe('removedHandleIds — all sides', () => {
 describe('SIDES', () => {
   it('lists all four sides', () => {
     expect([...SIDES].sort()).toEqual(['bottom', 'left', 'right', 'top'])
+  })
+})
+
+describe('zero connection points on top/bottom (issue: min was 1)', () => {
+  it('MIN_HANDLES is 0', () => {
+    expect(MIN_HANDLES).toBe(0)
+  })
+
+  it('sideHandleCount honours an explicit 0 on top and bottom', () => {
+    const data = { label: 'n', top_handles: 0, bottom_handles: 0 } as never
+    expect(sideHandleCount(data, 'top')).toBe(0)
+    expect(sideHandleCount(data, 'bottom')).toBe(0)
+  })
+
+  it('still defaults top/bottom to 1 when the field is missing', () => {
+    const data = { label: 'n' } as never
+    expect(sideHandleCount(data, 'top')).toBe(1)
+    expect(sideHandleCount(data, 'bottom')).toBe(1)
+  })
+
+  it('renders no handle position for a 0-count top/bottom side', () => {
+    expect(handlePositions('top', 0)).toEqual([])
+    expect(handlePositions('bottom', 0)).toEqual([])
+  })
+
+  it('removes every top handle when going 2 → 0', () => {
+    expect(removedHandleIds('top', 2, 0)).toEqual(new Set(['top', 'top-2']))
   })
 })

--- a/frontend/src/utils/exportYaml.ts
+++ b/frontend/src/utils/exportYaml.ts
@@ -28,11 +28,11 @@ function makeConnection(
   return conn
 }
 
-/** Write each side's handle count onto the entry when it exceeds the side default. */
+/** Write each side's handle count onto the entry when it differs from the side default (0 included). */
 function attachHandleCounts(entry: YamlNode, data: NodeData): void {
   for (const side of SIDES) {
     const count = sideHandleCount(data, side)
-    if (count > sideDefault(side)) {
+    if (count !== sideDefault(side)) {
       entry[`${side}Handles` as 'topHandles' | 'bottomHandles' | 'leftHandles' | 'rightHandles'] =
         count
     }

--- a/frontend/src/utils/handleUtils.ts
+++ b/frontend/src/utils/handleUtils.ts
@@ -19,14 +19,18 @@ export const SIDES: readonly Side[] = ['top', 'bottom', 'left', 'right']
 
 export const MAX_HANDLES = 64
 
+/** Every side can go down to zero connection points. */
+export const MIN_HANDLES = 0
+
 // Back-compat aliases (bottom was the original, only, multi-handle side).
-export const MIN_BOTTOM_HANDLES = 1
+export const MIN_BOTTOM_HANDLES = MIN_HANDLES
 export const MAX_BOTTOM_HANDLES = MAX_HANDLES
 
 /**
- * Minimum (and default) count for a side.
+ * Default count for a side when the node carries no explicit value.
  * Top/Bottom default to 1 (their historical single handle); Left/Right default
  * to 0 so existing diagrams gain no side handles unless the user opts in.
+ * This is a default, not a minimum — see MIN_HANDLES.
  */
 export function sideDefault(side: Side): number {
   return side === 'top' || side === 'bottom' ? 1 : 0
@@ -47,12 +51,15 @@ export function handleId(side: Side, idx: number): string {
   return idx === 0 ? side : `${side}-${idx + 1}`
 }
 
-/** Clamp a raw count into the supported range for a side (min = sideDefault, max = 64). */
+/**
+ * Clamp a raw count into the supported range (0..64) for a side.
+ * A non-numeric / non-finite input falls back to the side default, so a missing
+ * or corrupt field still yields the historical count; an explicit 0 is honoured.
+ */
 export function clampHandles(side: Side, n: unknown): number {
-  const min = sideDefault(side)
-  if (typeof n !== 'number' || !Number.isFinite(n)) return min
+  if (typeof n !== 'number' || !Number.isFinite(n)) return sideDefault(side)
   const i = Math.floor(n)
-  if (i < min) return min
+  if (i < MIN_HANDLES) return MIN_HANDLES
   if (i > MAX_HANDLES) return MAX_HANDLES
   return i
 }

--- a/frontend/src/utils/importYaml.ts
+++ b/frontend/src/utils/importYaml.ts
@@ -75,10 +75,12 @@ export function parseYamlToCanvas(
       ...(hasHardware ? { show_hardware: true } : {}),
       // Restore custom connection-point counts so the edges below attach to the
       // slots they were exported on instead of collapsing onto slot 0.
-      ...(yn.topHandles ? { top_handles: yn.topHandles } : {}),
-      ...(yn.bottomHandles ? { bottom_handles: yn.bottomHandles } : {}),
-      ...(yn.leftHandles ? { left_handles: yn.leftHandles } : {}),
-      ...(yn.rightHandles ? { right_handles: yn.rightHandles } : {}),
+      // A count of 0 is meaningful (side with no connection point), so test for
+      // a number rather than truthiness.
+      ...(typeof yn.topHandles === 'number' ? { top_handles: yn.topHandles } : {}),
+      ...(typeof yn.bottomHandles === 'number' ? { bottom_handles: yn.bottomHandles } : {}),
+      ...(typeof yn.leftHandles === 'number' ? { left_handles: yn.leftHandles } : {}),
+      ...(typeof yn.rightHandles === 'number' ? { right_handles: yn.rightHandles } : {}),
       // Restore the port-number toggle (issue #272).
       ...(yn.showPortNumbers ? { show_port_numbers: true } : {}),
     }


### PR DESCRIPTION
## What

Node connection points (React Flow handles) could be taken down to 0 on the left and right sides, but top and bottom were floored at 1. All four sides now share a minimum of 0, so a node can be drawn with no top and/or bottom handle.

## Changes

Frontend:
- `utils/handleUtils.ts` — new `MIN_HANDLES = 0`, the floor for every side. `sideDefault()` keeps its role as the value used when a node carries no explicit count (1 for top/bottom, 0 for left/right) and is no longer the minimum. A non-numeric or non-finite input still falls back to that default, so a missing or corrupt field yields the historical count while an explicit 0 is honoured. `MIN_BOTTOM_HANDLES` (back-compat alias) is now 0.
- `components/modals/NodeModal.tsx` — the per-side stepper uses `MIN_HANDLES`; the − button stays enabled down to 0 on top/bottom.
- `components/modals/CustomStyleModal.tsx` — per-type default counts accept 0 on all four sides.
- `utils/exportYaml.ts` — a side's count is written when it differs from the side default, not only when it exceeds it; otherwise a top/bottom 0 was dropped on export.
- `utils/importYaml.ts` — handle counts are tested with `typeof === 'number'` instead of truthiness, so an imported 0 no longer falls back to 1.

No change to existing canvases: nodes without an explicit count still render one top and one bottom handle. Rendering needed no change — `SideHandles` is already side-generic and `handlePositions(side, 0)` returns `[]`.

Note: setting a side to 0 removes the handles that edges may reference (e.g. the bare `top` id). Edges pointing at a removed handle no longer resolve — same behaviour as reducing any side's count today.

## Testing

- `utils/__tests__/handleUtils.test.ts` — new block covering 0 on top/bottom: `MIN_HANDLES`, `sideHandleCount` honouring an explicit 0, the default of 1 when the field is missing, empty positions at 0, and `removedHandleIds('top', 2, 0)`. Existing assertions that locked the old minimum of 1 were updated.
- `components/modals/__tests__/NodeModal.test.tsx` — submitting 0 for top and bottom, and the − button disabling at 0 rather than 1.
- `npm run lint`, `npm run typecheck`, `npm test` — 138 files, 1898 tests passing.

ha-relevant: yes