### PR TITLE
feat: allow a per-service host override

### DIFF
--- a/backend/app/services/status_checker.py
+++ b/backend/app/services/status_checker.py
@@ -138,6 +138,39 @@ def _service_host(svc: dict[str, Any], host: str) -> str:
     return f"[{host}]" if _is_ipv6(host) else host
 
 
+def _parse_override(raw: str) -> tuple[str, str | None, int | None]:
+    """Split a service `host` override into (hostname, scheme, port).
+
+    Mirrors the frontend `parseHostParts`: a node can serve several domains, so
+    a service may carry its own host, optionally with a scheme and a port
+    (`blog.example.com`, `blog.example.com:8443`, `https://blog.example.com`).
+    """
+    rest = raw
+    scheme: str | None = None
+    for prefix in ("https://", "http://"):
+        if rest.lower().startswith(prefix):
+            scheme = prefix[:-3]
+            rest = rest[len(prefix):]
+            break
+    rest = rest.split("/", 1)[0]
+
+    if rest.startswith("["):
+        closing = rest.find("]")
+        if closing == -1:
+            return rest, scheme, None
+        hostname = rest[1:closing]
+        remainder = rest[closing + 1:]
+        port = remainder[1:] if remainder.startswith(":") else ""
+        return hostname, scheme, int(port) if port.isdigit() else None
+
+    if rest.count(":") == 1:
+        hostname, _, port = rest.partition(":")
+        if hostname and port.isdigit():
+            return hostname, scheme, int(port)
+
+    return rest, scheme, None
+
+
 async def check_service(svc: dict[str, Any], host: str | None) -> str:
     """Check a single service. Returns 'online' | 'offline' | 'unknown'.
 
@@ -146,6 +179,12 @@ async def check_service(svc: dict[str, Any], host: str | None) -> str:
     so it keeps its category colour instead of flashing red. An open TCP socket
     doesn't prove a non-web service is healthy, so we don't pretend it does.
     """
+    override = str(svc.get("host") or "").strip()
+    override_scheme: str | None = None
+    override_port: int | None = None
+    if override:
+        host, override_scheme, override_port = _parse_override(override)
+
     if not host or host.startswith("-"):
         return "unknown"
     if str(svc.get("protocol", "")).lower() == "udp":
@@ -153,20 +192,22 @@ async def check_service(svc: dict[str, Any], host: str | None) -> str:
 
     port = svc.get("port")
     port = int(port) if isinstance(port, int) or (isinstance(port, str) and port.isdigit()) else None
+    if port is None:
+        port = override_port
 
     # Non-HTTP ports (SSH 22, DB, mail, …) are never checked — keep them grey.
     if port is not None and port in _NON_HTTP_PORTS:
         return "unknown"
 
     name = str(svc.get("service_name", "")).lower()
-    is_web = port is not None or "http" in name
+    is_web = port is not None or "http" in name or override_scheme is not None
     if not is_web:
         return "unknown"
 
     try:
-        scheme = "https" if (
+        scheme = override_scheme or ("https" if (
             port in _HTTPS_PORTS or "https" in name or "ssl" in name or "tls" in name
-        ) else "http"
+        ) else "http")
         url_host = _service_host(svc, host)
         url = f"{scheme}://{url_host}" + (f":{port}" if port is not None else "")
         return "online" if await _http_get(url, verify=False) else "offline"
@@ -187,6 +228,13 @@ async def check_services(
     async def _one(svc: dict[str, Any]) -> dict[str, Any]:
         async with sem:
             status = await check_service(svc, host)
-        return {"port": svc.get("port"), "protocol": svc.get("protocol"), "status": status}
+        # `host` rides along: several vhosts can share one port on one node, so
+        # port+protocol alone no longer identifies a service on the client side.
+        return {
+            "port": svc.get("port"),
+            "protocol": svc.get("protocol"),
+            "host": svc.get("host"),
+            "status": status,
+        }
 
     return await asyncio.gather(*[_one(s) for s in services]) if services else []

--- a/backend/app/services/status_checker.py
+++ b/backend/app/services/status_checker.py
@@ -145,7 +145,9 @@ def _parse_override(raw: str) -> tuple[str, str | None, int | None]:
     a service may carry its own host, optionally with a scheme and a port
     (`blog.example.com`, `blog.example.com:8443`, `https://blog.example.com`).
     """
-    rest = raw
+    # Like a node ip, an override may list several hosts — the first one wins,
+    # same as the frontend's `splitFirstHost`.
+    rest = raw.split(",")[0].strip()
     scheme: str | None = None
     for prefix in ("https://", "http://"):
         if rest.lower().startswith(prefix):

--- a/backend/tests/test_status_checker.py
+++ b/backend/tests/test_status_checker.py
@@ -528,6 +528,12 @@ async def test_check_service_lets_the_service_port_beat_the_override_port():
 
 
 @pytest.mark.asyncio
+async def test_check_service_uses_the_first_host_of_a_comma_list_override():
+    svc = {"port": 8080, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com, alt.example.com"}
+    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:8080"
+
+
+@pytest.mark.asyncio
 async def test_check_service_brackets_an_ipv6_override():
     svc = {"port": 80, "protocol": "tcp", "service_name": "http", "host": "[2001:db8::1]:8080"}
     assert await _captured_url(svc, "10.0.0.1") == "http://[2001:db8::1]:80"

--- a/backend/tests/test_status_checker.py
+++ b/backend/tests/test_status_checker.py
@@ -467,9 +467,78 @@ async def test_check_services_returns_status_per_service():
     with patch("app.services.status_checker._http_get", new_callable=AsyncMock, return_value=True):
         results = await check_services("10.0.0.1", services)
     assert results == [
-        {"port": 80, "protocol": "tcp", "status": "online"},
-        {"port": 5432, "protocol": "tcp", "status": "unknown"},
+        {"port": 80, "protocol": "tcp", "host": None, "status": "online"},
+        {"port": 5432, "protocol": "tcp", "host": None, "status": "unknown"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_check_services_echoes_the_host_override():
+    services = [{"port": 443, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com"}]
+    with patch("app.services.status_checker._http_get", new_callable=AsyncMock, return_value=True):
+        results = await check_services("10.0.0.1", services)
+    assert results == [
+        {"port": 443, "protocol": "tcp", "host": "blog.example.com", "status": "online"},
+    ]
+
+
+# --- Per-service host override ---
+
+
+async def _captured_url(svc, host):
+    captured = {}
+
+    async def fake_http_get(url, verify=False):
+        captured["url"] = url
+        return True
+
+    with patch("app.services.status_checker._http_get", side_effect=fake_http_get):
+        await check_service(svc, host)
+    return captured.get("url")
+
+
+@pytest.mark.asyncio
+async def test_check_service_uses_the_host_override():
+    svc = {"port": 8080, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com"}
+    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:8080"
+
+
+@pytest.mark.asyncio
+async def test_check_service_falls_back_to_the_node_host_when_override_is_blank():
+    svc = {"port": 8080, "protocol": "tcp", "service_name": "blog", "host": "   "}
+    assert await _captured_url(svc, "10.0.0.1") == "http://10.0.0.1:8080"
+
+
+@pytest.mark.asyncio
+async def test_check_service_honours_a_scheme_in_the_override():
+    svc = {"protocol": "tcp", "service_name": "blog", "host": "https://blog.example.com"}
+    assert await _captured_url(svc, "10.0.0.1") == "https://blog.example.com"
+
+
+@pytest.mark.asyncio
+async def test_check_service_takes_the_port_from_the_override():
+    svc = {"protocol": "tcp", "service_name": "blog", "host": "blog.example.com:8443"}
+    assert await _captured_url(svc, "10.0.0.1") == "https://blog.example.com:8443"
+
+
+@pytest.mark.asyncio
+async def test_check_service_lets_the_service_port_beat_the_override_port():
+    svc = {"port": 3000, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com:8443"}
+    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:3000"
+
+
+@pytest.mark.asyncio
+async def test_check_service_brackets_an_ipv6_override():
+    svc = {"port": 80, "protocol": "tcp", "service_name": "http", "host": "[2001:db8::1]:8080"}
+    assert await _captured_url(svc, "10.0.0.1") == "http://[2001:db8::1]:80"
+
+
+@pytest.mark.asyncio
+async def test_check_service_skips_a_non_http_port_behind_an_override():
+    svc = {"port": 5432, "protocol": "tcp", "service_name": "postgres", "host": "db.example.com"}
+    with patch("app.services.status_checker._http_get", new_callable=AsyncMock) as mock_get:
+        assert await check_service(svc, "10.0.0.1") == "unknown"
+    mock_get.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -498,7 +498,9 @@ export default function App() {
     // parent the LXC/VM stays a free node (linked by a virtual edge) — setting
     // extent:'parent' on a non-container would trap it inside the parent's tiny
     // bounding box with no way to drag it out (issue #205 follow-up).
-    const nestInParent = !!parentNode?.data.container_mode
+    // A visual group nests too, so it seeds its position the same way — mirrors
+    // the condition in the store's addNode, which is the authority here.
+    const nestInParent = !!parentNode?.data.container_mode || parentNode?.data.type === 'group'
     // Seed an ABSOLUTE position near the container's top-left; addNode converts
     // it to container-relative. addNode is the single authority for parentId /
     // extent, so we don't set them here.

--- a/frontend/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/canvas/nodes/BaseNode.tsx
@@ -162,7 +162,7 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
           <div className="flex flex-col gap-1 px-2.5 py-1.5 overflow-hidden">
             {services.map((svc, idx) => {
               const url = getServiceUrl(svc, serviceHost)
-              const svcOffline = serviceStatuses[serviceStatusKey(id, svc.port, svc.protocol)] === 'offline'
+              const svcOffline = serviceStatuses[serviceStatusKey(id, svc.port, svc.protocol, svc.host)] === 'offline'
               const row = (
                 <div
                   className="nodrag flex items-center justify-between gap-2 px-1.5 py-1 rounded text-[10px] min-w-0 overflow-hidden"

--- a/frontend/src/components/modals/NodeModal.tsx
+++ b/frontend/src/components/modals/NodeModal.tsx
@@ -13,7 +13,7 @@ import { resolveNodeColors } from '@/utils/nodeColors'
 import { ICON_REGISTRY, NODE_TYPE_DEFAULT_ICONS, isBrandIconKey, brandIconSlug, brandIconUrl } from '@/utils/nodeIcons'
 import { IconPickerPanel } from './IconPickerPanel'
 import { MAX_HANDLES, MIN_HANDLES, clampHandles, sideDefault, handleCountField, type Side } from '@/utils/handleUtils'
-import { getValidParentTypes } from '@/utils/virtualEdgeParent'
+import { isValidParentNode } from '@/utils/virtualEdgeParent'
 
 const NODE_TYPE_GROUPS: { label: string; types: NodeType[] }[] = [
   { label: 'Hardware',       types: ['isp', 'router', 'firewall', 'switch', 'server', 'nas', 'kvm', 'ap', 'printer'] },
@@ -174,15 +174,10 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
     setLabelError(false)
     const selectedType = (form.type ?? 'generic') as NodeType
     const canUseContainerMode = CONTAINER_MODE_TYPES.includes(selectedType)
-    const validParentTypes = getValidParentTypes(selectedType)
-    // A parent is valid either by the type rules (lxc/vm/docker_container) or
-    // because the candidate is a container-mode node (any child can nest in it).
-    const isValidParent = (p: ParentCandidate) =>
-      validParentTypes.includes(p.type) || p.container_mode === true
     let safeParentId = form.parent_id
     if (safeParentId) {
       const parent = parentCandidates.find((n) => n.id === safeParentId)
-      if (!parent || !isValidParent(parent)) safeParentId = undefined
+      if (!parent || !isValidParentNode(selectedType, parent)) safeParentId = undefined
     }
     const isGroupType = selectedType === 'groupRect' || selectedType === 'group'
     onSubmit({
@@ -225,7 +220,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                   // Drop the parent only if it's no longer a valid target for the
                   // new type — keep container-mode parents (any node can nest).
                   const parent = parentCandidates.find((n) => n.id === f.parent_id)
-                  if (f.parent_id && !(parent && (getValidParentTypes(t).includes(parent.type) || parent.container_mode === true))) {
+                  if (f.parent_id && !(parent && isValidParentNode(t, parent))) {
                     next.parent_id = undefined
                   }
                   return next
@@ -377,13 +372,13 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
             {/* Parent Container */}
             {(() => {
               const childType = (form.type ?? 'generic') as NodeType
-              const validParentTypes = getValidParentTypes(childType)
-              // Candidates: type-based parents (lxc/vm/docker_container) plus any
-              // container-mode node. The current parent is always kept so an
-              // already-nested node can be re-targeted or detached here.
+              // Candidates: type-based parents (lxc/vm/docker_container), any
+              // container-mode node, and visual groups. The current parent is
+              // always kept so an already-nested node can be re-targeted or
+              // detached here.
               const validParents = parentCandidates.filter(
                 (n) => n.id !== currentNodeId &&
-                  (validParentTypes.includes(n.type) || n.container_mode === true || n.id === form.parent_id),
+                  (isValidParentNode(childType, n) || n.id === form.parent_id),
               )
               if (validParents.length === 0) return null
               return (

--- a/frontend/src/components/modals/ServiceModal.tsx
+++ b/frontend/src/components/modals/ServiceModal.tsx
@@ -45,11 +45,13 @@ export function ServiceModal({ open, onClose, onSubmit, initial, title = 'Add Se
     const port = trimmedPort === '' ? undefined : Number.parseInt(trimmedPort, 10)
     if (port != null && (Number.isNaN(port) || port < 1 || port > 65535)) return
     const path = form.path.trim()
+    const hostOverride = form.host.trim()
     onSubmit({
       service_name: name,
       protocol: form.protocol,
       port,
       path: path || undefined,
+      host: hostOverride || undefined,
       icon: form.icon,
     })
     onClose()
@@ -132,6 +134,20 @@ export function ServiceModal({ open, onClose, onSubmit, initial, title = 'Add Se
                 <option value="udp">udp</option>
               </select>
             </div>
+          </div>
+
+          {/* Host override */}
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs text-muted-foreground">Host</Label>
+            <Input
+              value={form.host}
+              onChange={(e) => set('host', e.target.value)}
+              placeholder="Node host (app.example.com)"
+              className="bg-[#21262d] border-[#30363d] font-mono text-sm h-8"
+            />
+            <span className="text-[10px] text-muted-foreground/60">
+              Overrides the node host for this service only.
+            </span>
           </div>
 
           {/* Path */}

--- a/frontend/src/components/modals/__tests__/NodeModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModal.test.tsx
@@ -424,6 +424,33 @@ describe('NodeModal', () => {
     expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).parent_id).toBeUndefined()
   })
 
+  it('keeps a group parent_id on submit for a plain node', () => {
+    const { onSubmit } = renderModal({
+      initial: { ...BASE, type: 'server', parent_id: 'g1' },
+      parentCandidates: [{ id: 'g1', label: 'My Group', type: 'group' }],
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).parent_id).toBe('g1')
+  })
+
+  it('keeps a group parent_id when the type changes', () => {
+    const { onSubmit } = renderModal({
+      initial: { ...BASE, type: 'server', parent_id: 'g1' },
+      parentCandidates: [{ id: 'g1', label: 'My Group', type: 'group' }],
+    })
+    fireEvent.change(selects()[0], { target: { value: 'nas' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).parent_id).toBe('g1')
+  })
+
+  it('offers a group as a parent for a plain node', () => {
+    renderModal({
+      initial: { ...BASE, type: 'server' },
+      parentCandidates: [{ id: 'g1', label: 'My Group', type: 'group' }],
+    })
+    expect(screen.getByText('Parent Container')).toBeDefined()
+  })
+
   // ── Appearance ────────────────────────────────────────────────────────
 
   it('renders 3 color swatch labels (border, background, icon)', () => {

--- a/frontend/src/components/modals/__tests__/NodeModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModal.test.tsx
@@ -443,12 +443,21 @@ describe('NodeModal', () => {
     expect((onSubmit.mock.calls[0][0] as Partial<NodeData>).parent_id).toBe('g1')
   })
 
-  it('offers a group as a parent for a plain node', () => {
+  it('offers a group as a parent option for a plain node', () => {
     renderModal({
       initial: { ...BASE, type: 'server' },
       parentCandidates: [{ id: 'g1', label: 'My Group', type: 'group' }],
     })
-    expect(screen.getByText('Parent Container')).toBeDefined()
+    const option = screen.getByRole('option', { name: 'My Group' }) as HTMLOptionElement
+    expect(option.value).toBe('g1')
+  })
+
+  it('does not offer a group as a parent for another group', () => {
+    renderModal({
+      initial: { ...BASE, type: 'group' },
+      parentCandidates: [{ id: 'g1', label: 'My Group', type: 'group' }],
+    })
+    expect(screen.queryByText('Parent Container')).toBeNull()
   })
 
   // ── Appearance ────────────────────────────────────────────────────────

--- a/frontend/src/components/modals/__tests__/ServiceModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ServiceModal.test.tsx
@@ -28,6 +28,7 @@ describe('ServiceModal', () => {
         protocol: 'udp',
         port: 80,
         path: '/admin',
+        host: undefined,
         icon: undefined,
       })
       expect(onClose).toHaveBeenCalledOnce()
@@ -116,6 +117,34 @@ describe('ServiceModal', () => {
       fireEvent.change(screen.getByPlaceholderText('Path (/admin)'), { target: { value: '' } })
       submit('Save')
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ path: undefined }))
+    })
+
+    it('prefills and clears the host override', () => {
+      const withHost = serviceToForm({ port: 443, protocol: 'tcp', service_name: 'blog', host: 'blog.example.com' })
+      const { onSubmit } = setup({ initial: withHost, confirmLabel: 'Save' })
+      const input = screen.getByPlaceholderText('Node host (app.example.com)') as HTMLInputElement
+      expect(input.value).toBe('blog.example.com')
+      fireEvent.change(input, { target: { value: '' } })
+      submit('Save')
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ host: undefined }))
+    })
+  })
+
+  describe('host override', () => {
+    it('submits a trimmed host override', () => {
+      const { onSubmit } = setup()
+      fireEvent.change(screen.getByPlaceholderText('Service name'), { target: { value: 'blog' } })
+      fireEvent.change(screen.getByPlaceholderText('Node host (app.example.com)'), { target: { value: '  blog.example.com  ' } })
+      submit()
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ host: 'blog.example.com' }))
+    })
+
+    it('submits undefined when the host is left blank', () => {
+      const { onSubmit } = setup()
+      fireEvent.change(screen.getByPlaceholderText('Service name'), { target: { value: 'blog' } })
+      fireEvent.change(screen.getByPlaceholderText('Node host (app.example.com)'), { target: { value: '   ' } })
+      submit()
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ host: undefined }))
     })
   })
 

--- a/frontend/src/components/panels/DetailPanel.tsx
+++ b/frontend/src/components/panels/DetailPanel.tsx
@@ -102,6 +102,7 @@ export function DetailPanel({ onEdit }: DetailPanelProps) {
         protocol: data.protocol,
         service_name: data.service_name,
         ...(data.path ? { path: data.path } : {}),
+        ...(data.host ? { host: data.host } : {}),
         ...(data.icon ? { icon: data.icon } : {}),
       }
       updateNode(node.id, { services: [...services, svc] })
@@ -115,6 +116,7 @@ export function DetailPanel({ onEdit }: DetailPanelProps) {
             service_name: data.service_name,
             port: data.port,
             path: data.path,
+            host: data.host,
             icon: data.icon,
           }
         : svc

--- a/frontend/src/components/panels/DetailPanel.tsx
+++ b/frontend/src/components/panels/DetailPanel.tsx
@@ -235,7 +235,7 @@ export function DetailPanel({ onEdit }: DetailPanelProps) {
                   key={`${svc.port ?? 'host'}-${svc.protocol}-${svc.path ?? ''}-${i}`}
                   svc={svc}
                   host={host}
-                  status={serviceStatuses[serviceStatusKey(node.id, svc.port, svc.protocol)]}
+                  status={serviceStatuses[serviceStatusKey(node.id, svc.port, svc.protocol, svc.host)]}
                   draggable={services.length > 1}
                   isDragging={dragSvcIndex === i}
                   isDragOver={dragOverSvcIndex === i && dragSvcIndex !== i}

--- a/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
+++ b/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
@@ -784,7 +784,7 @@ describe('DetailPanel', () => {
     it('paints a service red when its live status is offline', () => {
       setupStore(
         { ip: '192.168.1.10', services: [{ port: 8080, protocol: 'tcp', service_name: 'nginx', path: '' }] },
-        { 'n1:8080/tcp': 'offline' },
+        { 'n1:8080/tcp@': 'offline' },
       )
       render(<DetailPanel onEdit={vi.fn()} />)
       expect(screen.getByRole('link', { name: 'nginx' }).style.color).toBe('rgb(248, 81, 73)') // #f85149
@@ -793,10 +793,26 @@ describe('DetailPanel', () => {
     it('keeps the category colour when the live status is online', () => {
       setupStore(
         { ip: '192.168.1.10', services: [{ port: 8080, protocol: 'tcp', service_name: 'nginx', path: '' }] },
-        { 'n1:8080/tcp': 'online' },
+        { 'n1:8080/tcp@': 'online' },
       )
       render(<DetailPanel onEdit={vi.fn()} />)
       expect(screen.getByRole('link', { name: 'nginx' }).style.color).toBe('rgb(0, 212, 255)') // #00d4ff (web)
+    })
+
+    it('paints only the offline vhost red when two services share a port', () => {
+      setupStore(
+        {
+          ip: '192.168.1.10',
+          services: [
+            { port: 443, protocol: 'tcp', service_name: 'blog', host: 'blog.example.com', path: '' },
+            { port: 443, protocol: 'tcp', service_name: 'shop', host: 'shop.example.com', path: '' },
+          ],
+        },
+        { 'n1:443/tcp@shop.example.com': 'offline' },
+      )
+      render(<DetailPanel onEdit={vi.fn()} />)
+      expect(screen.getByRole('link', { name: 'blog' }).style.color).toBe('rgb(0, 212, 255)') // #00d4ff (web)
+      expect(screen.getByRole('link', { name: 'shop' }).style.color).toBe('rgb(248, 81, 73)') // #f85149
     })
   })
 

--- a/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
+++ b/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
@@ -445,6 +445,46 @@ describe('DetailPanel', () => {
       expect(updateNode.mock.calls[0][1].services[0].port).toBeUndefined()
     })
 
+    it('stores a host override on the added service and links it', () => {
+      const updateNode = vi.fn()
+      vi.mocked(canvasStore.useCanvasStore).mockReturnValue({
+        nodes: [makeNode({ ip: '192.168.1.10' })],
+        selectedNodeId: 'n1',
+        selectedNodeIds: [],
+        setSelectedNode: vi.fn(),
+        deleteNode: vi.fn(),
+        updateNode,
+        snapshotHistory: vi.fn(),
+        createGroup: vi.fn(),
+        ungroup: vi.fn(),
+      } as unknown as ReturnType<typeof canvasStore.useCanvasStore>)
+      render(<DetailPanel onEdit={vi.fn()} />)
+      const addHeaders = screen.getAllByText('Add')
+      fireEvent.click(addHeaders[addHeaders.length - 1])
+      fireEvent.change(screen.getByPlaceholderText('Service name'), { target: { value: 'blog' } })
+      fireEvent.change(screen.getByPlaceholderText('Port'), { target: { value: '443' } })
+      fireEvent.change(screen.getByPlaceholderText('Node host (app.example.com)'), { target: { value: 'blog.example.com' } })
+      fireEvent.click(screen.getAllByRole('button', { name: 'Add' }).at(-1) as HTMLButtonElement)
+
+      expect(updateNode.mock.calls[0][1].services[0]).toMatchObject({ service_name: 'blog', host: 'blog.example.com' })
+    })
+
+    it('links a service badge to its host override rather than the node IP', () => {
+      vi.mocked(canvasStore.useCanvasStore).mockReturnValue({
+        nodes: [makeNode({ ip: '192.168.1.10', services: [{ port: 443, protocol: 'tcp', service_name: 'blog', host: 'blog.example.com' }] })],
+        selectedNodeId: 'n1',
+        selectedNodeIds: [],
+        setSelectedNode: vi.fn(),
+        deleteNode: vi.fn(),
+        updateNode: vi.fn(),
+        snapshotHistory: vi.fn(),
+        createGroup: vi.fn(),
+        ungroup: vi.fn(),
+      } as unknown as ReturnType<typeof canvasStore.useCanvasStore>)
+      render(<DetailPanel onEdit={vi.fn()} />)
+      expect(screen.getByRole('link', { name: 'blog' }).getAttribute('href')).toBe('https://blog.example.com:443')
+    })
+
     it('calls updateNode without the removed service when X is clicked', () => {
       const updateNode = vi.fn()
       const svc = { port: 80, protocol: 'tcp' as const, service_name: 'nginx' }

--- a/frontend/src/hooks/useStatusPolling.ts
+++ b/frontend/src/hooks/useStatusPolling.ts
@@ -6,6 +6,9 @@ import type { ServiceStatus } from '@/types'
 interface ServiceStatusEntry {
   port?: number
   protocol?: string
+  /** Per-service host override, part of the overlay key — several vhosts can
+   *  share one port on one node. Null when the service has none. */
+  host?: string | null
   status: ServiceStatus
 }
 

--- a/frontend/src/stores/__tests__/canvasStore/containers.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/containers.test.ts
@@ -83,6 +83,47 @@ describe('canvasStore — containers & nesting', () => {
     expect(node?.position.y).toBe(80)
   })
 
+  it('updateNode setting parent_id on a group nests the node visually', () => {
+    const group = { ...makeNode('g1', { type: 'group' }), position: { x: 100, y: 100 } }
+    const child = { ...makeNode('s1', { type: 'server' }), position: { x: 160, y: 180 } }
+    useCanvasStore.getState().addNode(group)
+    useCanvasStore.getState().addNode(child)
+    useCanvasStore.getState().updateNode('s1', { parent_id: 'g1' })
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === 's1')
+    expect(node?.parentId).toBe('g1')
+    expect(node?.extent).toBe('parent')
+    expect(node?.position).toEqual({ x: 60, y: 80 })
+  })
+
+  it('updateNode re-sending an unchanged group parent_id keeps the node in place', () => {
+    const group = { ...makeNode('g1', { type: 'group' }), position: { x: 100, y: 100 } }
+    const child = {
+      ...makeNode('s1', { type: 'server', parent_id: 'g1' }),
+      parentId: 'g1',
+      extent: 'parent' as const,
+      position: { x: 20, y: 30 },
+    }
+    useCanvasStore.setState({ nodes: [group, child] })
+    // What the node modal submits on an unrelated edit: label plus the parent it
+    // already had. It must not detach or re-offset the node (#332 follow-up).
+    useCanvasStore.getState().updateNode('s1', { label: 'renamed', parent_id: 'g1' })
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === 's1')
+    expect(node?.data.parent_id).toBe('g1')
+    expect(node?.parentId).toBe('g1')
+    expect(node?.extent).toBe('parent')
+    expect(node?.position).toEqual({ x: 20, y: 30 })
+  })
+
+  it('addNode keeps a node nested when its parent is a group', () => {
+    const group = { ...makeNode('g1', { type: 'group' }), position: { x: 100, y: 100 } }
+    useCanvasStore.setState({ nodes: [group] })
+    useCanvasStore.getState().addNode({ ...makeNode('s1', { type: 'server', parent_id: 'g1' }), position: { x: 160, y: 180 } })
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === 's1')
+    expect(node?.parentId).toBe('g1')
+    expect(node?.extent).toBe('parent')
+    expect(node?.position).toEqual({ x: 60, y: 80 })
+  })
+
   it('updateNode setting parent_id on non-container proxmox does NOT set React Flow parentId', () => {
     const proxmox = { ...makeNode('px1', { type: 'proxmox', container_mode: false }), position: { x: 100, y: 100 } }
     const lxc = { ...makeNode('lxc1', { type: 'lxc' }), position: { x: 160, y: 180 } }

--- a/frontend/src/stores/__tests__/canvasStore/nodes.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/nodes.test.ts
@@ -34,8 +34,19 @@ describe('canvasStore — nodes', () => {
       { port: 443, protocol: 'tcp', status: 'online' },
     ])
     const { serviceStatuses } = useCanvasStore.getState()
-    expect(serviceStatuses['node-1:80/tcp']).toBe('offline')
-    expect(serviceStatuses['node-1:443/tcp']).toBe('online')
+    expect(serviceStatuses['node-1:80/tcp@']).toBe('offline')
+    expect(serviceStatuses['node-1:443/tcp@']).toBe('online')
+  })
+
+  it('setServiceStatuses keys vhosts sharing a port apart by host', () => {
+    const { setServiceStatuses } = useCanvasStore.getState()
+    setServiceStatuses('node-1', [
+      { port: 443, protocol: 'tcp', host: 'blog.example.com', status: 'online' },
+      { port: 443, protocol: 'tcp', host: 'shop.example.com', status: 'offline' },
+    ])
+    const { serviceStatuses } = useCanvasStore.getState()
+    expect(serviceStatuses['node-1:443/tcp@blog.example.com']).toBe('online')
+    expect(serviceStatuses['node-1:443/tcp@shop.example.com']).toBe('offline')
   })
 
   it('setServiceStatuses merges without dropping other nodes', () => {
@@ -43,8 +54,8 @@ describe('canvasStore — nodes', () => {
     setServiceStatuses('node-1', [{ port: 80, protocol: 'tcp', status: 'online' }])
     setServiceStatuses('node-2', [{ port: 22, protocol: 'tcp', status: 'offline' }])
     const { serviceStatuses } = useCanvasStore.getState()
-    expect(serviceStatuses['node-1:80/tcp']).toBe('online')
-    expect(serviceStatuses['node-2:22/tcp']).toBe('offline')
+    expect(serviceStatuses['node-1:80/tcp@']).toBe('online')
+    expect(serviceStatuses['node-2:22/tcp@']).toBe('offline')
   })
 
   it('does not mark canvas unsaved on a service status update', () => {

--- a/frontend/src/stores/__tests__/canvasStore/nodes.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/nodes.test.ts
@@ -49,6 +49,12 @@ describe('canvasStore — nodes', () => {
     expect(serviceStatuses['node-1:443/tcp@shop.example.com']).toBe('offline')
   })
 
+  it('setServiceStatuses treats a null host from the wire as no override', () => {
+    const { setServiceStatuses } = useCanvasStore.getState()
+    setServiceStatuses('node-1', [{ port: 80, protocol: 'tcp', host: null, status: 'online' }])
+    expect(useCanvasStore.getState().serviceStatuses['node-1:80/tcp@']).toBe('online')
+  })
+
   it('setServiceStatuses merges without dropping other nodes', () => {
     const { setServiceStatuses } = useCanvasStore.getState()
     setServiceStatuses('node-1', [{ port: 80, protocol: 'tcp', status: 'online' }])

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -433,7 +433,8 @@ export const useCanvasStore = create<CanvasState>((rawSet) => {
   addNode: (node) =>
     set((state) => {
       const parent = node.data.parent_id ? state.nodes.find((n) => n.id === node.data.parent_id) : null
-      const shouldNestInParent = !!(parent?.data.container_mode)
+      // A visual group nests its children just like a container-mode host.
+      const shouldNestInParent = !!(parent?.data.container_mode) || parent?.data.type === 'group'
       const enriched = node.data.parent_id && shouldNestInParent
         ? {
             ...node,
@@ -487,8 +488,8 @@ export const useCanvasStore = create<CanvasState>((rawSet) => {
             updated.extent = undefined
           } else if (newParentId && newParentId !== n.parentId) {
             const parent = state.nodes.find((p) => p.id === newParentId)
-            if (parent?.data.container_mode) {
-              // Attaching to a container-mode Proxmox: nest visually
+            if (parent?.data.container_mode || parent?.data.type === 'group') {
+              // Attaching to a container-mode host or a visual group: nest visually
               updated.parentId = newParentId
               updated.extent = 'parent' as const
               // Convert absolute position to parent-relative (keep node visible inside)

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -104,7 +104,7 @@ function translateWaypointsForMovedNodes(
 /** Key for the live per-service status overlay.
  *  `host` is part of the key because several vhosts can share one port on one
  *  node — without it they'd all read the same status. */
-export const serviceStatusKey = (nodeId: string, port?: number, protocol?: string, host?: string): string =>
+export const serviceStatusKey = (nodeId: string, port?: number, protocol?: string, host?: string | null): string =>
   `${nodeId}:${port ?? ''}/${protocol ?? ''}@${host?.trim() ?? ''}`
 
 interface CanvasState {
@@ -188,7 +188,7 @@ interface CanvasState {
   fitViewPending: boolean
   clearFitViewPending: () => void
   notifyScanDeviceFound: () => void
-  setServiceStatuses: (nodeId: string, statuses: { port?: number; protocol?: string; host?: string; status: ServiceStatus }[]) => void
+  setServiceStatuses: (nodeId: string, statuses: { port?: number; protocol?: string; host?: string | null; status: ServiceStatus }[]) => void
   hideIp: boolean
   toggleHideIp: () => void
   setHideIp: (value: boolean) => void

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -101,9 +101,11 @@ function translateWaypointsForMovedNodes(
   })
 }
 
-/** Key for the live per-service status overlay. */
-export const serviceStatusKey = (nodeId: string, port?: number, protocol?: string): string =>
-  `${nodeId}:${port ?? ''}/${protocol ?? ''}`
+/** Key for the live per-service status overlay.
+ *  `host` is part of the key because several vhosts can share one port on one
+ *  node — without it they'd all read the same status. */
+export const serviceStatusKey = (nodeId: string, port?: number, protocol?: string, host?: string): string =>
+  `${nodeId}:${port ?? ''}/${protocol ?? ''}@${host?.trim() ?? ''}`
 
 interface CanvasState {
   nodes: Node<NodeData>[]
@@ -186,7 +188,7 @@ interface CanvasState {
   fitViewPending: boolean
   clearFitViewPending: () => void
   notifyScanDeviceFound: () => void
-  setServiceStatuses: (nodeId: string, statuses: { port?: number; protocol?: string; status: ServiceStatus }[]) => void
+  setServiceStatuses: (nodeId: string, statuses: { port?: number; protocol?: string; host?: string; status: ServiceStatus }[]) => void
   hideIp: boolean
   toggleHideIp: () => void
   setHideIp: (value: boolean) => void
@@ -913,7 +915,7 @@ export const useCanvasStore = create<CanvasState>((rawSet) => {
       // Live overlay only — never touches node data, so it stays out of saves.
       const next = { ...state.serviceStatuses }
       for (const s of statuses) {
-        next[serviceStatusKey(nodeId, s.port, s.protocol)] = s.status
+        next[serviceStatusKey(nodeId, s.port, s.protocol, s.host)] = s.status
       }
       return { serviceStatuses: next }
     }),

--- a/frontend/src/test/mocks/index.ts
+++ b/frontend/src/test/mocks/index.ts
@@ -65,6 +65,6 @@ export function makeUseCanvasStore<S extends Record<string, unknown>>(state: S) 
 }
 
 /** Common `serviceStatusKey` helper mirrored from the real store. */
-export function serviceStatusKey(nodeId: string, port?: number, protocol?: string) {
-  return `${nodeId}:${port ?? ''}/${protocol ?? ''}`
+export function serviceStatusKey(nodeId: string, port?: number, protocol?: string, host?: string) {
+  return `${nodeId}:${port ?? ''}/${protocol ?? ''}@${host?.trim() ?? ''}`
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -93,6 +93,10 @@ export interface ServiceInfo {
   path?: string
   icon?: string
   category?: string
+  /** Overrides the node host when building the service URL — one node can serve
+   *  several domains. Same accepted shapes as a node `ip`/`hostname`
+   *  (`host`, `host:port`, `https://host/…`). */
+  host?: string
 }
 
 export type ServiceStatus = 'online' | 'offline' | 'unknown'

--- a/frontend/src/utils/__tests__/serviceForm.test.ts
+++ b/frontend/src/utils/__tests__/serviceForm.test.ts
@@ -3,21 +3,23 @@ import { serviceToForm, EMPTY_SERVICE_FORM } from '../serviceForm'
 
 describe('serviceToForm', () => {
   it('maps a service onto string form fields', () => {
-    expect(serviceToForm({ port: 443, protocol: 'udp', service_name: 'svc', path: '/x', icon: 'database' })).toEqual({
+    expect(serviceToForm({ port: 443, protocol: 'udp', service_name: 'svc', path: '/x', host: 'svc.example.com', icon: 'database' })).toEqual({
       service_name: 'svc',
       port: '443',
       protocol: 'udp',
       path: '/x',
+      host: 'svc.example.com',
       icon: 'database',
     })
   })
 
-  it('blanks out absent port and path', () => {
+  it('blanks out absent port, path and host', () => {
     expect(serviceToForm({ protocol: 'tcp', service_name: 'svc' })).toEqual({
       service_name: 'svc',
       port: '',
       protocol: 'tcp',
       path: '',
+      host: '',
       icon: undefined,
     })
   })
@@ -27,6 +29,6 @@ describe('serviceToForm', () => {
   })
 
   it('starts from a blank tcp form', () => {
-    expect(EMPTY_SERVICE_FORM).toEqual({ service_name: '', port: '', protocol: 'tcp', path: '' })
+    expect(EMPTY_SERVICE_FORM).toEqual({ service_name: '', port: '', protocol: 'tcp', path: '', host: '' })
   })
 })

--- a/frontend/src/utils/__tests__/serviceUrl.test.ts
+++ b/frontend/src/utils/__tests__/serviceUrl.test.ts
@@ -80,4 +80,37 @@ describe('getServiceUrl', () => {
   it('supports path-only services inheriting the node port', () => {
     expect(getServiceUrl(svc(undefined, 'tcp', 'app', '/metrics'), '192.168.1.10:9090')).toBe('http://192.168.1.10:9090/metrics')
   })
+
+  describe('service host override', () => {
+    const withHost = (host: string, port?: number, path?: string): ServiceInfo =>
+      ({ ...svc(port, 'tcp', 'app', path), host })
+
+    it('uses the service host instead of the node one', () => {
+      expect(getServiceUrl(withHost('blog.example.com', 8080), '192.168.1.10')).toBe('http://blog.example.com:8080')
+    })
+
+    it('falls back to the node host when the override is blank', () => {
+      expect(getServiceUrl(withHost('   ', 8080), '192.168.1.10')).toBe('http://192.168.1.10:8080')
+    })
+
+    it('resolves against the override even when the node has no host', () => {
+      expect(getServiceUrl(withHost('blog.example.com', 80), undefined)).toBe('http://blog.example.com:80')
+    })
+
+    it('honours a scheme carried by the override', () => {
+      expect(getServiceUrl(withHost('https://blog.example.com'), '192.168.1.10')).toBe('https://blog.example.com')
+    })
+
+    it('takes the port from the override when the service has none', () => {
+      expect(getServiceUrl(withHost('blog.example.com:8443'), '192.168.1.10:80')).toBe('https://blog.example.com:8443')
+    })
+
+    it('appends the service path to the override host', () => {
+      expect(getServiceUrl(withHost('blog.example.com', 3000, 'admin'), '192.168.1.10')).toBe('http://blog.example.com:3000/admin')
+    })
+
+    it('still returns null for a UDP service', () => {
+      expect(getServiceUrl({ ...svc(53, 'udp', 'dns'), host: 'dns.example.com' }, '192.168.1.10')).toBeNull()
+    })
+  })
 })

--- a/frontend/src/utils/__tests__/serviceUrl.test.ts
+++ b/frontend/src/utils/__tests__/serviceUrl.test.ts
@@ -109,6 +109,14 @@ describe('getServiceUrl', () => {
       expect(getServiceUrl(withHost('blog.example.com', 3000, 'admin'), '192.168.1.10')).toBe('http://blog.example.com:3000/admin')
     })
 
+    it('returns null for a scheme-only override instead of throwing', () => {
+      expect(getServiceUrl(withHost('https://', 443), '192.168.1.10')).toBeNull()
+    })
+
+    it('lets the service port override the port carried by the override host', () => {
+      expect(getServiceUrl(withHost('blog.example.com:8443', 3000), '192.168.1.10')).toBe('http://blog.example.com:3000')
+    })
+
     it('still returns null for a UDP service', () => {
       expect(getServiceUrl({ ...svc(53, 'udp', 'dns'), host: 'dns.example.com' }, '192.168.1.10')).toBeNull()
     })

--- a/frontend/src/utils/__tests__/virtualEdgeParent.test.ts
+++ b/frontend/src/utils/__tests__/virtualEdgeParent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveVirtualEdgeParent, getValidParentTypes } from '../virtualEdgeParent'
+import { resolveVirtualEdgeParent, getValidParentTypes, isValidParentNode } from '../virtualEdgeParent'
 
 describe('getValidParentTypes', () => {
   it('returns container-mode types for lxc', () => {
@@ -19,6 +19,27 @@ describe('getValidParentTypes', () => {
     expect(getValidParentTypes('router')).toEqual([])
     expect(getValidParentTypes('proxmox')).toEqual([])
     expect(getValidParentTypes('docker_host')).toEqual([])
+  })
+})
+
+describe('isValidParentNode', () => {
+  it('accepts a group for any child type', () => {
+    expect(isValidParentNode('server', { type: 'group' })).toBe(true)
+    expect(isValidParentNode('router', { type: 'group' })).toBe(true)
+    expect(isValidParentNode('lxc', { type: 'group' })).toBe(true)
+  })
+
+  it('accepts a container-mode node for any child type', () => {
+    expect(isValidParentNode('server', { type: 'proxmox', container_mode: true })).toBe(true)
+  })
+
+  it('accepts a type-rule parent', () => {
+    expect(isValidParentNode('lxc', { type: 'proxmox' })).toBe(true)
+  })
+
+  it('rejects a non-container node that no type rule allows', () => {
+    expect(isValidParentNode('server', { type: 'proxmox', container_mode: false })).toBe(false)
+    expect(isValidParentNode('server', { type: 'groupRect' })).toBe(false)
   })
 })
 

--- a/frontend/src/utils/__tests__/virtualEdgeParent.test.ts
+++ b/frontend/src/utils/__tests__/virtualEdgeParent.test.ts
@@ -37,6 +37,11 @@ describe('isValidParentNode', () => {
     expect(isValidParentNode('lxc', { type: 'proxmox' })).toBe(true)
   })
 
+  it('rejects a group or a zone as the child of a group', () => {
+    expect(isValidParentNode('group', { type: 'group' })).toBe(false)
+    expect(isValidParentNode('groupRect', { type: 'group' })).toBe(false)
+  })
+
   it('rejects a non-container node that no type rule allows', () => {
     expect(isValidParentNode('server', { type: 'proxmox', container_mode: false })).toBe(false)
     expect(isValidParentNode('server', { type: 'groupRect' })).toBe(false)

--- a/frontend/src/utils/serviceForm.ts
+++ b/frontend/src/utils/serviceForm.ts
@@ -6,6 +6,7 @@ export interface ServiceFormData {
   port: string
   protocol: 'tcp' | 'udp'
   path: string
+  host: string
   icon?: string
 }
 
@@ -15,6 +16,7 @@ export interface ServiceSubmitData {
   protocol: 'tcp' | 'udp'
   port: number | undefined
   path: string | undefined
+  host: string | undefined
   icon: string | undefined
 }
 
@@ -23,6 +25,7 @@ export const EMPTY_SERVICE_FORM: ServiceFormData = {
   port: '',
   protocol: 'tcp',
   path: '',
+  host: '',
 }
 
 /** Turn a stored service into the string-based form shape. */
@@ -32,6 +35,7 @@ export function serviceToForm(svc: ServiceInfo): ServiceFormData {
     port: svc.port != null ? String(svc.port) : '',
     protocol: svc.protocol,
     path: svc.path ?? '',
+    host: svc.host ?? '',
     icon: svc.icon,
   }
 }

--- a/frontend/src/utils/serviceUrl.ts
+++ b/frontend/src/utils/serviceUrl.ts
@@ -78,10 +78,13 @@ function formatHostname(hostname: string): string {
 }
 
 export function getServiceUrl(svc: ServiceInfo, host?: string): string | null {
-  if (!host) return null
+  // A node can serve several domains, so a service may carry its own host that
+  // overrides the node one.
+  const effectiveHost = svc.host?.trim() || host
+  if (!effectiveHost) return null
   if (svc.protocol === 'udp') return null // UDP — not HTTP
 
-  const parts = parseHostParts(host)
+  const parts = parseHostParts(effectiveHost)
   if (!parts?.hostname) return null
 
   const effectivePort = svc.port ?? parts.port

--- a/frontend/src/utils/serviceUrl.ts
+++ b/frontend/src/utils/serviceUrl.ts
@@ -35,7 +35,15 @@ function parseHostParts(host: string): { protocol?: 'http' | 'https'; hostname: 
   if (!firstHost) return null
 
   if (firstHost.startsWith('http://') || firstHost.startsWith('https://')) {
-    const url = new URL(firstHost)
+    // A hand-typed host override can be a bare scheme ("https://"), which
+    // throws — an unusable URL is null, not a crashed render.
+    let url: URL
+    try {
+      url = new URL(firstHost)
+    } catch {
+      return null
+    }
+    if (!url.hostname) return null
     return {
       protocol: url.protocol === 'https:' ? 'https' : 'http',
       hostname: url.hostname,

--- a/frontend/src/utils/virtualEdgeParent.ts
+++ b/frontend/src/utils/virtualEdgeParent.ts
@@ -29,13 +29,14 @@ export function getValidParentTypes(childType: NodeType): NodeType[] {
  *
  *  A visual group holds any node type — the type rules above only govern
  *  virtual (container) nesting, so they'd wrongly reject a grouped node and
- *  drop it out of its group on the next edit.
+ *  drop it out of its group on the next edit. Groups and zones are excluded as
+ *  children, matching what the drag-onto-a-group path accepts.
  */
 export function isValidParentNode(
   childType: NodeType,
   parent: { type: NodeType; container_mode?: boolean },
 ): boolean {
-  if (parent.type === 'group') return true
+  if (parent.type === 'group') return childType !== 'group' && childType !== 'groupRect'
   return getValidParentTypes(childType).includes(parent.type) || parent.container_mode === true
 }
 

--- a/frontend/src/utils/virtualEdgeParent.ts
+++ b/frontend/src/utils/virtualEdgeParent.ts
@@ -25,6 +25,20 @@ export function getValidParentTypes(childType: NodeType): NodeType[] {
   return []
 }
 
+/** Can `parent` hold a child of `childType`?
+ *
+ *  A visual group holds any node type — the type rules above only govern
+ *  virtual (container) nesting, so they'd wrongly reject a grouped node and
+ *  drop it out of its group on the next edit.
+ */
+export function isValidParentNode(
+  childType: NodeType,
+  parent: { type: NodeType; container_mode?: boolean },
+): boolean {
+  if (parent.type === 'group') return true
+  return getValidParentTypes(childType).includes(parent.type) || parent.container_mode === true
+}
+
 export function resolveVirtualEdgeParent(
   source: VirtualEdgeEndpoint,
   target: VirtualEdgeEndpoint,


### PR DESCRIPTION
## What

A node can host several domains, so a single ip/hostname is not always the right base URL for every service it runs. Each service can now carry its own `host` that overrides the node one when its URL is built, opened from the canvas, and checked by the status checker. Leaving the field empty keeps today's behaviour.

Closes #332

## Changes

### Frontend
- `ServiceInfo.host` (optional): overrides the node ip/hostname for this service only. Accepts the same shapes as a node host — `host`, `host:port`, `https://host/path`, IPv6 literals, and a comma-separated list (first one wins).
- `ServiceModal`: new Host field between Protocol and Path, with a hint that it overrides the node host. Blank submits as `undefined`, so clearing it removes the override.
- `getServiceUrl` resolves `svc.host?.trim() || host`, keeping the existing precedence rules (service port beats the port carried by the host, UDP/SSH/non-HTTP ports still yield no link). Both call sites — the canvas node link and the detail panel badge — follow it with no change of their own.
- `getServiceUrl` no longer throws on an unparseable override: a hand-typed `https://` returned a `new URL()` exception mid-render, and now resolves to no link.
- `serviceStatusKey` takes the host as part of the key. Several vhosts sharing one port on one node used to collapse onto a single `node:port/protocol` entry and all display the same live status.

### Backend
- `check_service` honours the override: it resolves the hostname, an explicit scheme, and a port carried by the override, then probes that instead of the node host. Service port still beats the override port; non-HTTP ports stay unchecked.
- The service-status payload echoes `host` back, so the client can key vhosts apart.
- No schema or migration change: `services` is stored as untyped JSON on both the node model and the inventory model, so the new field rides along.

## Testing

- `frontend`: 1921 tests pass (`npm test`), plus lint and typecheck. New cases cover the override in `serviceUrl` (override wins, blank falls back, no node host, scheme, port precedence, path, comma list, scheme-only input, UDP), the modal field (submit, trim, clear), the store key (vhosts split apart, null host from the wire), and the detail panel (override stored on add, badge href, only the offline vhost painted red).
- `backend`: full `pytest` suite passes, plus `ruff` and `mypy`. New cases cover the override host, blank fallback, scheme, override port, service-port precedence, comma list, IPv6 bracketing, a non-HTTP port behind an override, and the `host` field in the broadcast payload.

ha-relevant: yes
