### PR TITLE
fix(deps): bump undici and ip-address to patch high severity advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6578,9 +6578,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9514,9 +9514,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What

Bumps two transitive frontend dev dependencies to clear the two high severity
Dependabot alerts open on `main`. Lockfile only — no source change, no runtime
dependency affected.

## Changes

- frontend: `undici` 7.28.0 -> 7.29.0 (transitive via `jsdom`) — fixes
  cross-user information disclosure and a parse-time crash via degenerate
  private cache directives (alert #52, high)
- frontend: `ip-address` 10.2.0 -> 10.5.0 (transitive via `shadcn` ->
  `@modelcontextprotocol/sdk` -> `express-rate-limit`) — fixes leading-zero
  octets being decoded as decimal while resolvers decode them as octal,
  allowing SSRF and trust-boundary bypass (alert #57, high)

Also closes the moderate advisories on the same two packages: #49, #50, #51,
#53, #54, #55.

Still open after this, both dev-only and out of scope here: `nanoid` <3.3.18
(high) and `hono` <=4.12.33 (moderate).

## Testing

- `npm test` in `frontend/` — 146 files, 2009 tests, all passing
- `npm run lint` and `npm run typecheck` clean via the pre-commit hook

ha-relevant: no
