### PR TITLE
feat: make the property value optional

### DIFF
--- a/frontend/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/canvas/nodes/BaseNode.tsx
@@ -148,7 +148,9 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
                 <div key={prop.key} className="flex items-center gap-1 font-mono text-[10px] min-w-0 overflow-hidden" style={{ color: theme.colors.nodeSubtextColor }}>
                   {Icon && <Icon size={9} className="shrink-0" />}
                   <span className="truncate max-w-15 shrink-0" title={prop.key}>{prop.key}</span>
-                  <span className="truncate min-w-0" title={prop.value}>· {prop.value}</span>
+                  {prop.value.trim() && (
+                    <span className="truncate min-w-0" title={prop.value}>· {prop.value}</span>
+                  )}
                 </div>
               )
             })}

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -120,7 +120,9 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
             >
               {Icon && <Icon size={9} className="shrink-0" />}
               <span className="truncate max-w-15 shrink-0" title={prop.key}>{prop.key}</span>
-              <span className="truncate min-w-0" title={prop.value}>· {prop.value}</span>
+              {prop.value.trim() && (
+                <span className="truncate min-w-0" title={prop.value}>· {prop.value}</span>
+              )}
             </div>
           )
         })}

--- a/frontend/src/components/common/PropertyList.tsx
+++ b/frontend/src/components/common/PropertyList.tsx
@@ -38,7 +38,7 @@ export function PropertyList({
   onChange,
   visibleLabel = 'Show on node',
   keyPlaceholder = 'Label (e.g. CPU Model)',
-  valuePlaceholder = 'Value (e.g. i7-12700K)',
+  valuePlaceholder = 'Value — optional (e.g. i7-12700K)',
   suggestions,
   title = 'Properties',
   emptyHint = 'No properties — click Add to define one.',
@@ -51,7 +51,8 @@ export function PropertyList({
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
 
   const handleAdd = () => {
-    if (!newProp.key.trim() || !newProp.value.trim()) return
+    // Only the key is required — a property may carry a label alone.
+    if (!newProp.key.trim()) return
     onChange([
       ...properties,
       { key: newProp.key.trim(), value: newProp.value.trim(), icon: newProp.icon, visible: newProp.visible },
@@ -82,7 +83,7 @@ export function PropertyList({
   }
 
   const handleSaveEdit = () => {
-    if (editingIndex === null || !editProp.key.trim() || !editProp.value.trim()) return
+    if (editingIndex === null || !editProp.key.trim()) return
     onChange(
       properties.map((p, i) =>
         i === editingIndex
@@ -192,7 +193,7 @@ export function PropertyList({
   )
 }
 
-export function PropertyForm({ form, onChange, onConfirm, onCancel, confirmLabel, visibleLabel = 'Show on node', keyPlaceholder = 'Label (e.g. CPU Model)', valuePlaceholder = 'Value (e.g. i7-12700K)' }: {
+export function PropertyForm({ form, onChange, onConfirm, onCancel, confirmLabel, visibleLabel = 'Show on node', keyPlaceholder = 'Label (e.g. CPU Model)', valuePlaceholder = 'Value — optional (e.g. i7-12700K)' }: {
   form: PropForm
   onChange: (f: PropForm) => void
   onConfirm: () => void
@@ -307,7 +308,9 @@ export function PropertyBadge({ prop, visibleLabel = 'node', draggable, isDraggi
         )}
         {Icon && createElement(Icon, { size: 11, className: 'shrink-0 text-muted-foreground' })}
         <span className="font-medium truncate text-foreground" title={prop.key}>{prop.key}</span>
-        <span className="text-muted-foreground truncate" title={prop.value}>· {prop.value}</span>
+        {prop.value.trim() && (
+          <span className="text-muted-foreground truncate" title={prop.value}>· {prop.value}</span>
+        )}
       </div>
       <div className="flex items-center gap-1 shrink-0">
         <button

--- a/frontend/src/components/common/__tests__/PropertyList.test.tsx
+++ b/frontend/src/components/common/__tests__/PropertyList.test.tsx
@@ -40,7 +40,7 @@ describe('PropertyList', () => {
     ])
   })
 
-  it('refuses a property with no key or no value', () => {
+  it('adds a property with a label and no value', () => {
     const onChange = vi.fn()
     render(<PropertyList properties={[]} onChange={onChange} />)
 
@@ -48,7 +48,25 @@ describe('PropertyList', () => {
     fireEvent.change(screen.getByPlaceholderText(/^Label/), { target: { value: 'GPU' } })
     fireEvent.click(confirm('Add'))
 
+    expect(onChange).toHaveBeenCalledWith([{ key: 'GPU', value: '', icon: null, visible: true }])
+  })
+
+  it('refuses a property with no key', () => {
+    const onChange = vi.fn()
+    render(<PropertyList properties={[]} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    fireEvent.change(screen.getByPlaceholderText(/^Value/), { target: { value: 'RTX' } })
+    fireEvent.click(confirm('Add'))
+
     expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('prints a value-less property as a bare label', () => {
+    render(<PropertyList properties={[{ key: 'Rented', value: '', icon: null, visible: true }]} onChange={vi.fn()} />)
+
+    expect(screen.getByTitle('Rented')).toBeInTheDocument()
+    expect(screen.queryByText(/^·/)).not.toBeInTheDocument()
   })
 
   it('toggles a property between shown and hidden', () => {
@@ -108,6 +126,17 @@ describe('PropertyList', () => {
       { key: 'B', value: '22', icon: null, visible: true },
       { key: 'C', value: '3', icon: null, visible: true },
     ])
+  })
+
+  it('saves an edit that clears the value', () => {
+    const onChange = vi.fn()
+    render(<PropertyList properties={props()} onChange={onChange} />)
+
+    fireEvent.click(screen.getAllByTitle('Edit property')[1])
+    fireEvent.change(screen.getByDisplayValue('2'), { target: { value: '' } })
+    fireEvent.click(confirm('Save'))
+
+    expect(onChange.mock.calls[0][0][1]).toEqual({ key: 'B', value: '', icon: null, visible: true })
   })
 
   it('words the visibility toggle for the surface it edits', () => {

--- a/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
+++ b/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
@@ -137,9 +137,9 @@ describe('DetailPanel', () => {
       fireEvent.click(addButtons[0]) // first Add = properties
       // Form is now open — fill key and value
       fireEvent.change(screen.getByPlaceholderText('Label (e.g. CPU Model)'), { target: { value: 'GPU' } })
-      fireEvent.change(screen.getByPlaceholderText('Value (e.g. i7-12700K)'), { target: { value: 'RTX 4090' } })
+      fireEvent.change(screen.getByPlaceholderText(/^Value/), { target: { value: 'RTX 4090' } })
       // The PropertyForm confirm button is labeled "Add" — use the form's confirm button
-      fireEvent.keyDown(screen.getByPlaceholderText('Value (e.g. i7-12700K)'), { key: 'Enter' })
+      fireEvent.keyDown(screen.getByPlaceholderText(/^Value/), { key: 'Enter' })
       expect(updateNode).toHaveBeenCalledOnce()
       const [, payload] = updateNode.mock.calls[0]
       expect(payload.properties[0]).toMatchObject({ key: 'GPU', value: 'RTX 4090', visible: true })
@@ -243,7 +243,7 @@ describe('DetailPanel', () => {
       const addButtons = screen.getAllByText('Add')
       fireEvent.click(addButtons[0])
       // Only fill value, leave key empty
-      fireEvent.change(screen.getByPlaceholderText('Value (e.g. i7-12700K)'), { target: { value: 'some value' } })
+      fireEvent.change(screen.getByPlaceholderText(/^Value/), { target: { value: 'some value' } })
       const confirmButtons = screen.getAllByRole('button', { name: 'Add' })
       fireEvent.click(confirmButtons[confirmButtons.length - 1])
       expect(updateNode).not.toHaveBeenCalled()

--- a/frontend/src/rack/__tests__/CableLayer.test.tsx
+++ b/frontend/src/rack/__tests__/CableLayer.test.tsx
@@ -161,6 +161,19 @@ describe('CableLayer selection', () => {
     expect(lines).toEqual(['Uplink', 'Length: 2 m'])
   })
 
+  it('prints a value-less property as a bare label', () => {
+    const store = useRackStore.getState()
+    store.setCableVisibility('always')
+    store.updateCable(store.cables[0].id, {
+      labelVisible: false,
+      properties: [{ key: 'Spare', value: '', icon: null, visible: true }],
+    })
+
+    const { getAllByTestId } = render(<CableLayer />)
+    const lines = Array.from(getAllByTestId('cable-annotation')[0].querySelectorAll('text')).map((t) => t.textContent)
+    expect(lines).toEqual(['Spare'])
+  })
+
   it('draws the selected cable with a highlight halo', () => {
     useRackStore.getState().toggleCableMode()
     const { container, rerender } = render(<CableLayer />)

--- a/frontend/src/rack/__tests__/RackCablePanel.test.tsx
+++ b/frontend/src/rack/__tests__/RackCablePanel.test.tsx
@@ -119,7 +119,7 @@ describe('RackCablePanel', () => {
     render(<RackCablePanel />)
 
     fireEvent.click(screen.getByText('+ Length'))
-    fireEvent.change(screen.getByPlaceholderText('Value (e.g. 2 m)'), { target: { value: '2 m' } })
+    fireEvent.change(screen.getByPlaceholderText(/^Value/), { target: { value: '2 m' } })
     // Two buttons read "Add": the section's, then the form's confirm.
     const addButtons = screen.getAllByRole('button', { name: 'Add' })
     fireEvent.click(addButtons[addButtons.length - 1])

--- a/frontend/src/rack/components/CableLayer.tsx
+++ b/frontend/src/rack/components/CableLayer.tsx
@@ -47,7 +47,8 @@ function annotationLines(cable: Cable): string[] {
   const lines: string[] = []
   if (cable.labelVisible && cable.label?.trim()) lines.push(cable.label.trim())
   for (const prop of cable.properties ?? []) {
-    if (prop.visible) lines.push(`${prop.key}: ${prop.value}`)
+    // The value is optional — a property may print as a bare label.
+    if (prop.visible) lines.push(prop.value?.trim() ? `${prop.key}: ${prop.value}` : prop.key)
   }
   return lines
 }

--- a/frontend/src/rack/components/RackCablePanel.tsx
+++ b/frontend/src/rack/components/RackCablePanel.tsx
@@ -146,7 +146,7 @@ export function RackCablePanel() {
         onChange={(next) => updateCable(cable.id, { properties: next })}
         visibleLabel="Show on canvas"
         keyPlaceholder="Label (e.g. Length)"
-        valuePlaceholder="Value (e.g. 2 m)"
+        valuePlaceholder="Value — optional (e.g. 2 m)"
         suggestions={CABLE_PROPERTY_SUGGESTIONS}
         emptyHint="No properties — add a length, a VLAN, whatever this run needs."
       />


### PR DESCRIPTION
## What
Node and cable properties can now be created with a label only. The value was mandatory in the shared property editor, which made it impossible to record a plain marker ("Spare", "Rented") without inventing a filler value.

## Changes

Frontend
- `components/common/PropertyList.tsx`: add and edit only require a key; the value placeholder now reads "Value — optional"; the property badge drops the `· value` part when the value is empty.
- `components/canvas/nodes/BaseNode.tsx` and `ProxmoxGroupNode.tsx`: same — a value-less property prints as a bare label on the canvas.
- `rack/components/CableLayer.tsx`: a cable annotation prints `key` instead of `key: ` when the value is empty.
- `rack/components/RackCablePanel.tsx`: matching placeholder wording.

No backend change: properties are stored free-form (`list[dict[str, Any]]`) and no schema required a value.

## Testing
- New tests: add a property with no value, refuse a property with no key, render a value-less property as a bare label, save an edit that clears the value (`components/common/__tests__/PropertyList.test.tsx`), and a bare-label cable annotation (`rack/__tests__/CableLayer.test.tsx`).
- Updated: the old `refuses a property with no key or no value` case contradicted the new rule and was split; hard-coded value placeholders in `DetailPanel.test.tsx` and `RackCablePanel.test.tsx` became `/^Value/` matchers.
- `npm run lint && npm run typecheck && npm test` — 147 files, 2032 tests pass.

ha-relevant: yes
