### PR TITLE
fix: give a valueless property label the full node width

### DIFF
--- a/frontend/src/components/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/canvas/nodes/BaseNode.tsx
@@ -146,11 +146,12 @@ export function BaseNode({ id, data, selected, icon: typeIcon, width, height }: 
           <div className="flex flex-col gap-1 px-2.5 py-1.5 overflow-hidden">
             {visibleProperties.map((prop) => {
               const Icon = resolvePropertyIcon(prop.icon)
+              const hasValue = Boolean(prop.value.trim())
               return (
                 <div key={prop.key} className="flex items-center gap-1 font-mono text-[10px] min-w-0 overflow-hidden" style={{ color: theme.colors.nodeSubtextColor }}>
                   {Icon && <Icon size={9} className="shrink-0" />}
-                  <span className="truncate max-w-15 shrink-0" title={prop.key}>{prop.key}</span>
-                  {prop.value.trim() && (
+                  <span className={hasValue ? 'truncate max-w-15 shrink-0' : 'truncate min-w-0'} title={prop.key}>{prop.key}</span>
+                  {hasValue && (
                     <span className="truncate min-w-0" title={prop.value}>· {prop.value}</span>
                   )}
                 </div>

--- a/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
+++ b/frontend/src/components/canvas/nodes/ProxmoxGroupNode.tsx
@@ -107,6 +107,7 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
         {/* Properties */}
         {data.properties?.filter((p) => p.visible).map((prop, i, arr) => {
           const Icon = resolvePropertyIcon(prop.icon)
+          const hasValue = Boolean(prop.value.trim())
           return (
             <div
               key={prop.key}
@@ -119,8 +120,8 @@ export function ProxmoxGroupNode(props: NodeProps<Node<NodeData>>) {
               }}
             >
               {Icon && <Icon size={9} className="shrink-0" />}
-              <span className="truncate max-w-15 shrink-0" title={prop.key}>{prop.key}</span>
-              {prop.value.trim() && (
+              <span className={hasValue ? 'truncate max-w-15 shrink-0' : 'truncate min-w-0'} title={prop.key}>{prop.key}</span>
+              {hasValue && (
                 <span className="truncate min-w-0" title={prop.value}>· {prop.value}</span>
               )}
             </div>

--- a/frontend/src/components/canvas/nodes/__tests__/BaseNode.properties.test.tsx
+++ b/frontend/src/components/canvas/nodes/__tests__/BaseNode.properties.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * A property with no value gives its whole line to the label.
+ *
+ * The label is capped at max-w-15 so a long key cannot crowd out the value
+ * beside it. With no value there is nothing to protect, and keeping the cap
+ * truncated the label against empty space (issue #361).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { Server } from 'lucide-react'
+import { BaseNode } from '../BaseNode'
+import type { NodeData, NodeProperty } from '@/types'
+
+vi.mock('@/stores/canvasStore', async () => {
+  const actual = await vi.importActual<typeof import('@/stores/canvasStore')>('@/stores/canvasStore')
+  return {
+    ...actual,
+    useCanvasStore: (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({ hideIp: false, serviceStatuses: {} }),
+  }
+})
+
+function renderNode(properties: NodeProperty[]) {
+  const data: NodeData = { label: 'NAS', type: 'nas', status: 'online', properties }
+  return render(
+    <ReactFlowProvider>
+      <BaseNode
+        {...({ id: 'n1', data, selected: false, icon: Server } as React.ComponentProps<typeof BaseNode>)}
+      />
+    </ReactFlowProvider>,
+  )
+}
+
+function labelOf(container: HTMLElement, key: string) {
+  return [...container.querySelectorAll('span')].find((s) => s.textContent === key)
+}
+
+const prop = (key: string, value: string): NodeProperty => ({ key, value, visible: true })
+
+describe('BaseNode properties', () => {
+  it('drops the label width cap when the value is empty', () => {
+    const { container } = renderNode([prop('A very long property label', '')])
+    const label = labelOf(container, 'A very long property label')
+    expect(label).toBeDefined()
+    expect(label!.className).not.toContain('max-w-15')
+    expect(label!.className).toContain('min-w-0')
+  })
+
+  it('treats a whitespace-only value as empty', () => {
+    const { container } = renderNode([prop('Label', '   ')])
+    const label = labelOf(container, 'Label')
+    expect(label!.className).not.toContain('max-w-15')
+  })
+
+  it('keeps the cap when a value shares the line', () => {
+    const { container } = renderNode([prop('Label', '42')])
+    const label = labelOf(container, 'Label')
+    expect(label!.className).toContain('max-w-15')
+    expect(container.textContent).toContain('· 42')
+  })
+})


### PR DESCRIPTION
## What

A node property whose value is left empty had its label truncated with an
ellipsis even though half the node line was blank. Property values became
optional in 3.3.x, so this is now a common case.

Root cause: the label span is capped at `max-w-15` (60px) so a long key
cannot crowd out the value drawn beside it. That cap applied unconditionally,
including when no value followed it — the label truncated against reserved
but unused space.

Fix: drop the cap when the value is blank and let the label truncate against
the node width instead.

Closes #361

## Changes

Frontend (canvas):
- `BaseNode.tsx` — label span uses `truncate min-w-0` instead of
  `truncate max-w-15 shrink-0` when the property value is empty or
  whitespace-only.
- `ProxmoxGroupNode.tsx` — same fix, it renders properties with its own copy
  of that markup.

No behaviour change when a value is present.

## Testing

- New `frontend/src/components/canvas/nodes/__tests__/BaseNode.properties.test.tsx`:
  regression coverage for an empty value, a whitespace-only value, and the
  unchanged with-value case.
- Full suite: `npm test` — 149 files, 2048 tests passing. Lint and typecheck clean.

ha-relevant: yes