### PR TITLE
fix: stop an endless response body from OOM-killing the backend

### DIFF
--- a/backend/app/services/http_probe.py
+++ b/backend/app/services/http_probe.py
@@ -16,12 +16,33 @@ logger = logging.getLogger(__name__)
 
 # Headers that commonly carry the application name.
 _SIGNAL_HEADERS = ("Server", "X-Powered-By")
-# Cap how much body we read when hunting for <title> — avoids large downloads.
+# Cap how much body we read when hunting for <title>. This is a cap on the
+# download itself, not just on what we scan: the body is streamed and the
+# connection dropped once we hold this much. Some endpoints stream without end
+# and send no Content-Length (bandwidth-test endpoints, MJPEG cameras), so
+# buffering a full response would OOM the backend.
 _MAX_BODY_BYTES = 64 * 1024
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
 _PROBE_TIMEOUT = 3.0
 # Ports we never bother probing over HTTP (not web services).
 _NON_HTTP_PORTS = frozenset({22, 21, 23, 25, 53, 110, 143, 161, 162, 179, 445, 3306, 5432, 6379})
+
+
+async def _read_capped(resp: httpx.Response) -> str:
+    """Read at most _MAX_BODY_BYTES of a streaming response, then stop."""
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in resp.aiter_bytes():
+        chunks.append(chunk)
+        size += len(chunk)
+        if size >= _MAX_BODY_BYTES:
+            break
+    raw = b"".join(chunks)[:_MAX_BODY_BYTES]
+    encoding = resp.charset_encoding or "utf-8"
+    try:
+        return raw.decode(encoding, errors="replace")
+    except LookupError:
+        return raw.decode("utf-8", errors="replace")
 
 
 def _extract_title(body: str) -> str | None:
@@ -34,11 +55,11 @@ def _extract_title(body: str) -> str | None:
 
 async def _probe_scheme(client: httpx.AsyncClient, url: str) -> dict[str, Any] | None:
     try:
-        resp = await client.get(url, follow_redirects=True)
+        async with client.stream("GET", url, follow_redirects=True) as resp:
+            headers = {h: resp.headers[h] for h in _SIGNAL_HEADERS if h in resp.headers}
+            body = await _read_capped(resp)
     except (httpx.HTTPError, OSError):
         return None
-    headers = {h: resp.headers[h] for h in _SIGNAL_HEADERS if h in resp.headers}
-    body = resp.text[:_MAX_BODY_BYTES] if resp.text else ""
     title = _extract_title(body)
     if not title and not headers:
         return None

--- a/backend/app/services/status_checker.py
+++ b/backend/app/services/status_checker.py
@@ -103,8 +103,16 @@ async def _ping(host: str) -> bool:
 
 
 async def _http_get(url: str, verify: bool = False) -> bool:
-    async with httpx.AsyncClient(verify=verify, timeout=5) as client:
-        resp = await client.get(url, follow_redirects=True)
+    # Only the status line matters here. A plain .get() buffers the whole body
+    # first, and some endpoints stream without end (bandwidth-test endpoints,
+    # MJPEG cameras, log tails) — enough to OOM the backend. timeout=5 does not
+    # save us: httpx applies it per network operation, not to the total time
+    # spent draining a socket that keeps delivering data. stream() closes the
+    # connection on exit without draining it.
+    async with (
+        httpx.AsyncClient(verify=verify, timeout=5) as client,
+        client.stream("GET", url, follow_redirects=True) as resp,
+    ):
         return resp.status_code < 500
 
 

--- a/backend/tests/test_http_probe.py
+++ b/backend/tests/test_http_probe.py
@@ -1,10 +1,11 @@
 """Tests for the HTTP probe used by deep-scan service identification."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
 
 from app.services.http_probe import (
+    _MAX_BODY_BYTES,
     _extract_title,
     probe_open_ports,
     probe_port,
@@ -13,6 +14,39 @@ from app.services.http_probe import (
 
 def _response(text: str = "", headers: dict | None = None, status: int = 200) -> httpx.Response:
     return httpx.Response(status_code=status, text=text, headers=headers or {})
+
+
+class _TransportClient:
+    """
+    Patch target for httpx.AsyncClient that routes through a MockTransport.
+
+    Real client, fake network: the probe exercises the genuine httpx request
+    path (including .stream() and aiter_bytes()) instead of a mock that would
+    happily accept any call shape. `requests` records what was actually sent.
+    """
+
+    def __init__(self, handler):
+        self._handler = handler
+        # Bound before patching, so building the real client here does not
+        # recurse back into this stand-in.
+        self._real = httpx.AsyncClient
+        self.kwargs: list[dict] = []
+        self.requests: list[httpx.Request] = []
+
+    def _record(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._handler(request)
+
+    def __call__(self, **kwargs):
+        self.kwargs.append(dict(kwargs))
+        kwargs.pop("verify", None)
+        return self._real(transport=httpx.MockTransport(self._record), **kwargs)
+
+
+def _patch_client(handler) -> tuple:
+    """Return (context manager, factory) patching http_probe's AsyncClient."""
+    factory = _TransportClient(handler)
+    return patch("app.services.http_probe.httpx.AsyncClient", factory), factory
 
 
 # ── _extract_title ──────────────────────────────────────────────────────────
@@ -37,15 +71,18 @@ def test_extract_title_case_insensitive():
 
 @pytest.mark.asyncio
 async def test_probe_port_reads_title():
-    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=_response("<title>Jellyfin</title>"))):
+    ctx, _ = _patch_client(lambda req: _response("<title>Jellyfin</title>"))
+    with ctx:
         result = await probe_port("10.0.0.5", 8096)
     assert result == {"title": "Jellyfin", "headers": {}}
 
 
 @pytest.mark.asyncio
 async def test_probe_port_reads_headers():
-    resp = _response("", headers={"Server": "nginx", "X-Powered-By": "Express"})
-    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=resp)):
+    ctx, _ = _patch_client(
+        lambda req: _response("", headers={"Server": "nginx", "X-Powered-By": "Express"})
+    )
+    with ctx:
         result = await probe_port("10.0.0.5", 3000)
     assert result["headers"] == {"Server": "nginx", "X-Powered-By": "Express"}
 
@@ -53,30 +90,33 @@ async def test_probe_port_reads_headers():
 @pytest.mark.asyncio
 async def test_probe_port_falls_back_to_http():
     # https raises, http succeeds
-    calls = {"n": 0}
-
-    async def fake_get(self, url, **kw):
-        calls["n"] += 1
-        if url.startswith("https"):
+    def handler(request):
+        if str(request.url).startswith("https"):
             raise httpx.ConnectError("tls fail")
         return _response("<title>HTTP App</title>")
 
-    with patch("httpx.AsyncClient.get", new=fake_get):
+    ctx, factory = _patch_client(handler)
+    with ctx:
         result = await probe_port("10.0.0.5", 8080)
     assert result["title"] == "HTTP App"
-    assert calls["n"] == 2  # tried https then http
+    assert len(factory.requests) == 2  # tried https then http
 
 
 @pytest.mark.asyncio
 async def test_probe_port_no_signal_returns_none():
-    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=_response(""))):
+    ctx, _ = _patch_client(lambda req: _response(""))
+    with ctx:
         result = await probe_port("10.0.0.5", 8080)
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_probe_port_timeout_returns_none():
-    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=httpx.TimeoutException("slow"))):
+    def handler(request):
+        raise httpx.TimeoutException("slow")
+
+    ctx, _ = _patch_client(handler)
+    with ctx:
         result = await probe_port("10.0.0.5", 8080)
     assert result is None
 
@@ -84,33 +124,101 @@ async def test_probe_port_timeout_returns_none():
 @pytest.mark.asyncio
 async def test_probe_port_skips_non_http_ports():
     # SSH should never trigger an HTTP request
-    get = AsyncMock()
-    with patch("httpx.AsyncClient.get", new=get):
+    ctx, factory = _patch_client(lambda req: _response("<title>nope</title>"))
+    with ctx:
         result = await probe_port("10.0.0.5", 22)
     assert result is None
-    get.assert_not_called()
+    assert factory.requests == []
 
 
 @pytest.mark.asyncio
 async def test_probe_port_verify_tls_flag_passed():
-    with patch("app.services.http_probe.httpx.AsyncClient") as client_cls:
-        instance = client_cls.return_value.__aenter__.return_value
-        instance.get = AsyncMock(return_value=_response("<title>X</title>"))
+    ctx, factory = _patch_client(lambda req: _response("<title>X</title>"))
+    with ctx:
         await probe_port("10.0.0.5", 8443, verify_tls=True)
-    assert client_cls.call_args.kwargs["verify"] is True
+    assert factory.kwargs[0]["verify"] is True
+
+
+# ── endless bodies (issue #375) ─────────────────────────────────────────────
+
+_CHUNK_SIZE = 16 * 1024
+
+
+def _endless_body(counter: dict, head: bytes = b""):
+    """
+    A body that never ends and declares no Content-Length. Bounded at 512
+    chunks so a regression fails the test instead of hanging the suite.
+    """
+
+    async def gen():
+        if head:
+            counter["bytes"] += len(head)
+            yield head
+        for _ in range(512):
+            counter["bytes"] += _CHUNK_SIZE
+            yield b"\0" * _CHUNK_SIZE
+
+    return gen()
+
+
+@pytest.mark.asyncio
+async def test_probe_caps_the_download_of_an_endless_body():
+    # _MAX_BODY_BYTES caps the download, not just the <title> scan: the body is
+    # streamed and the connection dropped once we hold enough. Allow one chunk
+    # of overshoot — the read stops on a chunk boundary.
+    counter = {"bytes": 0}
+
+    def handler(request):
+        # Plain HTTP only, like the reproducer, so the counter covers one probe.
+        if str(request.url).startswith("https"):
+            raise httpx.ConnectError("no tls")
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/octet-stream"},
+            content=_endless_body(counter),
+        )
+
+    ctx, _ = _patch_client(handler)
+    with ctx:
+        result = await probe_port("10.0.0.5", 8095)
+    assert result is None  # null bytes carry no title and no signal header
+    assert counter["bytes"] <= _MAX_BODY_BYTES + _CHUNK_SIZE
+
+
+@pytest.mark.asyncio
+async def test_probe_still_reads_a_title_from_an_endless_body():
+    # Stopping early must not cost us the signal: a <title> in the first chunk
+    # is still found even though the rest of the stream is abandoned.
+    counter = {"bytes": 0}
+
+    def handler(request):
+        if str(request.url).startswith("https"):
+            raise httpx.ConnectError("no tls")
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "text/html"},
+            content=_endless_body(counter, head=b"<html><title>Jellyfin</title>"),
+        )
+
+    ctx, _ = _patch_client(handler)
+    with ctx:
+        result = await probe_port("10.0.0.5", 8096)
+    assert result["title"] == "Jellyfin"
+    assert counter["bytes"] <= _MAX_BODY_BYTES + _CHUNK_SIZE
 
 
 # ── probe_open_ports ─────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_probe_open_ports_enriches_each_port():
-    async def fake_get(self, url, **kw):
-        if ":8096" in url:
+    def handler(request):
+        if ":8096" in str(request.url):
             return _response("<title>Jellyfin</title>")
         return _response("")
 
     ports = [{"port": 8096, "protocol": "tcp"}, {"port": 9999, "protocol": "tcp"}]
-    with patch("httpx.AsyncClient.get", new=fake_get):
+    ctx, _ = _patch_client(handler)
+    with ctx:
         result = await probe_open_ports("10.0.0.5", ports)
 
     by_port = {p["port"]: p for p in result}

--- a/backend/tests/test_status_checker.py
+++ b/backend/tests/test_status_checker.py
@@ -1,6 +1,7 @@
 """Tests for status_checker service: each check method."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from app.services.status_checker import (
@@ -13,16 +14,31 @@ from app.services.status_checker import (
 )
 
 
+class _TransportClient:
+    """
+    Patch target for httpx.AsyncClient that routes through a MockTransport.
+
+    Real client, fake network: _http_get exercises the genuine httpx request
+    path (including .stream()) instead of a mock that would happily accept any
+    call shape.
+    """
+
+    def __init__(self, handler):
+        self._handler = handler
+        # Bound before patching, so building the real client here does not
+        # recurse back into this stand-in.
+        self._real = httpx.AsyncClient
+        self.kwargs = []
+
+    def __call__(self, **kwargs):
+        self.kwargs.append(dict(kwargs))
+        kwargs.pop("verify", None)
+        return self._real(transport=httpx.MockTransport(self._handler), **kwargs)
+
+
 def _mock_httpx_client(status_code):
     """Build a stand-in for httpx.AsyncClient whose GET returns status_code."""
-    resp = MagicMock()
-    resp.status_code = status_code
-    client = MagicMock()
-    client.get = AsyncMock(return_value=resp)
-    ctx = MagicMock()
-    ctx.__aenter__ = AsyncMock(return_value=client)
-    ctx.__aexit__ = AsyncMock(return_value=False)
-    return MagicMock(return_value=ctx)
+    return _TransportClient(lambda request: httpx.Response(status_code))
 
 # --- check_node dispatcher ---
 
@@ -553,6 +569,43 @@ async def test_check_services_empty_list():
 
 
 # --- _http_get status-code interpretation (real primitive, mocked transport) ---
+
+# --- Regression: an endless response body must not be buffered (issue #375) ---
+
+_CHUNK = b"\0" * 65536
+
+
+def _endless_body(counter: dict):
+    """
+    A body that never ends and declares no Content-Length — the Freebox
+    bandwidth-test endpoint from issue #375. Bounded at 512 chunks (32 MiB) so
+    a regression fails the test instead of hanging the suite forever.
+    """
+
+    async def gen():
+        for _ in range(512):
+            counter["chunks"] += 1
+            yield _CHUNK
+
+    return gen()
+
+
+@pytest.mark.asyncio
+async def test_http_get_does_not_read_the_body():
+    # _http_get only needs the status line. Buffering the body of an endless
+    # stream is what OOM-killed the backend, so assert not one byte is pulled.
+    counter = {"chunks": 0}
+    factory = _TransportClient(
+        lambda request: httpx.Response(
+            200,
+            headers={"Content-Type": "application/octet-stream"},
+            content=_endless_body(counter),
+        )
+    )
+    with patch("app.services.status_checker.httpx.AsyncClient", factory):
+        assert await _http_get("http://192.168.1.254:8095/") is True
+    assert counter["chunks"] == 0
+
 
 @pytest.mark.asyncio
 async def test_http_get_true_on_2xx():


### PR DESCRIPTION
## What

Two HTTP paths downloaded the entire response body before looking at it. An
endpoint that streams without end and sends no `Content-Length` — a Freebox
bandwidth-test port, an MJPEG camera, a log tail — made the backend grow until
the container memory limit killed it, every 5-10 minutes at a constant ~1.04 GB
RSS. Both paths now stream and stop early.

Root cause is not the timeout: httpx applies `timeout` per network operation,
not to the total time spent draining a socket that keeps delivering data. A
5-second timeout never fires on a socket that answers promptly and forever.

Fixes #375.

## Changes

Backend — status checker:
- `status_checker._http_get` only needs the status line, so it now uses
  `client.stream()` and never reads the body. The context manager closes the
  connection on exit without draining it. This covers all seven call sites
  (`http`, `https`, `health`, `prometheus` checks and the service checker).

Backend — deep-scan HTTP probe:
- `http_probe._probe_scheme` needs at most `_MAX_BODY_BYTES` (64 KiB) to hunt
  for a `<title>`, so it now streams via a new `_read_capped()` helper and drops
  the connection once it holds that much. The cap already existed but was
  applied to `resp.text`, i.e. after the full body had been downloaded — it
  bounded the regex scan, not the transfer.
- `_read_capped()` decodes with `resp.charset_encoding` (falling back to UTF-8,
  `errors="replace"`), since `resp.text` is not available on a streamed
  response.

No API, schema or migration changes. No behaviour change for well-behaved
endpoints: the same status codes and the same `<title>` / `Server` /
`X-Powered-By` signals come back.

## Testing

New regression tests, all four verified failing against the previous code:
- `test_http_get_does_not_read_the_body` — asserts zero chunks are pulled from
  an endless body.
- `test_probe_caps_the_download_of_an_endless_body` — asserts the transfer stays
  within `_MAX_BODY_BYTES` plus one chunk of overshoot.
- `test_probe_still_reads_a_title_from_an_endless_body` — stopping early must
  not cost the signal; a `<title>` in the first chunk is still found.

The endless bodies are served through an `httpx.MockTransport` and bounded at
512 chunks, so a regression fails the test instead of hanging the suite.

Existing test scaffolding was rebuilt: the old mocks patched
`httpx.AsyncClient.get`, which neither path calls any more. They now run against
a real `AsyncClient` over a `MockTransport` — real request path, fake network.
Every original assertion is kept; `test_probe_port_falls_back_to_http` and
`test_probe_port_skips_non_http_ports` now count actually-sent requests rather
than mock calls.

`ruff check`, `mypy app/` and the full `pytest` suite pass (122 tests).

ha-relevant: yes
