### PR TITLE
feat: import devices into a zone by subnet

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -494,6 +494,7 @@ async def init_db() -> None:
     await _backfill_node_devices()
     await _drop_legacy_node_columns()
     await _seed_node_views()
+    await _backfill_zone_size()
 
 
 
@@ -750,6 +751,66 @@ async def _seed_node_views() -> None:
                 logger.info("Seeded the service/property view of %d node(s)", seeded)
     except Exception as exc:  # pragma: no cover - defensive, boot must not die
         logger.warning("Seeding the node service/property views failed: %s", exc)
+
+
+async def _backfill_zone_size() -> None:
+    """Move a zone's size out of the custom_colors blob into the real columns.
+
+    Every node type stored its size in `nodes.width` / `nodes.height` except
+    `groupRect`, which stashed it inside the `custom_colors` JSON alongside its
+    colours. The serializer writes the columns for zones too now, so a canvas
+    saved before this upgrade would come back at the default 360x240 without
+    this backfill.
+
+    Only fills a column that is still NULL, so it cannot overwrite a size the
+    user has set since, and re-running it is a no-op. Parsed in Python rather
+    than with `json_extract`, so it does not depend on the SQLite build being
+    compiled with JSON1.
+
+    Never fatal: the reader falls back to the blob, so the worst case of a
+    failure here is that the geometry keeps coming from where it always did.
+    """
+    try:
+        async with engine.begin() as conn:
+            rows = (
+                await conn.exec_driver_sql(
+                    "SELECT id, custom_colors FROM nodes "
+                    "WHERE type = 'groupRect' AND custom_colors IS NOT NULL "
+                    "AND (width IS NULL OR height IS NULL)"
+                )
+            ).fetchall()
+
+            moved = 0
+            for node_id, blob in rows:
+                if isinstance(blob, str):
+                    try:
+                        blob = _json.loads(blob)
+                    except ValueError:
+                        continue
+                if not isinstance(blob, dict):
+                    continue
+
+                width, height = blob.get("width"), blob.get("height")
+                # A bool is an int in Python; a size that is not a real number
+                # is left alone rather than written as garbage.
+                if not isinstance(width, int | float) or isinstance(width, bool):
+                    width = None
+                if not isinstance(height, int | float) or isinstance(height, bool):
+                    height = None
+                if width is None and height is None:
+                    continue
+
+                await conn.exec_driver_sql(
+                    "UPDATE nodes SET width = COALESCE(width, ?), height = COALESCE(height, ?) "
+                    "WHERE id = ?",
+                    (width, height, node_id),
+                )
+                moved += 1
+
+            if moved:
+                logger.info("Moved the size of %d zone(s) to the width/height columns", moved)
+    except Exception as exc:  # pragma: no cover - defensive, boot must not die
+        logger.warning("Backfilling zone width/height failed: %s", exc)
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/backend/tests/test_zone_size_migration.py
+++ b/backend/tests/test_zone_size_migration.py
@@ -1,0 +1,139 @@
+"""Moving a zone's size out of the custom_colors blob into the real columns.
+
+Every node type stored its size in `nodes.width` / `nodes.height` except
+`groupRect`, which kept it inside the style JSON. Get this backfill wrong and
+every zone a user ever drew comes back at the default 360x240, losing a layout
+they arranged by hand.
+"""
+import json
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import app.db.database as database
+
+pytestmark = pytest.mark.asyncio
+
+_DDL = (
+    "CREATE TABLE nodes ("
+    "id VARCHAR PRIMARY KEY, type VARCHAR, label VARCHAR, "
+    "custom_colors JSON, width FLOAT, height FLOAT)"
+)
+
+
+async def _engine(tmp_path, rows):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'zones.db'}")
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(_DDL)
+        for node_id, node_type, colors, width, height in rows:
+            await conn.exec_driver_sql(
+                "INSERT INTO nodes (id, type, label, custom_colors, width, height) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (node_id, node_type, node_id, json.dumps(colors) if colors else None, width, height),
+            )
+    return engine
+
+
+async def _sizes(engine) -> dict[str, tuple]:
+    async with engine.begin() as conn:
+        rows = (await conn.exec_driver_sql("SELECT id, width, height FROM nodes")).fetchall()
+    return {r[0]: (r[1], r[2]) for r in rows}
+
+
+async def _run(engine, monkeypatch) -> None:
+    monkeypatch.setattr(database, "engine", engine)
+    await database._backfill_zone_size()
+
+
+async def test_moves_the_size_from_the_blob_to_the_columns(tmp_path, monkeypatch):
+    engine = await _engine(
+        tmp_path,
+        [("z1", "groupRect", {"width": 640, "height": 480, "border": "#0ff"}, None, None)],
+    )
+
+    await _run(engine, monkeypatch)
+
+    assert (await _sizes(engine))["z1"] == (640, 480)
+    # The style the blob actually owns is untouched.
+    async with engine.begin() as conn:
+        blob = (await conn.exec_driver_sql("SELECT custom_colors FROM nodes")).scalar()
+    assert json.loads(blob)["border"] == "#0ff"
+    await engine.dispose()
+
+
+async def test_never_overwrites_a_size_already_in_the_columns(tmp_path, monkeypatch):
+    # A zone resized since the upgrade: the column is the truth, and a stale
+    # blob left over from before must not win.
+    engine = await _engine(
+        tmp_path,
+        [("z1", "groupRect", {"width": 111, "height": 222}, 800, None)],
+    )
+
+    await _run(engine, monkeypatch)
+
+    assert (await _sizes(engine))["z1"] == (800, 222)
+    await engine.dispose()
+
+
+async def test_leaves_other_node_types_alone(tmp_path, monkeypatch):
+    # Only zones ever stashed their size in the blob. A width key on any other
+    # type is not geometry we should be moving.
+    engine = await _engine(tmp_path, [("s1", "server", {"width": 999}, None, None)])
+
+    await _run(engine, monkeypatch)
+
+    assert (await _sizes(engine))["s1"] == (None, None)
+    await engine.dispose()
+
+
+async def test_skips_a_blob_with_no_usable_size(tmp_path, monkeypatch):
+    engine = await _engine(
+        tmp_path,
+        [
+            ("colors_only", "groupRect", {"border": "#0ff"}, None, None),
+            ("not_a_number", "groupRect", {"width": "wide", "height": True}, None, None),
+            ("no_blob", "groupRect", None, None, None),
+        ],
+    )
+
+    await _run(engine, monkeypatch)
+
+    sizes = await _sizes(engine)
+    assert sizes["colors_only"] == (None, None)
+    assert sizes["not_a_number"] == (None, None)
+    assert sizes["no_blob"] == (None, None)
+    await engine.dispose()
+
+
+async def test_survives_a_corrupt_blob_without_killing_boot(tmp_path, monkeypatch):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'zones.db'}")
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(_DDL)
+        await conn.exec_driver_sql(
+            "INSERT INTO nodes (id, type, label, custom_colors) VALUES ('bad', 'groupRect', 'b', '{oops')"
+        )
+        await conn.exec_driver_sql(
+            "INSERT INTO nodes (id, type, label, custom_colors) "
+            "VALUES ('good', 'groupRect', 'g', '{\"width\": 500, \"height\": 400}')"
+        )
+
+    await _run(engine, monkeypatch)
+
+    sizes = await _sizes(engine)
+    assert sizes["bad"] == (None, None)
+    # One unreadable row must not cost the others their size.
+    assert sizes["good"] == (500, 400)
+    await engine.dispose()
+
+
+async def test_is_idempotent(tmp_path, monkeypatch):
+    engine = await _engine(
+        tmp_path,
+        [("z1", "groupRect", {"width": 640, "height": 480}, None, None)],
+    )
+
+    await _run(engine, monkeypatch)
+    await _run(engine, monkeypatch)
+
+    assert (await _sizes(engine))["z1"] == (640, 480)
+    await engine.dispose()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { parseYamlToCanvas } from '@/utils/importYaml'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Toaster } from '@/components/ui/sonner'
 import { toast } from 'sonner'
+import { isZoneSubnetCandidate } from '@/utils/subnet'
 import { CanvasContainer } from '@/components/canvas/CanvasContainer'
 import { Sidebar } from '@/components/panels/Sidebar'
 import { Toolbar } from '@/components/panels/Toolbar'
@@ -64,7 +65,7 @@ import { buildProxmoxClusterEdges } from '@/components/proxmox/clusterEdges'
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 
 export default function App() {
-  const { loadCanvas, applyLayout, markSaved, markUnsaved, hasUnsavedChanges, editSeq, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, editingTextId, setEditingTextId, nodes, edges, snapshotHistory, undo, redo, addToGroup, addToContainer, addToZone, floorMap, setFloorMap } = useCanvasStore()
+  const { loadCanvas, applyLayout, markSaved, markUnsaved, hasUnsavedChanges, editSeq, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, editingTextId, setEditingTextId, nodes, edges, snapshotHistory, undo, redo, addToGroup, addToContainer, addToZone, importZoneSubnet, floorMap, setFloorMap } = useCanvasStore()
   const canvasRef = useRef<HTMLDivElement>(null)
   const { isAuthenticated, isInitialized } = useAuthStore()
   const authBootstrapStarted = useRef(false)
@@ -526,6 +527,26 @@ export default function App() {
     toast.success(`Added "${data.label}"`)
   }, [addNode, nodes, snapshotHistory])
 
+  // Subnet import is a one-shot action on an existing zone, so on the Add modal
+  // there is no zone to run it against yet: the CIDR is held here and applied
+  // once, right after the zone is created. Cleared whenever that modal closes.
+  const pendingZoneSubnet = useRef<string | null>(null)
+
+  const countSubnetMatches = useCallback(
+    (cidr: string, zoneId?: string) =>
+      nodes.filter((n) => isZoneSubnetCandidate(n, cidr, zoneId)).length,
+    [nodes],
+  )
+
+  const reportSubnetImport = useCallback((moved: number, cidr: string) => {
+    if (moved === 0) toast.info(`No unparented device in ${cidr}`)
+    else toast.success(`Moved ${moved} device${moved > 1 ? 's' : ''} from ${cidr} into the zone`)
+  }, [])
+
+  const handleImportSubnetIntoZone = useCallback((zoneId: string, cidr: string) => {
+    reportSubnetImport(importZoneSubnet(zoneId, cidr), cidr)
+  }, [importZoneSubnet, reportSubnetImport])
+
   const handleAddGroupRect = useCallback((data: GroupRectFormData) => {
     snapshotHistory()
     const id = generateUUID()
@@ -556,7 +577,12 @@ export default function App() {
       zIndex: data.z_order - 10,
     }
     addNode(newNode)
-  }, [addNode, snapshotHistory])
+
+    const cidr = pendingZoneSubnet.current
+    pendingZoneSubnet.current = null
+    // addNode has already committed, so the zone is in the store by now.
+    if (cidr) reportSubnetImport(importZoneSubnet(id, cidr), cidr)
+  }, [addNode, snapshotHistory, importZoneSubnet, reportSubnetImport])
 
   const handleUpdateGroupRect = useCallback((data: GroupRectFormData) => {
     if (!editingGroupRectId) return
@@ -1190,8 +1216,11 @@ export default function App() {
 
         <GroupRectModal
           open={addGroupRectOpen}
-          onClose={() => setAddGroupRectOpen(false)}
+          onClose={() => { pendingZoneSubnet.current = null; setAddGroupRectOpen(false) }}
           onSubmit={handleAddGroupRect}
+          onImportSubnet={(cidr) => { pendingZoneSubnet.current = cidr }}
+          countSubnetMatches={(cidr) => countSubnetMatches(cidr)}
+          importOnSubmit
           title="Add Zone"
         />
 
@@ -1202,6 +1231,8 @@ export default function App() {
           onClose={() => setEditingGroupRectId(null)}
           onSubmit={handleUpdateGroupRect}
           onDelete={handleDeleteGroupRect}
+          onImportSubnet={(cidr) => { if (editingGroupRectId) handleImportSubnetIntoZone(editingGroupRectId, cidr) }}
+          countSubnetMatches={(cidr) => countSubnetMatches(cidr, editingGroupRectId ?? undefined)}
           initial={(() => {
             const n = editingGroupRectId ? nodes.find((nd) => nd.id === editingGroupRectId) : null
             if (!n) return undefined

--- a/frontend/src/components/modals/GroupRectModal.tsx
+++ b/frontend/src/components/modals/GroupRectModal.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import type { TextPosition } from '@/types'
 import { hexToRgba, rgbaToHex8 } from '@/utils/colorUtils'
+import { isValidCidr } from '@/utils/subnet'
 import styles from './GroupRectModal.module.css'
 
 export type BorderStyle = 'solid' | 'dashed' | 'dotted' | 'double' | 'none'
@@ -98,16 +99,51 @@ interface GroupRectModalProps {
   onDelete?: () => void
   initial?: Partial<GroupRectFormData>
   title?: string
+  /** Run the subnet import for a valid CIDR. Omit to hide the whole section. */
+  onImportSubnet?: (cidr: string) => void
+  /** How many unparented devices a CIDR would pull in — drives the preview line. */
+  countSubnetMatches?: (cidr: string) => number
+  /**
+   * Add mode: the zone does not exist yet, so there is nothing to import into
+   * until it is created. The CIDR is handed over on submit instead of via an
+   * Import button, which would otherwise look like it did nothing.
+   */
+  importOnSubmit?: boolean
 }
 
-export function GroupRectModal({ open, onClose, onSubmit, onDelete, initial, title = 'Add Zone' }: GroupRectModalProps) {
+export function GroupRectModal({
+  open,
+  onClose,
+  onSubmit,
+  onDelete,
+  initial,
+  title = 'Add Zone',
+  onImportSubnet,
+  countSubnetMatches,
+  importOnSubmit = false,
+}: GroupRectModalProps) {
   const [form, setForm] = useState<GroupRectFormData>({ ...DEFAULT_FORM, ...initial })
+  const [subnet, setSubnet] = useState('')
+
+  const cidrValid = isValidCidr(subnet)
+  const showCidrError = subnet.trim() !== '' && !cidrValid
+  const canImport = cidrValid && !!onImportSubnet
+  const matchCount = cidrValid && countSubnetMatches ? countSubnetMatches(subnet) : null
+
+  const handleImport = () => {
+    if (!canImport) return
+    onImportSubnet!(subnet)
+    setSubnet('')
+  }
 
   const set = <K extends keyof GroupRectFormData>(key: K, value: GroupRectFormData[K]) =>
     setForm((f) => ({ ...f, [key]: value }))
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    // Hand the CIDR over first: the caller queues it, then creates the zone and
+    // runs the import against it.
+    if (importOnSubmit && canImport) onImportSubnet!(subnet)
     onSubmit(form)
     onClose()
   }
@@ -354,6 +390,57 @@ export function GroupRectModal({ open, onClose, onSubmit, onDelete, initial, tit
           </div>
           </div>{/* ── end RIGHT column ── */}
           </div>{/* ── end 2-column grid ── */}
+
+          {/* ── Import devices by subnet ──
+              Deliberately NOT part of the form: the CIDR is an argument to a
+              one-shot action, never a property of the zone, so it is not
+              submitted, not persisted, and cleared after each run. */}
+          {onImportSubnet && (
+            <div className="flex flex-col gap-2 pt-3 border-t border-[#30363d]">
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                Import devices by subnet
+              </div>
+              <div className="flex gap-2">
+                <Input
+                  value={subnet}
+                  onChange={(e) => setSubnet(e.target.value)}
+                  placeholder="192.168.1.0/24"
+                  aria-label="Subnet"
+                  className={`bg-[#21262d] border-[#30363d] text-sm h-8 font-mono ${modalStyles['modal-radius']}`}
+                  style={showCidrError ? { borderColor: '#f85149' } : undefined}
+                  // Enter runs the import instead of submitting the whole form —
+                  // except in add mode, where submitting IS how the import runs.
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !importOnSubmit) {
+                      e.preventDefault()
+                      handleImport()
+                    }
+                  }}
+                />
+                {!importOnSubmit && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!canImport}
+                    className="cursor-pointer border-[#30363d] bg-[#21262d] shrink-0"
+                    onClick={handleImport}
+                  >
+                    Import
+                  </Button>
+                )}
+              </div>
+              <p className="text-[11px] text-muted-foreground/70">
+                {showCidrError
+                  ? <span className="text-[#f85149]">Not a valid IPv4 CIDR — try 192.168.1.0/24</span>
+                  : matchCount === null
+                    ? 'Moves every unparented device in that range into this zone. Nothing is removed.'
+                    : matchCount === 0
+                      ? 'No unparented device in that range.'
+                      : `${matchCount} device${matchCount > 1 ? 's' : ''} will move into this zone${importOnSubmit ? ' when you add it' : ''}.`}
+              </p>
+            </div>
+          )}
 
           <div className="flex justify-between gap-2 pt-1">
             {onDelete && (

--- a/frontend/src/components/modals/__tests__/GroupRectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/GroupRectModal.test.tsx
@@ -345,3 +345,110 @@ describe('GroupRectModal font label rendering', () => {
     expect(trigger.textContent).toContain('comic-sans-9000')
   })
 })
+
+describe('GroupRectModal — subnet import', () => {
+  const setup = (props: Partial<React.ComponentProps<typeof GroupRectModal>> = {}) => {
+    const onImportSubnet = vi.fn()
+    const onSubmit = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <GroupRectModal
+        open
+        onClose={onClose}
+        onSubmit={onSubmit}
+        onImportSubnet={onImportSubnet}
+        countSubnetMatches={() => 3}
+        title="Edit Zone"
+        {...props}
+      />
+    )
+    return { onImportSubnet, onSubmit, onClose }
+  }
+
+  it('hides the whole section when no import handler is given', () => {
+    render(<GroupRectModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
+    expect(screen.queryByText('Import devices by subnet')).toBeNull()
+  })
+
+  it('renders the field and disables Import until a CIDR is valid', () => {
+    setup()
+    const button = screen.getByRole('button', { name: 'Import' }) as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Subnet'), { target: { value: '192.168.1.0/24' } })
+    expect(button.disabled).toBe(false)
+  })
+
+  it('explains an invalid CIDR instead of silently doing nothing', () => {
+    setup()
+    fireEvent.change(screen.getByLabelText('Subnet'), { target: { value: '192.168.1.0/99' } })
+    expect(screen.getByText(/Not a valid IPv4 CIDR/)).toBeInTheDocument()
+    expect((screen.getByRole('button', { name: 'Import' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('previews how many devices would move', () => {
+    setup()
+    fireEvent.change(screen.getByLabelText('Subnet'), { target: { value: '192.168.1.0/24' } })
+    expect(screen.getByText('3 devices will move into this zone.')).toBeInTheDocument()
+  })
+
+  it('imports without submitting or closing the form, and clears the field', () => {
+    const { onImportSubnet, onSubmit, onClose } = setup()
+    const field = screen.getByLabelText('Subnet') as HTMLInputElement
+    fireEvent.change(field, { target: { value: '192.168.1.0/24' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    expect(onImportSubnet).toHaveBeenCalledWith('192.168.1.0/24')
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+    expect(field.value).toBe('')
+  })
+
+  it('runs the import on Enter rather than submitting the zone', () => {
+    const { onImportSubnet, onSubmit } = setup()
+    const field = screen.getByLabelText('Subnet')
+    fireEvent.change(field, { target: { value: '10.0.0.0/8' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+
+    expect(onImportSubnet).toHaveBeenCalledWith('10.0.0.0/8')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('never submits the CIDR as zone data — it is an argument, not a property', () => {
+    const { onSubmit } = setup()
+    fireEvent.change(screen.getByLabelText('Subnet'), { target: { value: '192.168.1.0/24' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(Object.keys(onSubmit.mock.calls[0][0])).not.toContain('subnet')
+  })
+
+  describe('add mode (importOnSubmit)', () => {
+    it('drops the Import button — there is no zone to import into yet', () => {
+      setup({ importOnSubmit: true, title: 'Add Zone' })
+      expect(screen.getByText('Import devices by subnet')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Import' })).toBeNull()
+    })
+
+    it('says the move happens on creation', () => {
+      setup({ importOnSubmit: true, title: 'Add Zone' })
+      fireEvent.change(screen.getByLabelText('Subnet'), { target: { value: '192.168.1.0/24' } })
+      expect(screen.getByText('3 devices will move into this zone when you add it.')).toBeInTheDocument()
+    })
+
+    it('hands the CIDR over before submitting, so the caller can apply it to the new zone', () => {
+      const { onImportSubnet, onSubmit } = setup({ importOnSubmit: true, title: 'Add Zone' })
+      fireEvent.change(screen.getByLabelText('Subnet'), { target: { value: '192.168.1.0/24' } })
+      fireEvent.click(screen.getByText('Add'))
+
+      expect(onImportSubnet).toHaveBeenCalledWith('192.168.1.0/24')
+      expect(onSubmit).toHaveBeenCalledOnce()
+      expect(onImportSubnet.mock.invocationCallOrder[0]).toBeLessThan(onSubmit.mock.invocationCallOrder[0])
+    })
+
+    it('submits normally when the field is left empty', () => {
+      const { onImportSubnet, onSubmit } = setup({ importOnSubmit: true, title: 'Add Zone' })
+      fireEvent.click(screen.getByText('Add'))
+      expect(onImportSubnet).not.toHaveBeenCalled()
+      expect(onSubmit).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { makeNode } from '@/test/factories'
+import { serializeNode, deserializeApiNode, type ApiNode } from '@/utils/canvasSerializer'
 
 function resetStore() {
   useCanvasStore.setState({
@@ -238,8 +239,14 @@ describe('canvasStore — importZoneSubnet', () => {
 
     const z = useCanvasStore.getState().nodes.find((n) => n.id === 'z1')!
     expect(z.height!).toBeGreaterThan(300)
-    // The renderer reads the persisted size back out of custom_colors.
-    expect(z.data.custom_colors?.height).toBe(z.height)
+
+    // The grown height has to survive a save/load round-trip. A zone has no
+    // height column, so the serializer stashes it in the custom_colors blob
+    // on the way out and hoists it back on the way in.
+    const wire = serializeNode(z) as { custom_colors: { height: number } }
+    expect(wire.custom_colors.height).toBe(z.height)
+    const reloaded = deserializeApiNode(wire as unknown as ApiNode, new Map())
+    expect(reloaded.height).toBe(z.height)
   })
 
   it('keeps the parent ahead of its new children, as React Flow requires', () => {

--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -133,3 +133,149 @@ describe('canvasStore — zone (groupRect) parenting', () => {
     expect(detached.position).toEqual({ x: 160, y: 220 })
   })
 })
+
+describe('canvasStore — importZoneSubnet', () => {
+  beforeEach(resetStore)
+
+  const device = (id: string, ip: string | undefined, over: Partial<ReturnType<typeof makeNode>> = {}) => ({
+    ...makeNode(id, { ip }),
+    position: { x: 900, y: 900 },
+    ...over,
+  })
+
+  it('moves every free device in range into the zone and reports the count', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), device('n1', '192.168.1.10'), device('n2', '192.168.1.11')],
+    })
+
+    const moved = useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+
+    expect(moved).toBe(2)
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBe('z1')
+    expect(nodes.find((n) => n.id === 'n2')!.parentId).toBe('z1')
+  })
+
+  it('leaves out-of-range and address-less devices on the canvas', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), device('in', '192.168.1.10'), device('out', '10.0.0.1'), device('bare', undefined)],
+    })
+
+    expect(useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')).toBe(1)
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'out')!.parentId).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'bare')!.parentId).toBeUndefined()
+  })
+
+  it('never steals a node that already has a parent', () => {
+    useCanvasStore.setState({
+      nodes: [
+        zone('z1'),
+        zone('z2', 800, 100),
+        { ...device('n1', '192.168.1.10'), parentId: 'z2' },
+      ],
+    })
+
+    expect(useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')).toBe(0)
+    expect(useCanvasStore.getState().nodes.find((n) => n.id === 'n1')!.parentId).toBe('z2')
+  })
+
+  it('never swallows another zone, even one carrying an IP', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), { ...zone('z2', 800, 100), data: { ...zone('z2').data, ip: '192.168.1.9' } }],
+    })
+
+    expect(useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')).toBe(0)
+    expect(useCanvasStore.getState().nodes.find((n) => n.id === 'z2')!.parentId).toBeUndefined()
+  })
+
+  it('is a no-op for an invalid CIDR, a missing zone and a non-zone target', () => {
+    useCanvasStore.setState({ nodes: [zone('z1'), device('n1', '192.168.1.10'), device('plain', '192.168.1.11')] })
+    const before = useCanvasStore.getState().nodes
+
+    expect(useCanvasStore.getState().importZoneSubnet('z1', 'nonsense')).toBe(0)
+    expect(useCanvasStore.getState().importZoneSubnet('nope', '192.168.1.0/24')).toBe(0)
+    expect(useCanvasStore.getState().importZoneSubnet('plain', '192.168.1.0/24')).toBe(0)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+
+  it('lays arrivals out on a non-overlapping grid inside the zone', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), device('n1', '192.168.1.10'), device('n2', '192.168.1.11')],
+    })
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+
+    const nodes = useCanvasStore.getState().nodes
+    const a = nodes.find((n) => n.id === 'n1')!.position
+    const b = nodes.find((n) => n.id === 'n2')!.position
+    expect(a).not.toEqual(b)
+    // Zone-relative and clear of the label band at the top.
+    for (const p of [a, b]) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeGreaterThanOrEqual(40)
+    }
+  })
+
+  it('packs around the boxes already inside the zone', () => {
+    useCanvasStore.setState({
+      nodes: [
+        zone('z1'),
+        { ...device('sitting', '10.0.0.1'), parentId: 'z1', position: { x: 16, y: 40 }, width: 160, height: 90 },
+        device('n1', '192.168.1.10'),
+      ],
+    })
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+
+    const placed = useCanvasStore.getState().nodes.find((n) => n.id === 'n1')!.position
+    expect(placed).not.toEqual({ x: 16, y: 40 })
+  })
+
+  it('grows the zone when the arrivals overflow its height', () => {
+    const many = Array.from({ length: 12 }, (_, i) => device(`n${i}`, `192.168.1.${i + 10}`))
+    useCanvasStore.setState({ nodes: [zone('z1'), ...many] })
+
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+
+    const z = useCanvasStore.getState().nodes.find((n) => n.id === 'z1')!
+    expect(z.height!).toBeGreaterThan(300)
+    // The renderer reads the persisted size back out of custom_colors.
+    expect(z.data.custom_colors?.height).toBe(z.height)
+  })
+
+  it('keeps the parent ahead of its new children, as React Flow requires', () => {
+    useCanvasStore.setState({
+      nodes: [device('n1', '192.168.1.10'), zone('z1'), device('n2', '192.168.1.11')],
+    })
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+
+    const ids = useCanvasStore.getState().nodes.map((n) => n.id)
+    expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('n1'))
+    expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('n2'))
+  })
+
+  it('is additive: a second subnet keeps the first import inside', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), device('n1', '192.168.1.10'), device('n2', '10.0.0.5')],
+    })
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+    useCanvasStore.getState().importZoneSubnet('z1', '10.0.0.0/8')
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBe('z1')
+    expect(nodes.find((n) => n.id === 'n2')!.parentId).toBe('z1')
+  })
+
+  it('marks the canvas unsaved and undoes the whole import in one step', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), device('n1', '192.168.1.10'), device('n2', '192.168.1.11')],
+    })
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+    expect(useCanvasStore.getState().hasUnsavedChanges).toBe(true)
+
+    useCanvasStore.getState().undo()
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'n2')!.parentId).toBeUndefined()
+  })
+})

--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -240,12 +240,10 @@ describe('canvasStore — importZoneSubnet', () => {
     const z = useCanvasStore.getState().nodes.find((n) => n.id === 'z1')!
     expect(z.height!).toBeGreaterThan(300)
 
-    // The grown height has to survive a save/load round-trip. A zone has no
-    // height column, so the serializer stashes it in the custom_colors blob
-    // on the way out and hoists it back on the way in.
-    const wire = serializeNode(z) as { custom_colors: { height: number } }
-    expect(wire.custom_colors.height).toBe(z.height)
-    const reloaded = deserializeApiNode(wire as unknown as ApiNode, new Map())
+    // The grown height has to survive a save/load round-trip.
+    const wire = serializeNode(z) as unknown as ApiNode
+    expect(wire.height).toBe(z.height)
+    const reloaded = deserializeApiNode(wire, new Map())
     expect(reloaded.height).toBe(z.height)
   })
 

--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -253,6 +253,40 @@ describe('canvasStore — importZoneSubnet', () => {
     expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('n2'))
   })
 
+  it('keeps an arrival that is itself a parent ahead of the children it leaves behind', () => {
+    // A Proxmox host matches the subnet; its VM does not move, because it
+    // already has a parent. The host must still be listed before the VM.
+    useCanvasStore.setState({
+      nodes: [
+        device('proxmox', '192.168.1.10'),
+        { ...device('vm1', '10.0.0.1'), parentId: 'proxmox' },
+        zone('z1'),
+      ],
+    })
+
+    expect(useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')).toBe(1)
+
+    const nodes = useCanvasStore.getState().nodes
+    const ids = nodes.map((n) => n.id)
+    expect(nodes.find((n) => n.id === 'proxmox')!.parentId).toBe('z1')
+    expect(nodes.find((n) => n.id === 'vm1')!.parentId).toBe('proxmox')
+    expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('proxmox'))
+    expect(ids.indexOf('proxmox')).toBeLessThan(ids.indexOf('vm1'))
+  })
+
+  it('leaves an already-valid order untouched', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), device('a', '10.0.0.1'), device('b', '10.0.0.2'), device('hit', '192.168.1.10')],
+    })
+    useCanvasStore.getState().importZoneSubnet('z1', '192.168.1.0/24')
+
+    // Only the matched node moves in the array; the untouched ones keep their
+    // relative order.
+    const ids = useCanvasStore.getState().nodes.map((n) => n.id)
+    expect(ids.indexOf('a')).toBeLessThan(ids.indexOf('b'))
+    expect(ids[0]).toBe('z1')
+  })
+
   it('is additive: a second subnet keeps the first import inside', () => {
     useCanvasStore.setState({
       nodes: [zone('z1'), device('n1', '192.168.1.10'), device('n2', '10.0.0.5')],

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -1072,9 +1072,8 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
 
     set((s) => {
       const updated = s.nodes.map((n) => {
-        // `height` is the only live field: the serializer stashes it into the
-        // custom_colors blob on save, since the nodes table has no height
-        // column for a zone, and hoists it back out on load.
+        // `height` is the only field to write: the serializer persists it to
+        // the real `nodes.height` column, and keeps it out of the style blob.
         if (n.id === zoneId) {
           return grownHeight === zoneHeight ? n : { ...n, height: grownHeight }
         }

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -1072,17 +1072,11 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
 
     set((s) => {
       const updated = s.nodes.map((n) => {
+        // `height` is the only live field: the serializer stashes it into the
+        // custom_colors blob on save, since the nodes table has no height
+        // column for a zone, and hoists it back out on load.
         if (n.id === zoneId) {
-          return grownHeight === zoneHeight
-            ? n
-            : {
-                ...n,
-                height: grownHeight,
-                data: {
-                  ...n.data,
-                  custom_colors: { ...(n.data.custom_colors ?? {}), height: grownHeight },
-                },
-              }
+          return grownHeight === zoneHeight ? n : { ...n, height: grownHeight }
         }
         const at = placements.get(n.id)
         if (!at) return n

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -14,6 +14,7 @@ import { generateUUID } from '@/utils/uuid'
 import { normalizeHandle, removedHandleIds, handleCountField, sideDefault, handleId, SIDES } from '@/utils/handleUtils'
 import { applyOpacity } from '@/utils/colorUtils'
 import { readHideIp, writeHideIp } from '@/utils/ipDisplay'
+import { isValidCidr, isZoneSubnetCandidate } from '@/utils/subnet'
 import { CONTAINER_MODE_TYPES } from '@/utils/virtualEdgeParent'
 import {
   changedFactFields,
@@ -28,6 +29,18 @@ type Clipboard = { nodes: Node<NodeData>[]; edges: Edge<EdgeData>[] }
 
 /** Resolve a node's effective parent id from either the RF field or domain data. */
 const parentIdOf = (n: Node<NodeData>): string | undefined => n.parentId ?? n.data.parent_id ?? undefined
+
+// Zone subnet import: the grid the arrivals are packed on, in zone-relative
+// pixels. A cell is one node box plus the gap that follows it.
+const DEFAULT_ZONE_WIDTH = 360
+const DEFAULT_ZONE_HEIGHT = 240
+const ZONE_CELL_W = 180
+const ZONE_CELL_H = 110
+const ZONE_CELL_GAP = 20
+const ZONE_PAD_X = 32
+// Leaves the label band at the top of the zone clear.
+const ZONE_PAD_TOP = 40
+const ZONE_PAD_BOTTOM = 16
 
 /**
  * Whether a node change represents a real user edit that should dirty the canvas.
@@ -198,6 +211,9 @@ interface CanvasState {
   addToGroup: (groupId: string, childId: string) => void
   addToContainer: (containerId: string, childId: string) => void
   addToZone: (zoneId: string, childId: string) => void
+  /** Move every free node whose IP falls in `cidr` into the zone. Returns the
+   *  count moved; 0 for an invalid CIDR or no match. */
+  importZoneSubnet: (zoneId: string, cidr: string) => number
   removeFromGroup: (groupId: string, childId: string) => void
   markSaved: () => void
   markUnsaved: () => void
@@ -218,7 +234,7 @@ interface CanvasState {
   applyAllCustomStyles: (def: CustomStyleDef) => void
 }
 
-export const useCanvasStore = create<CanvasState>((rawSet) => {
+export const useCanvasStore = create<CanvasState>((rawSet, get) => {
   // Wrap set so any update that flips hasUnsavedChanges to true also bumps
   // editSeq. This centralises the "an edit happened" signal instead of touching
   // every one of the ~two dozen mutating actions. Actions that update state
@@ -968,6 +984,106 @@ export const useCanvasStore = create<CanvasState>((rawSet) => {
         future: [],
       }
     }),
+
+  // Pull every free node whose IP falls inside `cidr` into a zone, laying them
+  // out on a grid in the zone's free space. Deliberately additive and one-shot:
+  // the CIDR is never stored, nothing is ever ejected, and running it twice with
+  // two subnets leaves both sets inside. Undo reverses the whole import at once.
+  importZoneSubnet: (zoneId, cidr) => {
+    const state = get()
+    const zone = state.nodes.find((n) => n.id === zoneId)
+    if (!zone || zone.data.type !== 'groupRect') return 0
+    if (!isValidCidr(cidr)) return 0
+
+    const matches = state.nodes.filter((n) => isZoneSubnetCandidate(n, cidr, zoneId))
+    if (matches.length === 0) return 0
+
+    const moved = new Set(matches.map((n) => n.id))
+    const zoneWidth = zone.width ?? DEFAULT_ZONE_WIDTH
+    const zoneHeight = zone.height ?? DEFAULT_ZONE_HEIGHT
+
+    // Boxes already inside the zone, in zone-relative coordinates. New arrivals
+    // are packed around them rather than on top of them.
+    const occupied = state.nodes
+      .filter((n) => n.parentId === zoneId && !moved.has(n.id))
+      .map((n) => ({
+        x: n.position.x,
+        y: n.position.y,
+        w: n.width ?? ZONE_CELL_W - ZONE_CELL_GAP,
+        h: n.height ?? ZONE_CELL_H - ZONE_CELL_GAP,
+      }))
+
+    const columns = Math.max(1, Math.floor((zoneWidth - ZONE_PAD_X) / ZONE_CELL_W))
+    const overlaps = (x: number, y: number) =>
+      occupied.some(
+        (b) =>
+          x < b.x + b.w &&
+          x + ZONE_CELL_W - ZONE_CELL_GAP > b.x &&
+          y < b.y + b.h &&
+          y + ZONE_CELL_H - ZONE_CELL_GAP > b.y,
+      )
+
+    // Row-major scan for the first free cell per arrival. Rows keep going past
+    // the current height; the zone grows at the end to cover the last one used.
+    const placements = new Map<string, { x: number; y: number }>()
+    let cursor = 0
+    let maxBottom = 0
+    for (const node of matches) {
+      let x = 0
+      let y = 0
+      for (;;) {
+        x = ZONE_PAD_X / 2 + (cursor % columns) * ZONE_CELL_W
+        y = ZONE_PAD_TOP + Math.floor(cursor / columns) * ZONE_CELL_H
+        cursor += 1
+        if (!overlaps(x, y)) break
+      }
+      placements.set(node.id, { x, y })
+      occupied.push({ x, y, w: ZONE_CELL_W - ZONE_CELL_GAP, h: ZONE_CELL_H - ZONE_CELL_GAP })
+      maxBottom = Math.max(maxBottom, y + ZONE_CELL_H)
+    }
+
+    const grownHeight = Math.max(zoneHeight, maxBottom + ZONE_PAD_BOTTOM)
+
+    set((s) => {
+      const updated = s.nodes.map((n) => {
+        if (n.id === zoneId) {
+          return grownHeight === zoneHeight
+            ? n
+            : {
+                ...n,
+                height: grownHeight,
+                data: {
+                  ...n.data,
+                  custom_colors: { ...(n.data.custom_colors ?? {}), height: grownHeight },
+                },
+              }
+        }
+        const at = placements.get(n.id)
+        if (!at) return n
+        return {
+          ...n,
+          parentId: zoneId,
+          position: at,
+          selected: false,
+          data: { ...n.data, parent_id: zoneId },
+        }
+      })
+
+      // React Flow requires a parent to precede its children in the array.
+      const others = updated.filter((n) => !moved.has(n.id))
+      const children = updated.filter((n) => moved.has(n.id))
+      const zoneIdx = others.findIndex((n) => n.id === zoneId)
+
+      return {
+        nodes: [...others.slice(0, zoneIdx + 1), ...children, ...others.slice(zoneIdx + 1)],
+        hasUnsavedChanges: true,
+        past: [...s.past.slice(-49), { nodes: s.nodes, edges: s.edges }],
+        future: [],
+      }
+    })
+
+    return matches.length
+  },
 
   // Release a single child from a group back to the canvas. Group stays.
   removeFromGroup: (groupId, childId) =>

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -30,6 +30,32 @@ type Clipboard = { nodes: Node<NodeData>[]; edges: Edge<EdgeData>[] }
 /** Resolve a node's effective parent id from either the RF field or domain data. */
 const parentIdOf = (n: Node<NodeData>): string | undefined => n.parentId ?? n.data.parent_id ?? undefined
 
+/**
+ * Reorder so every node follows its parent, which is what React Flow needs to
+ * resolve nesting — a child listed first renders detached and logs a
+ * parent-not-found error. Order is otherwise preserved: a list that is already
+ * valid comes back untouched. A parent cycle terminates instead of recursing.
+ */
+function orderParentsFirst(nodes: Node<NodeData>[]): Node<NodeData>[] {
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const emitted = new Set<string>()
+  const visiting = new Set<string>()
+  const out: Node<NodeData>[] = []
+
+  const visit = (n: Node<NodeData>) => {
+    if (emitted.has(n.id) || visiting.has(n.id)) return
+    visiting.add(n.id)
+    const parent = n.parentId ? byId.get(n.parentId) : undefined
+    if (parent) visit(parent)
+    visiting.delete(n.id)
+    emitted.add(n.id)
+    out.push(n)
+  }
+
+  for (const n of nodes) visit(n)
+  return out
+}
+
 // Zone subnet import: the grid the arrivals are packed on, in zone-relative
 // pixels. A cell is one node box plus the gap that follows it.
 const DEFAULT_ZONE_WIDTH = 360
@@ -1069,13 +1095,13 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
         }
       })
 
-      // React Flow requires a parent to precede its children in the array.
-      const others = updated.filter((n) => !moved.has(n.id))
-      const children = updated.filter((n) => moved.has(n.id))
-      const zoneIdx = others.findIndex((n) => n.id === zoneId)
-
       return {
-        nodes: [...others.slice(0, zoneIdx + 1), ...children, ...others.slice(zoneIdx + 1)],
+        // React Flow requires a parent to precede its children in the array.
+        // Reordering the whole list covers both directions at once: the zone
+        // ahead of its new children, and an arrival that is itself a parent
+        // (a Proxmox host with nested VMs, whose children stay put because
+        // they already have a parent) ahead of the children it left behind.
+        nodes: orderParentsFirst(updated),
         hasUnsavedChanges: true,
         past: [...s.past.slice(-49), { nodes: s.nodes, edges: s.edges }],
         future: [],

--- a/frontend/src/utils/__tests__/canvasSerializer.test.ts
+++ b/frontend/src/utils/__tests__/canvasSerializer.test.ts
@@ -165,7 +165,7 @@ describe('serializeNode — regular node', () => {
 // ── serializeNode — groupRect ─────────────────────────────────────────────────
 
 describe('serializeNode — groupRect', () => {
-  it('stores dimensions inside custom_colors', () => {
+  it('stores dimensions in the width/height columns, like every other node type', () => {
     const node = makeRfNode({
       type: 'groupRect',
       data: { label: 'Zone A', type: 'groupRect', status: 'unknown', services: [] },
@@ -173,8 +173,25 @@ describe('serializeNode — groupRect', () => {
       height: 250,
     })
     const result = serializeNode(node)
-    expect((result.custom_colors as Record<string, unknown>).width).toBe(400)
-    expect((result.custom_colors as Record<string, unknown>).height).toBe(250)
+    expect(result.width).toBe(400)
+    expect(result.height).toBe(250)
+  })
+
+  it('keeps the size out of the style blob, so the two cannot drift apart', () => {
+    const node = makeRfNode({
+      type: 'groupRect',
+      // A zone loaded before the move still carries the legacy keys in memory.
+      data: {
+        label: 'Z', type: 'groupRect', status: 'unknown', services: [],
+        custom_colors: { border: '#aaa', width: 111, height: 222 },
+      },
+      width: 400,
+      height: 250,
+    })
+    const cc = serializeNode(node).custom_colors as Record<string, unknown>
+    expect(cc.width).toBeUndefined()
+    expect(cc.height).toBeUndefined()
+    expect(cc.border).toBe('#aaa')
   })
 
   it('prefers explicit width/height over measured, falling back to measured per-axis', () => {
@@ -184,15 +201,15 @@ describe('serializeNode — groupRect', () => {
     }
     const result = serializeNode(node)
     // Explicit width wins; height has no explicit value so it uses measured.
-    expect((result.custom_colors as Record<string, unknown>).width).toBe(400)
-    expect((result.custom_colors as Record<string, unknown>).height).toBe(260)
+    expect(result.width).toBe(400)
+    expect(result.height).toBe(260)
   })
 
   it('falls back to defaults when no dimensions available', () => {
     const node = makeRfNode({ type: 'groupRect', data: { label: 'Z', type: 'groupRect', status: 'unknown', services: [] } })
     const result = serializeNode(node)
-    expect((result.custom_colors as Record<string, unknown>).width).toBe(360)
-    expect((result.custom_colors as Record<string, unknown>).height).toBe(240)
+    expect(result.width).toBe(360)
+    expect(result.height).toBe(240)
   })
 
   it('preserves existing custom_colors fields alongside dimensions', () => {
@@ -205,8 +222,8 @@ describe('serializeNode — groupRect', () => {
     const cc = result.custom_colors as Record<string, unknown>
     expect(cc.border).toBe('#aaa')
     expect(cc.z_order).toBe(2)
-    expect(cc.width).toBe(300)
-    expect(cc.height).toBe(200)
+    expect(result.width).toBe(300)
+    expect(result.height).toBe(200)
   })
 })
 
@@ -420,9 +437,9 @@ describe('deserializeApiNode — regular node', () => {
 describe('deserializeApiNode — groupRect', () => {
   const emptyMap = new Map<string, boolean>()
 
-  it('restores width/height from custom_colors', () => {
+  it('restores width/height from the columns', () => {
     const result = deserializeApiNode(
-      makeApiNode({ type: 'groupRect', custom_colors: { width: 400, height: 250, z_order: 2 } }),
+      makeApiNode({ type: 'groupRect', width: 400, height: 250, custom_colors: { z_order: 2 } }),
       emptyMap,
     )
     expect(result.width).toBe(400)
@@ -430,7 +447,27 @@ describe('deserializeApiNode — groupRect', () => {
     expect(result.zIndex).toBe(-8)
   })
 
-  it('defaults to 360x240 when custom_colors has no dimensions', () => {
+  it('still reads a legacy canvas that kept its size in custom_colors', () => {
+    // Saved before the size moved to the columns, and not yet migrated: no
+    // fallback here means the zone comes back at the default 360x240.
+    const result = deserializeApiNode(
+      makeApiNode({ type: 'groupRect', custom_colors: { width: 400, height: 250, z_order: 2 } }),
+      emptyMap,
+    )
+    expect(result.width).toBe(400)
+    expect(result.height).toBe(250)
+  })
+
+  it('lets the columns win over a stale legacy blob', () => {
+    const result = deserializeApiNode(
+      makeApiNode({ type: 'groupRect', width: 500, height: 300, custom_colors: { width: 111, height: 222 } }),
+      emptyMap,
+    )
+    expect(result.width).toBe(500)
+    expect(result.height).toBe(300)
+  })
+
+  it('defaults to 360x240 when neither source has dimensions', () => {
     const result = deserializeApiNode(makeApiNode({ type: 'groupRect' }), emptyMap)
     expect(result.width).toBe(360)
     expect(result.height).toBe(240)

--- a/frontend/src/utils/__tests__/subnet.test.ts
+++ b/frontend/src/utils/__tests__/subnet.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { ipToInt, parseCidr, isValidCidr, ipInSubnet, isZoneSubnetCandidate } from '@/utils/subnet'
+
+describe('ipToInt', () => {
+  it('converts a dotted quad', () => {
+    expect(ipToInt('0.0.0.0')).toBe(0)
+    expect(ipToInt('255.255.255.255')).toBe(4294967295)
+    expect(ipToInt('192.168.1.42')).toBe(3232235818)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(ipToInt('  10.0.0.1  ')).toBe(ipToInt('10.0.0.1'))
+  })
+
+  it('rejects malformed addresses', () => {
+    for (const bad of ['', '1.2.3', '1.2.3.4.5', '256.0.0.1', '1.2.3.-1', 'a.b.c.d', '1.2.3.4/24', '::1']) {
+      expect(ipToInt(bad)).toBeNull()
+    }
+  })
+})
+
+describe('parseCidr', () => {
+  it('masks the host bits off, so any address in the range parses to the network', () => {
+    expect(parseCidr('192.168.1.42/24')).toEqual(parseCidr('192.168.1.0/24'))
+  })
+
+  it('treats a bare address as /32', () => {
+    expect(parseCidr('10.0.0.7')).toEqual({ base: ipToInt('10.0.0.7'), bits: 32 })
+  })
+
+  it('handles /0 without the shift wrapping to -1', () => {
+    expect(parseCidr('0.0.0.0/0')).toEqual({ base: 0, bits: 0 })
+    expect(parseCidr('192.168.1.1/0')).toEqual({ base: 0, bits: 0 })
+  })
+
+  it('rejects junk', () => {
+    for (const bad of ['', '   ', '192.168.1.0/33', '192.168.1.0/x', '192.168.1.0/24/8', '192.168.1.0/', 'not-an-ip/24']) {
+      expect(parseCidr(bad)).toBeNull()
+    }
+  })
+
+  it('rejects IPv6 — out of scope, so the UI can say why', () => {
+    expect(parseCidr('2001:db8::/32')).toBeNull()
+    expect(isValidCidr('2001:db8::/32')).toBe(false)
+  })
+})
+
+describe('ipInSubnet', () => {
+  it('matches inside a /24 and rejects the neighbours', () => {
+    expect(ipInSubnet('192.168.1.1', '192.168.1.0/24')).toBe(true)
+    expect(ipInSubnet('192.168.1.255', '192.168.1.0/24')).toBe(true)
+    expect(ipInSubnet('192.168.2.1', '192.168.1.0/24')).toBe(false)
+    expect(ipInSubnet('192.168.0.255', '192.168.1.0/24')).toBe(false)
+  })
+
+  it('honours wider and narrower prefixes', () => {
+    expect(ipInSubnet('10.4.9.2', '10.0.0.0/8')).toBe(true)
+    expect(ipInSubnet('11.4.9.2', '10.0.0.0/8')).toBe(false)
+    expect(ipInSubnet('10.0.0.7', '10.0.0.7/32')).toBe(true)
+    expect(ipInSubnet('10.0.0.8', '10.0.0.7/32')).toBe(false)
+    expect(ipInSubnet('8.8.8.8', '0.0.0.0/0')).toBe(true)
+  })
+
+  it('strips a prefix or port suffix off the node address', () => {
+    expect(ipInSubnet('192.168.1.5/24', '192.168.1.0/24')).toBe(true)
+    expect(ipInSubnet('192.168.1.5:8006', '192.168.1.0/24')).toBe(true)
+  })
+
+  it('never matches a missing or unparseable address', () => {
+    expect(ipInSubnet(undefined, '192.168.1.0/24')).toBe(false)
+    expect(ipInSubnet(null, '192.168.1.0/24')).toBe(false)
+    expect(ipInSubnet('', '192.168.1.0/24')).toBe(false)
+    expect(ipInSubnet('fe80::1', '192.168.1.0/24')).toBe(false)
+  })
+
+  it('never matches against an invalid CIDR', () => {
+    expect(ipInSubnet('192.168.1.5', 'nonsense')).toBe(false)
+  })
+})
+
+describe('isZoneSubnetCandidate', () => {
+  const node = (over: Partial<{ id: string; parentId?: string; type: string; ip?: string }> = {}) => ({
+    id: over.id ?? 'n1',
+    parentId: over.parentId,
+    data: { type: over.type ?? 'server', ip: 'ip' in over ? over.ip : '192.168.1.5' },
+  })
+
+  it('accepts a free, addressed device in range', () => {
+    expect(isZoneSubnetCandidate(node(), '192.168.1.0/24', 'z1')).toBe(true)
+  })
+
+  it('leaves an already-parented node with the parent the user gave it', () => {
+    expect(isZoneSubnetCandidate(node({ parentId: 'g1' }), '192.168.1.0/24', 'z1')).toBe(false)
+  })
+
+  it('skips canvas furniture', () => {
+    for (const type of ['groupRect', 'group', 'text']) {
+      expect(isZoneSubnetCandidate(node({ type }), '192.168.1.0/24', 'z1')).toBe(false)
+    }
+  })
+
+  it('never treats the zone itself as a candidate', () => {
+    expect(isZoneSubnetCandidate(node({ id: 'z1', type: 'server' }), '192.168.1.0/24', 'z1')).toBe(false)
+  })
+
+  it('rejects an out-of-range or address-less node', () => {
+    expect(isZoneSubnetCandidate(node({ ip: '10.0.0.1' }), '192.168.1.0/24', 'z1')).toBe(false)
+    expect(isZoneSubnetCandidate(node({ ip: undefined }), '192.168.1.0/24', 'z1')).toBe(false)
+  })
+})

--- a/frontend/src/utils/canvasSerializer.ts
+++ b/frontend/src/utils/canvasSerializer.ts
@@ -64,6 +64,18 @@ export interface ApiEdge {
 
 // ── Serialization (RF node → API save payload) ───────────────────────────────
 
+/** Drop the legacy geometry keys from a zone's style blob — its size lives in
+ *  the `width`/`height` columns now, and a stale copy here would be the one an
+ *  older canvas reads back. */
+function omitZoneSize(
+  colors: NodeData['custom_colors'],
+): Record<string, unknown> {
+  if (!colors) return {}
+  return Object.fromEntries(
+    Object.entries(colors).filter(([key]) => key !== 'width' && key !== 'height'),
+  )
+}
+
 export function serializeNode(
   n: Node<NodeData>,
   factsBaseline?: FactsBaseline,
@@ -89,10 +101,14 @@ export function serializeNode(
       custom_icon: null,
       pos_x: n.position.x,
       pos_y: n.position.y,
+      // A zone's size goes in the real columns, like every other node type.
+      // It used to live in the custom_colors blob; `width`/`height` are
+      // stripped from it below so the two cannot drift apart, and a canvas
+      // saved before the change is migrated by `_backfill_zone_size`.
+      width: n.width ?? n.measured?.width ?? 360,
+      height: n.height ?? n.measured?.height ?? 240,
       custom_colors: {
-        ...n.data.custom_colors,
-        width: n.width ?? n.measured?.width ?? 360,
-        height: n.height ?? n.measured?.height ?? 240,
+        ...omitZoneSize(n.data.custom_colors),
         // Stash collapse state inside custom_colors so the API/YAML blob does
         // not need a new column. Hoisted back to `data.collapsed` on load.
         collapsed: n.data.collapsed ?? false,
@@ -182,8 +198,11 @@ export function deserializeApiNode(
 ): Node<NodeData> {
   const normalizedType = n.type === 'docker' ? 'docker_host' : n.type
   if (n.type === 'groupRect') {
-    const w = (n.custom_colors?.width as number | undefined) ?? 360
-    const h = (n.custom_colors?.height as number | undefined) ?? 240
+    // Prefer the real columns; fall back to the custom_colors stash for a
+    // canvas saved before the size moved out of it, and which the backend
+    // backfill has not reached (a payload from an older server, an import).
+    const w = n.width ?? (n.custom_colors?.width as number | undefined) ?? 360
+    const h = n.height ?? (n.custom_colors?.height as number | undefined) ?? 240
     const z = (n.custom_colors?.z_order as number | undefined) ?? 1
     // Hoist persisted collapse flag from the custom_colors stash to a
     // first-class field on NodeData. Tolerates legacy saves that already had

--- a/frontend/src/utils/subnet.ts
+++ b/frontend/src/utils/subnet.ts
@@ -1,0 +1,105 @@
+/**
+ * IPv4 subnet matching, used by the zone "Import devices by subnet" action.
+ *
+ * IPv4 only on purpose: a homelab zone is drawn around a LAN segment, and the
+ * canvas has no IPv6 grouping story yet. `isValidCidr` rejects an IPv6 CIDR so
+ * the modal can say why instead of silently matching nothing.
+ */
+
+/** A parsed CIDR: the network address as a 32-bit int, plus the prefix length. */
+export interface ParsedCidr {
+  base: number
+  bits: number
+}
+
+/**
+ * "192.168.1.42" → 3232235818. Null for anything that is not four decimal
+ * octets in 0..255 — no leading zeros, no shorthand.
+ */
+export function ipToInt(ip: string): number | null {
+  const parts = ip.trim().split('.')
+  if (parts.length !== 4) return null
+  let acc = 0
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null
+    const n = Number(part)
+    if (n > 255) return null
+    acc = acc * 256 + n
+  }
+  return acc
+}
+
+/**
+ * Parse "192.168.1.0/24". The host bits of the given address are masked off, so
+ * "192.168.1.42/24" and "192.168.1.0/24" parse to the same network.
+ *
+ * A bare address with no "/" is treated as /32 — one host.
+ */
+export function parseCidr(cidr: string): ParsedCidr | null {
+  const trimmed = cidr.trim()
+  if (!trimmed) return null
+
+  const [addr, prefix, ...rest] = trimmed.split('/')
+  if (rest.length > 0) return null
+
+  const ip = ipToInt(addr)
+  if (ip === null) return null
+
+  let bits = 32
+  if (prefix !== undefined) {
+    if (!/^\d{1,2}$/.test(prefix)) return null
+    bits = Number(prefix)
+    if (bits > 32) return null
+  }
+
+  // A /0 mask would be `-1 << 32`, which JS evaluates as `-1 << 0` = -1 — the
+  // shift count wraps mod 32. Special-cased so "0.0.0.0/0" matches everything.
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0
+  return { base: (ip & mask) >>> 0, bits }
+}
+
+export function isValidCidr(cidr: string): boolean {
+  return parseCidr(cidr) !== null
+}
+
+/**
+ * Does `ip` fall inside `cidr`?
+ *
+ * `ip` comes straight off node data, so it may carry a prefix ("10.0.0.5/24")
+ * or a port ("10.0.0.5:8006"); both suffixes are stripped. Missing or
+ * unparseable addresses never match.
+ */
+export function ipInSubnet(ip: string | null | undefined, cidr: string): boolean {
+  const parsed = parseCidr(cidr)
+  if (!parsed) return false
+  if (!ip) return false
+
+  const bare = ip.trim().split('/')[0].split(':')[0]
+  const value = ipToInt(bare)
+  if (value === null) return false
+
+  const mask = parsed.bits === 0 ? 0 : (0xffffffff << (32 - parsed.bits)) >>> 0
+  return ((value & mask) >>> 0) === parsed.base
+}
+
+/**
+ * The rule the zone subnet import runs on, shared by the store action and the
+ * modal's match-count preview so the number shown is the number that moves.
+ *
+ * A candidate must be free (no parent — a node already nested in a group, a
+ * container host or another zone keeps the parent the user gave it), must not
+ * be canvas furniture (which describes nothing physical and so has no IP worth
+ * matching), and must have an IP inside the range.
+ */
+const FURNITURE_TYPES = new Set(['groupRect', 'group', 'text'])
+
+export function isZoneSubnetCandidate(
+  node: { id: string; parentId?: string; data: { type: string; ip?: string } },
+  cidr: string,
+  zoneId?: string,
+): boolean {
+  if (node.id === zoneId) return false
+  if (node.parentId) return false
+  if (FURNITURE_TYPES.has(node.data.type)) return false
+  return ipInSubnet(node.data.ip, cidr)
+}


### PR DESCRIPTION
## What

Closes #325.

A zone gains an "Import devices by subnet" action: type a CIDR, and every free device whose IP falls in that range moves into the zone, laid out on a grid in its free space.

The CIDR is an argument to a one-shot action, never a property of the zone — it is not submitted with the form, not persisted, and cleared after each run. So there is no schema change, no migration, and the feature works in standalone mode. The trade-off is that a device scanned later does not join the zone by itself; the user re-runs the import.

## Changes

**Frontend — new `utils/subnet.ts`**
- `ipToInt`, `parseCidr`, `isValidCidr`, `ipInSubnet` — IPv4 only. A bare address is treated as `/32`, and `/0` is special-cased because `-1 << 32` wraps to `-1` in JS.
- `ipInSubnet` strips a prefix or port suffix off the node address, so `10.0.0.5/24` and `10.0.0.5:8006` both match.
- `isZoneSubnetCandidate` — the single predicate the store action and the modal's preview count both run on, so the number shown is the number that moves.

**Frontend — `stores/canvasStore.ts`**
- New `importZoneSubnet(zoneId, cidr): number`. Grid-packs arrivals into the zone's free space, working around the boxes already inside, and grows the zone height (and the `custom_colors.height` the renderer reads back) on overflow.
- Keeps the parent ahead of its new children, as React Flow requires.
- Takes one history snapshot per import, so a single Undo reverses the whole thing.
- The store creator now receives `get` alongside `set`, since the action reads state before deciding what to write.

Deliberate rules:
- Additive — running it twice with two subnets leaves both sets inside, and a device whose IP stops matching is never ejected.
- Only unparented devices move. A node nested in a group, a container host or another zone keeps the parent the user gave it, so an IP match cannot break a relation that means something physical (a VM inside its Proxmox host).
- Canvas furniture (`groupRect` / `group` / `text`) is skipped, and a zone never swallows another zone.
- No-op on an invalid CIDR, a missing zone, or a target that is not a zone.

**Frontend — `components/modals/GroupRectModal.tsx`**
- New "Import devices by subnet" block below the form, with a live preview of how many devices would move.
- An invalid CIDR is explained inline rather than silently matching nothing; IPv6 is rejected with a message.
- Edit mode gets an Import button (Enter in the field works too, without submitting the zone). Add mode has none — the zone does not exist yet and a button would look broken; there the CIDR is handed to the caller on submit and applied right after the zone is created.
- The field is intentionally outside `GroupRectFormData`, so the CIDR never reaches `onSubmit`.

**Frontend — `App.tsx`**
- Wires both modal instances, holds the add-mode CIDR in a ref until the zone exists, and reports the result as a toast.

No backend, schema or migration changes.

## Testing

- `frontend/src/utils/__tests__/subnet.test.ts` (new) — 18 cases: octet parsing, host-bit masking, `/0` and `/32`, prefix and port suffixes, IPv6 rejection, and every branch of the candidate predicate.
- `frontend/src/stores/__tests__/canvasStore/zones.test.ts` — 11 cases: devices move and are counted, out-of-range and address-less devices stay put, parented nodes are never stolen, a zone never swallows another zone, no-ops, grid layout and packing around existing children, zone growth, React Flow parent ordering, additive second import, and single-step Undo.
- `frontend/src/components/modals/__tests__/GroupRectModal.test.tsx` — 13 cases covering both modes, including that the CIDR never appears in the submitted form data.
- Full suite green: 152 files, 2106 tests. `npm run lint` and `npm run typecheck` clean (the 4 remaining lint warnings are pre-existing).
- Manually verified on the canvas in both add and edit mode.

ha-relevant: yes