### PR TITLE
fix: don't append the scanned port to a custom service host

### DIFF
--- a/backend/app/services/status_checker.py
+++ b/backend/app/services/status_checker.py
@@ -219,7 +219,11 @@ async def check_service(svc: dict[str, Any], host: str | None) -> str:
             port in _HTTPS_PORTS or "https" in name or "ssl" in name or "tls" in name
         ) else "http")
         url_host = _service_host(svc, host)
-        url = f"{scheme}://{url_host}" + (f":{port}" if port is not None else "")
+        # A host override usually points at a reverse proxy, where the scanned
+        # port is an internal detail that would break the public URL. Only a
+        # port typed into the override itself is used.
+        url_port = override_port if override else port
+        url = f"{scheme}://{url_host}" + (f":{url_port}" if url_port is not None else "")
         return "online" if await _http_get(url, verify=False) else "offline"
     except Exception as exc:
         logger.debug("Service check failed for %s:%s (%s)", host, port, exc)

--- a/backend/tests/test_status_checker.py
+++ b/backend/tests/test_status_checker.py
@@ -516,7 +516,14 @@ async def _captured_url(svc, host):
 @pytest.mark.asyncio
 async def test_check_service_uses_the_host_override():
     svc = {"port": 8080, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com"}
-    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:8080"
+    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com"
+
+
+@pytest.mark.asyncio
+async def test_check_service_drops_the_scanned_port_behind_a_reverse_proxy():
+    """Issue #382 — an override points at a proxy; the internal port breaks it."""
+    svc = {"port": 8083, "protocol": "tcp", "service_name": "blog", "host": "https://mywebserver.mydomain.com"}
+    assert await _captured_url(svc, "192.168.100.100") == "https://mywebserver.mydomain.com"
 
 
 @pytest.mark.asyncio
@@ -538,21 +545,21 @@ async def test_check_service_takes_the_port_from_the_override():
 
 
 @pytest.mark.asyncio
-async def test_check_service_lets_the_service_port_beat_the_override_port():
+async def test_check_service_keeps_the_port_typed_into_the_override():
     svc = {"port": 3000, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com:8443"}
-    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:3000"
+    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:8443"
 
 
 @pytest.mark.asyncio
 async def test_check_service_uses_the_first_host_of_a_comma_list_override():
     svc = {"port": 8080, "protocol": "tcp", "service_name": "blog", "host": "blog.example.com, alt.example.com"}
-    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com:8080"
+    assert await _captured_url(svc, "10.0.0.1") == "http://blog.example.com"
 
 
 @pytest.mark.asyncio
 async def test_check_service_brackets_an_ipv6_override():
     svc = {"port": 80, "protocol": "tcp", "service_name": "http", "host": "[2001:db8::1]:8080"}
-    assert await _captured_url(svc, "10.0.0.1") == "http://[2001:db8::1]:80"
+    assert await _captured_url(svc, "10.0.0.1") == "http://[2001:db8::1]:8080"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/modals/ServiceModal.tsx
+++ b/frontend/src/components/modals/ServiceModal.tsx
@@ -146,7 +146,8 @@ export function ServiceModal({ open, onClose, onSubmit, initial, title = 'Add Se
               className="bg-[#21262d] border-[#30363d] font-mono text-sm h-8"
             />
             <span className="text-[10px] text-muted-foreground/60">
-              Overrides the node host for this service only.
+              Overrides the node host for this service only. The port above is
+              dropped &mdash; add one here (host:port) if the URL needs it.
             </span>
           </div>
 

--- a/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
+++ b/frontend/src/components/panels/__tests__/DetailPanel.test.tsx
@@ -482,7 +482,7 @@ describe('DetailPanel', () => {
         ungroup: vi.fn(),
       } as unknown as ReturnType<typeof canvasStore.useCanvasStore>)
       render(<DetailPanel onEdit={vi.fn()} />)
-      expect(screen.getByRole('link', { name: 'blog' }).getAttribute('href')).toBe('https://blog.example.com:443')
+      expect(screen.getByRole('link', { name: 'blog' }).getAttribute('href')).toBe('https://blog.example.com')
     })
 
     it('calls updateNode without the removed service when X is clicked', () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -95,7 +95,9 @@ export interface ServiceInfo {
   category?: string
   /** Overrides the node host when building the service URL — one node can serve
    *  several domains. Same accepted shapes as a node `ip`/`hostname`
-   *  (`host`, `host:port`, `https://host/…`). */
+   *  (`host`, `host:port`, `https://host/…`). An override suppresses `port`:
+   *  it usually names a reverse proxy, where the scanned port breaks the URL,
+   *  so only a port written here is used. */
   host?: string
   /** Whether the node drawing this device shows the service. Per node, not per
    *  device — the same device on another canvas keeps its own answer. Absent

--- a/frontend/src/utils/__tests__/serviceUrl.test.ts
+++ b/frontend/src/utils/__tests__/serviceUrl.test.ts
@@ -86,7 +86,11 @@ describe('getServiceUrl', () => {
       ({ ...svc(port, 'tcp', 'app', path), host })
 
     it('uses the service host instead of the node one', () => {
-      expect(getServiceUrl(withHost('blog.example.com', 8080), '192.168.1.10')).toBe('http://blog.example.com:8080')
+      expect(getServiceUrl(withHost('blog.example.com', 8080), '192.168.1.10')).toBe('http://blog.example.com')
+    })
+
+    it('drops the scanned port so a reverse-proxy host stays reachable', () => {
+      expect(getServiceUrl(withHost('https://mywebserver.mydomain.com', 8083), '192.168.100.100')).toBe('https://mywebserver.mydomain.com')
     })
 
     it('falls back to the node host when the override is blank', () => {
@@ -94,7 +98,7 @@ describe('getServiceUrl', () => {
     })
 
     it('resolves against the override even when the node has no host', () => {
-      expect(getServiceUrl(withHost('blog.example.com', 80), undefined)).toBe('http://blog.example.com:80')
+      expect(getServiceUrl(withHost('blog.example.com', 80), undefined)).toBe('http://blog.example.com')
     })
 
     it('honours a scheme carried by the override', () => {
@@ -106,15 +110,20 @@ describe('getServiceUrl', () => {
     })
 
     it('appends the service path to the override host', () => {
-      expect(getServiceUrl(withHost('blog.example.com', 3000, 'admin'), '192.168.1.10')).toBe('http://blog.example.com:3000/admin')
+      expect(getServiceUrl(withHost('blog.example.com', 3000, 'admin'), '192.168.1.10')).toBe('http://blog.example.com/admin')
     })
 
     it('returns null for a scheme-only override instead of throwing', () => {
       expect(getServiceUrl(withHost('https://', 443), '192.168.1.10')).toBeNull()
     })
 
-    it('lets the service port override the port carried by the override host', () => {
-      expect(getServiceUrl(withHost('blog.example.com:8443', 3000), '192.168.1.10')).toBe('http://blog.example.com:3000')
+    it('keeps the port typed into the override host over the scanned one', () => {
+      expect(getServiceUrl(withHost('blog.example.com:8443', 3000), '192.168.1.10')).toBe('http://blog.example.com:8443')
+    })
+
+    it('still gates the override on the scanned port', () => {
+      expect(getServiceUrl(withHost('db.example.com', 3306), '192.168.1.10')).toBeNull()
+      expect(getServiceUrl(withHost('shell.example.com', 22), '192.168.1.10')).toBeNull()
     })
 
     it('still returns null for a UDP service', () => {

--- a/frontend/src/utils/serviceUrl.ts
+++ b/frontend/src/utils/serviceUrl.ts
@@ -88,7 +88,8 @@ function formatHostname(hostname: string): string {
 export function getServiceUrl(svc: ServiceInfo, host?: string): string | null {
   // A node can serve several domains, so a service may carry its own host that
   // overrides the node one.
-  const effectiveHost = svc.host?.trim() || host
+  const overrideHost = svc.host?.trim()
+  const effectiveHost = overrideHost || host
   if (!effectiveHost) return null
   if (svc.protocol === 'udp') return null // UDP — not HTTP
 
@@ -106,7 +107,12 @@ export function getServiceUrl(svc: ServiceInfo, host?: string): string | null {
       ? 'https'
       : 'http'
   )
+  // A host override usually points at a reverse proxy, where the scanned port
+  // is an internal detail that would break the public URL. Only a port typed
+  // into the override itself is printed.
+  const urlPort = overrideHost ? parts.port : effectivePort
+
   const base = `${protocol}://${formatHostname(parts.hostname)}`
-  const port = effectivePort != null ? `:${effectivePort}` : ''
+  const port = urlPort != null ? `:${urlPort}` : ''
   return `${base}${port}${normalizePath(svc.path)}`
 }


### PR DESCRIPTION
## What

A service `host` override normally points at a reverse proxy, so the port the
scanner found is an internal detail that does not exist on the public URL.
Homelable was still appending it, producing links like
`https://mywebserver.mydomain.com:8083/` that resolve to nothing. The override
now suppresses the scanned port; only a port typed into the override itself
(`host:port`) is used.

Closes #382

## Changes

Frontend
- `utils/serviceUrl.ts` — when a service carries a `host` override, the URL port
  comes from that override alone, never from `svc.port`. Without an override,
  behaviour is unchanged.
- `ServiceModal` — the Host field hint now says the port is dropped and that one
  can be added as `host:port`.
- `types/index.ts` — documented the rule on `ServiceInfo.host`.

Backend
- `services/status_checker.py` — same rule for the URL the per-service check
  probes. It had the same bug, so a service behind a proxy was reported offline.

Unchanged on purpose: the scanned port still drives the non-HTTP / SSH skip and
the http/https scheme guess, so a MySQL or SSH service behind an override stays
unlinked and unchecked.

Behaviour change worth noting: with an override that carries a port
(`blog.example.com:8443`) and a scanned port of 3000, the URL is now `:8443`.
The typed port wins.

## Testing

- `frontend/src/utils/__tests__/serviceUrl.test.ts` — updated the four cases that
  encoded the old behaviour, added the reverse-proxy regression from the issue
  and a case asserting the scanned port still gates non-HTTP ports.
- `backend/tests/test_status_checker.py` — same, four updated plus a
  reverse-proxy regression.
- `frontend/src/components/panels/__tests__/DetailPanel.test.tsx` — badge link
  assertion updated.
- Full suites green: `npm test` (2126 passed), `pytest` (936 passed), plus lint,
  typecheck, ruff and mypy.

ha-relevant: yes
