### PR TITLE
feat: add a whole selection to a zone, and expose zones to the MCP server

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,7 @@ import { buildProxmoxClusterEdges } from '@/components/proxmox/clusterEdges'
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
 
 export default function App() {
-  const { loadCanvas, applyLayout, markSaved, markUnsaved, hasUnsavedChanges, editSeq, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, editingTextId, setEditingTextId, nodes, edges, snapshotHistory, undo, redo, addToGroup, addToContainer, addToZone, importZoneSubnet, floorMap, setFloorMap } = useCanvasStore()
+  const { loadCanvas, applyLayout, markSaved, markUnsaved, hasUnsavedChanges, editSeq, selectedNodeId, selectedNodeIds, addNode, updateNode, deleteNode, onConnect, updateEdge, deleteEdge, setProxmoxContainerMode, setNodeZIndex, editingGroupRectId, setEditingGroupRectId, editingTextId, setEditingTextId, nodes, edges, snapshotHistory, undo, redo, addNodesToGroup, addNodesToContainer, addNodesToZone, importZoneSubnet, floorMap, setFloorMap } = useCanvasStore()
   const canvasRef = useRef<HTMLDivElement>(null)
   const { isAuthenticated, isInitialized } = useAuthStore()
   const authBootstrapStarted = useRef(false)
@@ -132,9 +132,14 @@ export default function App() {
   const [addTextOpen, setAddTextOpen] = useState(false)
   const [editNodeId, setEditNodeId] = useState<string | null>(null)
   const [pendingConnection, setPendingConnection] = useState<Connection | null>(null)
-  const [pendingGroupAdd, setPendingGroupAdd] = useState<{ nodeId: string; groupId: string } | null>(null)
-  const [pendingContainerAdd, setPendingContainerAdd] = useState<{ nodeId: string; containerId: string } | null>(null)
-  const [pendingZoneAdd, setPendingZoneAdd] = useState<{ nodeId: string; zoneId: string } | null>(null)
+  const [pendingGroupAdd, setPendingGroupAdd] = useState<{ nodeIds: string[]; groupId: string } | null>(null)
+  const [pendingContainerAdd, setPendingContainerAdd] = useState<{ nodeIds: string[]; containerId: string } | null>(null)
+  const [pendingZoneAdd, setPendingZoneAdd] = useState<{ nodeIds: string[]; zoneId: string } | null>(null)
+  // Labels for the add-to-group/container/zone confirmation, in the order dropped.
+  const labelsOf = useCallback(
+    (ids: string[]) => ids.map((id) => nodes.find((n) => n.id === id)?.data.label ?? ''),
+    [nodes],
+  )
   const [editEdgeId, setEditEdgeId] = useState<string | null>(null)
   const [scanConfigOpen, setScanConfigOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -1317,10 +1322,10 @@ export default function App() {
 
         <ConfirmAddToGroupModal
           open={!!pendingGroupAdd}
-          nodeLabel={pendingGroupAdd ? (nodes.find((n) => n.id === pendingGroupAdd.nodeId)?.data.label ?? '') : ''}
+          nodeLabels={pendingGroupAdd ? labelsOf(pendingGroupAdd.nodeIds) : []}
           targetLabel={pendingGroupAdd ? (nodes.find((n) => n.id === pendingGroupAdd.groupId)?.data.label ?? '') : ''}
           onConfirm={() => {
-            if (pendingGroupAdd) addToGroup(pendingGroupAdd.groupId, pendingGroupAdd.nodeId)
+            if (pendingGroupAdd) addNodesToGroup(pendingGroupAdd.groupId, pendingGroupAdd.nodeIds)
             setPendingGroupAdd(null)
           }}
           onCancel={() => setPendingGroupAdd(null)}
@@ -1329,10 +1334,10 @@ export default function App() {
         <ConfirmAddToGroupModal
           open={!!pendingContainerAdd}
           variant="container"
-          nodeLabel={pendingContainerAdd ? (nodes.find((n) => n.id === pendingContainerAdd.nodeId)?.data.label ?? '') : ''}
+          nodeLabels={pendingContainerAdd ? labelsOf(pendingContainerAdd.nodeIds) : []}
           targetLabel={pendingContainerAdd ? (nodes.find((n) => n.id === pendingContainerAdd.containerId)?.data.label ?? '') : ''}
           onConfirm={() => {
-            if (pendingContainerAdd) addToContainer(pendingContainerAdd.containerId, pendingContainerAdd.nodeId)
+            if (pendingContainerAdd) addNodesToContainer(pendingContainerAdd.containerId, pendingContainerAdd.nodeIds)
             setPendingContainerAdd(null)
           }}
           onCancel={() => setPendingContainerAdd(null)}
@@ -1341,10 +1346,10 @@ export default function App() {
         <ConfirmAddToGroupModal
           open={!!pendingZoneAdd}
           variant="zone"
-          nodeLabel={pendingZoneAdd ? (nodes.find((n) => n.id === pendingZoneAdd.nodeId)?.data.label ?? '') : ''}
+          nodeLabels={pendingZoneAdd ? labelsOf(pendingZoneAdd.nodeIds) : []}
           targetLabel={pendingZoneAdd ? (nodes.find((n) => n.id === pendingZoneAdd.zoneId)?.data.label ?? '') : ''}
           onConfirm={() => {
-            if (pendingZoneAdd) addToZone(pendingZoneAdd.zoneId, pendingZoneAdd.nodeId)
+            if (pendingZoneAdd) addNodesToZone(pendingZoneAdd.zoneId, pendingZoneAdd.nodeIds)
             setPendingZoneAdd(null)
           }}
           onCancel={() => setPendingZoneAdd(null)}

--- a/frontend/src/components/canvas/CanvasContainer.tsx
+++ b/frontend/src/components/canvas/CanvasContainer.tsx
@@ -46,7 +46,7 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
     setSelectedNode, snapshotHistory,
     fitViewPending, clearFitViewPending,
     copySelectedNodes, pasteNodes,
-    removeFromGroup,
+    removeNodesFromGroup,
   } = useCanvasStore()
   const { fitView, screenToFlowPosition, getIntersectingNodes } = useReactFlow<Node<NodeData>>()
 
@@ -166,9 +166,10 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
         // how the user takes a node back out of it. The whole selection leaves
         // with it, not only the node under the cursor.
         if (!intersecting.some((n) => n.id === zoneParent.id)) {
-          for (const n of movable) {
-            if (n.parentId === zoneParent.id) removeFromGroup(zoneParent.id, n.id)
-          }
+          const leaving = movable.filter((n) => n.parentId === zoneParent.id).map((n) => n.id)
+          // One history entry, so a single undo puts the whole selection back —
+          // symmetric with the batched add.
+          removeNodesFromGroup(zoneParent.id, leaving)
         }
       } else if (!dragNode.parentId) {
         // Only free nodes join a new parent; one already nested elsewhere in the
@@ -198,7 +199,7 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
       }
     }
     onNodeDragStop(event, dragNode, dragNodes)
-  }, [onRequestAddToGroup, onRequestAddToContainer, onRequestAddToZone, removeFromGroup, nodes, getIntersectingNodes, onNodeDragStop])
+  }, [onRequestAddToGroup, onRequestAddToContainer, onRequestAddToZone, removeNodesFromGroup, nodes, getIntersectingNodes, onNodeDragStop])
 
   return (
     <div ref={wrapperRef} className="w-full h-full" style={{ background: theme.colors.canvasBackground }} onMouseMove={onMouseMove}>

--- a/frontend/src/components/canvas/CanvasContainer.tsx
+++ b/frontend/src/components/canvas/CanvasContainer.tsx
@@ -32,9 +32,9 @@ interface CanvasContainerProps {
   onEdgeDoubleClick?: (edge: Edge<EdgeData>) => void
   onNodeDoubleClick?: (node: Node<NodeData>) => void
   onNodeDragStart?: () => void
-  onRequestAddToGroup?: (payload: { nodeId: string; groupId: string }) => void
-  onRequestAddToContainer?: (payload: { nodeId: string; containerId: string }) => void
-  onRequestAddToZone?: (payload: { nodeId: string; zoneId: string }) => void
+  onRequestAddToGroup?: (payload: { nodeIds: string[]; groupId: string }) => void
+  onRequestAddToContainer?: (payload: { nodeIds: string[]; containerId: string }) => void
+  onRequestAddToZone?: (payload: { nodeIds: string[]; zoneId: string }) => void
   onOpenInventory?: (deviceId: string) => void
 }
 
@@ -145,33 +145,55 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
 
   const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides()
 
-  // Drop a top-level node onto a group → ask App to confirm adding it. Runs
-  // before the alignment snap so detection uses the dropped position.
+  // Drop a selection onto a group → ask App to confirm adding it. Runs before
+  // the alignment snap so detection uses the dropped position. `dragNodes` is
+  // the whole multi-selection being dragged; `dragNode` (the one under the
+  // cursor) only picks the destination.
   const handleNodeDragStop = useCallback<NonNullable<typeof onNodeDragStop>>((event, dragNode, dragNodes) => {
-    if (dragNode && dragNode.data.type !== 'group' && dragNode.data.type !== 'groupRect') {
+    // A single drag reports an empty `dragNodes` in some React Flow paths, so
+    // fall back to the dragged node itself.
+    const dragged = dragNodes && dragNodes.length > 0 ? dragNodes : dragNode ? [dragNode] : []
+    // Groups and zones are containers, never contents.
+    const movable = dragged.filter((n) => n.data.type !== 'group' && n.data.type !== 'groupRect')
+
+    if (dragNode && dragNode.data.type !== 'group' && dragNode.data.type !== 'groupRect' && movable.length > 0) {
       const intersecting = getIntersectingNodes(dragNode)
       const zoneParent = dragNode.parentId
         ? nodes.find((n) => n.id === dragNode.parentId && n.data.type === 'groupRect')
         : undefined
       if (zoneParent) {
         // Zone children are not extent-clamped, so a drop outside the zone is
-        // how the user takes a node back out of it.
+        // how the user takes a node back out of it. The whole selection leaves
+        // with it, not only the node under the cursor.
         if (!intersecting.some((n) => n.id === zoneParent.id)) {
-          removeFromGroup(zoneParent.id, dragNode.id)
+          for (const n of movable) {
+            if (n.parentId === zoneParent.id) removeFromGroup(zoneParent.id, n.id)
+          }
         }
       } else if (!dragNode.parentId) {
+        // Only free nodes join a new parent; one already nested elsewhere in the
+        // selection keeps its own parent.
+        const nodeIds = movable.filter((n) => !n.parentId).map((n) => n.id)
         const group = intersecting.find((n) => n.data.type === 'group')
         const container = intersecting.find((n) => n.id !== dragNode.id && n.data.container_mode === true)
+        // The destination can be part of the dragged selection (lasso over
+        // everything); it cannot also be one of its own new children.
+        const targetless = (targetId: string) => nodeIds.filter((id) => id !== targetId)
         if (group) {
-          onRequestAddToGroup?.({ nodeId: dragNode.id, groupId: group.id })
+          const ids = targetless(group.id)
+          if (ids.length > 0) onRequestAddToGroup?.({ nodeIds: ids, groupId: group.id })
         } else if (container) {
           // Any node in container_mode (proxmox, docker_host, …) accepts children.
-          onRequestAddToContainer?.({ nodeId: dragNode.id, containerId: container.id })
+          const ids = targetless(container.id)
+          if (ids.length > 0) onRequestAddToContainer?.({ nodeIds: ids, containerId: container.id })
         } else {
           // Zones come last: they are the loosest container and the largest, so
           // a group/container inside one still wins the drop.
           const zone = intersecting.find((n) => n.data.type === 'groupRect')
-          if (zone) onRequestAddToZone?.({ nodeId: dragNode.id, zoneId: zone.id })
+          if (zone) {
+            const ids = targetless(zone.id)
+            if (ids.length > 0) onRequestAddToZone?.({ nodeIds: ids, zoneId: zone.id })
+          }
         }
       }
     }

--- a/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
@@ -177,7 +177,7 @@ describe('CanvasContainer', () => {
     rf.intersecting = [group]
     render(<CanvasContainer onRequestAddToGroup={onRequestAddToGroup} />)
     ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, node, [node])
-    expect(onRequestAddToGroup).toHaveBeenCalledWith({ nodeId: 'n1', groupId: 'g1' })
+    expect(onRequestAddToGroup).toHaveBeenCalledWith({ nodeIds: ['n1'], groupId: 'g1' })
   })
 
   it('does not fire onRequestAddToGroup when no group is under the node', () => {
@@ -219,7 +219,7 @@ describe('CanvasContainer', () => {
     rf.intersecting = [containerNode('px1')]
     render(<CanvasContainer onRequestAddToContainer={onRequestAddToContainer} />)
     ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, node, [node])
-    expect(onRequestAddToContainer).toHaveBeenCalledWith({ nodeId: 'n1', containerId: 'px1' })
+    expect(onRequestAddToContainer).toHaveBeenCalledWith({ nodeIds: ['n1'], containerId: 'px1' })
   })
 
   it('prefers a group over a container when both intersect', () => {
@@ -229,7 +229,7 @@ describe('CanvasContainer', () => {
     rf.intersecting = [containerNode('px1'), groupNode('g1')]
     render(<CanvasContainer onRequestAddToGroup={onRequestAddToGroup} onRequestAddToContainer={onRequestAddToContainer} />)
     ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, node, [node])
-    expect(onRequestAddToGroup).toHaveBeenCalledWith({ nodeId: 'n1', groupId: 'g1' })
+    expect(onRequestAddToGroup).toHaveBeenCalledWith({ nodeIds: ['n1'], groupId: 'g1' })
     expect(onRequestAddToContainer).not.toHaveBeenCalled()
   })
 
@@ -263,7 +263,7 @@ describe('CanvasContainer', () => {
     rf.intersecting = [zoneNode('z1')]
     render(<CanvasContainer onRequestAddToZone={onRequestAddToZone} />)
     ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, node, [node])
-    expect(onRequestAddToZone).toHaveBeenCalledWith({ nodeId: 'n1', zoneId: 'z1' })
+    expect(onRequestAddToZone).toHaveBeenCalledWith({ nodeIds: ['n1'], zoneId: 'z1' })
   })
 
   it('prefers a group and a container over a zone when they overlap', () => {
@@ -273,7 +273,7 @@ describe('CanvasContainer', () => {
     rf.intersecting = [zoneNode('z1'), containerNode('px1')]
     render(<CanvasContainer onRequestAddToZone={onRequestAddToZone} onRequestAddToContainer={onRequestAddToContainer} />)
     ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, node, [node])
-    expect(onRequestAddToContainer).toHaveBeenCalledWith({ nodeId: 'n1', containerId: 'px1' })
+    expect(onRequestAddToContainer).toHaveBeenCalledWith({ nodeIds: ['n1'], containerId: 'px1' })
     expect(onRequestAddToZone).not.toHaveBeenCalled()
   })
 
@@ -306,6 +306,59 @@ describe('CanvasContainer', () => {
     render(<CanvasContainer />)
     ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, child, [child])
     expect(useCanvasStore.getState().nodes.find((n) => n.id === 'n1')?.parentId).toBe('z1')
+  })
+
+  // ── Multi-selection drops (#365) ──────────────────────────────────────────
+
+  it('fires onRequestAddToZone with every dragged node, not just the one under the cursor', () => {
+    const onRequestAddToZone = vi.fn()
+    const dragged = [makeNode('n1'), makeNode('n2'), makeNode('n3')]
+    rf.intersecting = [zoneNode('z1')]
+    render(<CanvasContainer onRequestAddToZone={onRequestAddToZone} />)
+    ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, dragged[0], dragged)
+    expect(onRequestAddToZone).toHaveBeenCalledWith({ nodeIds: ['n1', 'n2', 'n3'], zoneId: 'z1' })
+  })
+
+  it('leaves zones and groups out of a dragged selection', () => {
+    const onRequestAddToZone = vi.fn()
+    const dragged = [makeNode('n1'), zoneNode('z1'), groupNode('g1')]
+    rf.intersecting = [zoneNode('z2')]
+    render(<CanvasContainer onRequestAddToZone={onRequestAddToZone} />)
+    ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, dragged[0], dragged)
+    expect(onRequestAddToZone).toHaveBeenCalledWith({ nodeIds: ['n1'], zoneId: 'z2' })
+  })
+
+  it('never asks to add the destination container to itself', () => {
+    const onRequestAddToContainer = vi.fn()
+    const target = containerNode('px1')
+    const dragged = [makeNode('n1'), target]
+    rf.intersecting = [target]
+    render(<CanvasContainer onRequestAddToContainer={onRequestAddToContainer} />)
+    ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, dragged[0], dragged)
+    expect(onRequestAddToContainer).toHaveBeenCalledWith({ nodeIds: ['n1'], containerId: 'px1' })
+  })
+
+  it('keeps an already-parented node in the selection with its own parent', () => {
+    const onRequestAddToZone = vi.fn()
+    const dragged = [makeNode('n1'), { ...makeNode('n2'), parentId: 'pxOther' }]
+    rf.intersecting = [zoneNode('z1')]
+    render(<CanvasContainer onRequestAddToZone={onRequestAddToZone} />)
+    ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, dragged[0], dragged)
+    expect(onRequestAddToZone).toHaveBeenCalledWith({ nodeIds: ['n1'], zoneId: 'z1' })
+  })
+
+  it('detaches every dragged child when a selection leaves its zone', () => {
+    const zone = { ...zoneNode('z1'), position: { x: 100, y: 100 } }
+    const c1 = { ...makeNode('n1'), parentId: 'z1', position: { x: 20, y: 20 } }
+    const c2 = { ...makeNode('n2'), parentId: 'z1', position: { x: 40, y: 40 } }
+    useCanvasStore.setState({ nodes: [zone, c1, c2] })
+    rf.intersecting = []
+    render(<CanvasContainer />)
+    ;(rfProps.onNodeDragStop as (...args: unknown[]) => unknown)({} as MouseEvent, c1, [c1, c2])
+    const after = useCanvasStore.getState().nodes
+    expect(after.find((n) => n.id === 'n1')!.parentId).toBeUndefined()
+    expect(after.find((n) => n.id === 'n2')!.parentId).toBeUndefined()
+    expect(after.find((n) => n.id === 'n2')!.position).toEqual({ x: 140, y: 140 })
   })
 
   // ── Canvas settings ───────────────────────────────────────────────────────

--- a/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
@@ -359,6 +359,11 @@ describe('CanvasContainer', () => {
     expect(after.find((n) => n.id === 'n1')!.parentId).toBeUndefined()
     expect(after.find((n) => n.id === 'n2')!.parentId).toBeUndefined()
     expect(after.find((n) => n.id === 'n2')!.position).toEqual({ x: 140, y: 140 })
+    // One history entry for the whole selection: a single undo puts both back.
+    useCanvasStore.getState().undo()
+    const restored = useCanvasStore.getState().nodes
+    expect(restored.find((n) => n.id === 'n1')!.parentId).toBe('z1')
+    expect(restored.find((n) => n.id === 'n2')!.parentId).toBe('z1')
   })
 
   // ── Canvas settings ───────────────────────────────────────────────────────

--- a/frontend/src/components/modals/ConfirmAddToGroupModal.tsx
+++ b/frontend/src/components/modals/ConfirmAddToGroupModal.tsx
@@ -9,9 +9,14 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 
+/** Labels past this many are summarized as "+N more" instead of listed. */
+const MAX_LISTED_LABELS = 5
+
 interface ConfirmAddToGroupModalProps {
   open: boolean
-  nodeLabel: string
+  /** Labels of the nodes being added — one entry for a single drop, several for
+   *  a multi-selection. */
+  nodeLabels: string[]
   /** Label of the destination group/container. */
   targetLabel: string
   /** Destination kind — drives the wording. Defaults to 'group'. */
@@ -22,7 +27,7 @@ interface ConfirmAddToGroupModalProps {
 
 export function ConfirmAddToGroupModal({
   open,
-  nodeLabel,
+  nodeLabels,
   targetLabel,
   variant = 'group',
   onConfirm,
@@ -30,6 +35,14 @@ export function ConfirmAddToGroupModal({
 }: ConfirmAddToGroupModalProps) {
   const noun = variant === 'container' ? 'container' : variant === 'zone' ? 'zone' : 'group'
   const action = `Add to ${noun}`
+  const count = nodeLabels.length
+  const listed = nodeLabels.slice(0, MAX_LISTED_LABELS).join(', ')
+  const subject =
+    count === 1
+      ? nodeLabels[0]
+      : count <= MAX_LISTED_LABELS
+        ? `${count} nodes (${listed})`
+        : `${count} nodes (${listed}, +${count - MAX_LISTED_LABELS} more)`
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel() }}>
       <DialogContent className="max-w-sm">
@@ -39,7 +52,7 @@ export function ConfirmAddToGroupModal({
             {action}
           </DialogTitle>
           <DialogDescription>
-            Add <span className="font-medium text-foreground">{nodeLabel}</span> to the {noun}{' '}
+            Add <span className="font-medium text-foreground">{subject}</span> to the {noun}{' '}
             <span className="font-medium text-foreground">{targetLabel}</span>?
           </DialogDescription>
         </DialogHeader>

--- a/frontend/src/components/modals/__tests__/ConfirmAddToGroupModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ConfirmAddToGroupModal.test.tsx
@@ -5,14 +5,14 @@ import { ConfirmAddToGroupModal } from '../ConfirmAddToGroupModal'
 describe('ConfirmAddToGroupModal', () => {
   it('renders nothing when closed', () => {
     render(
-      <ConfirmAddToGroupModal open={false} nodeLabel="Router" targetLabel="DMZ" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+      <ConfirmAddToGroupModal open={false} nodeLabels={['Router']} targetLabel="DMZ" onConfirm={vi.fn()} onCancel={vi.fn()} />,
     )
     expect(screen.queryByText('Add to group')).toBeNull()
   })
 
   it('shows node and group labels when open', () => {
     render(
-      <ConfirmAddToGroupModal open nodeLabel="Router" targetLabel="DMZ" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+      <ConfirmAddToGroupModal open nodeLabels={['Router']} targetLabel="DMZ" onConfirm={vi.fn()} onCancel={vi.fn()} />,
     )
     expect(screen.getByText('Router')).toBeDefined()
     expect(screen.getByText('DMZ')).toBeDefined()
@@ -21,7 +21,7 @@ describe('ConfirmAddToGroupModal', () => {
   it('calls onConfirm when the confirm button is clicked', () => {
     const onConfirm = vi.fn()
     render(
-      <ConfirmAddToGroupModal open nodeLabel="Router" targetLabel="DMZ" onConfirm={onConfirm} onCancel={vi.fn()} />,
+      <ConfirmAddToGroupModal open nodeLabels={['Router']} targetLabel="DMZ" onConfirm={onConfirm} onCancel={vi.fn()} />,
     )
     fireEvent.click(screen.getByRole('button', { name: /add to group/i }))
     expect(onConfirm).toHaveBeenCalledOnce()
@@ -30,7 +30,7 @@ describe('ConfirmAddToGroupModal', () => {
   it('calls onCancel when the cancel button is clicked', () => {
     const onCancel = vi.fn()
     render(
-      <ConfirmAddToGroupModal open nodeLabel="Router" targetLabel="DMZ" onConfirm={vi.fn()} onCancel={onCancel} />,
+      <ConfirmAddToGroupModal open nodeLabels={['Router']} targetLabel="DMZ" onConfirm={vi.fn()} onCancel={onCancel} />,
     )
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(onCancel).toHaveBeenCalledOnce()
@@ -38,9 +38,30 @@ describe('ConfirmAddToGroupModal', () => {
 
   it('uses container wording when variant is container', () => {
     render(
-      <ConfirmAddToGroupModal open variant="container" nodeLabel="VM" targetLabel="Proxmox" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+      <ConfirmAddToGroupModal open variant="container" nodeLabels={['VM']} targetLabel="Proxmox" onConfirm={vi.fn()} onCancel={vi.fn()} />,
     )
     expect(screen.getByRole('button', { name: /add to container/i })).toBeDefined()
     expect(screen.queryByText('Add to group')).toBeNull()
+  })
+
+  it('counts and lists the nodes when several are added at once', () => {
+    render(
+      <ConfirmAddToGroupModal open nodeLabels={['Router', 'Switch', 'NAS']} targetLabel="DMZ" variant="zone" onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect(screen.getByText(/3 nodes \(Router, Switch, NAS\)/)).toBeInTheDocument()
+    expect(screen.getByText('DMZ')).toBeInTheDocument()
+  })
+
+  it('summarizes the tail past five labels', () => {
+    render(
+      <ConfirmAddToGroupModal
+        open
+        nodeLabels={['a', 'b', 'c', 'd', 'e', 'f', 'g']}
+        targetLabel="DMZ"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/7 nodes \(a, b, c, d, e, \+2 more\)/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -238,6 +238,50 @@ describe('canvasStore — batch parenting (#365)', () => {
     expect(nodes.find((n) => n.id === 'n2')!.position).toEqual({ x: 8, y: 8 })
   })
 
+  it('removeNodesFromGroup detaches the whole selection in one undo step', () => {
+    const z = zone('z1')
+    useCanvasStore.setState({
+      nodes: [
+        z,
+        { ...makeNode('n1'), parentId: 'z1', position: { x: 20, y: 20 }, data: { ...makeNode('n1').data, parent_id: 'z1' } },
+        { ...makeNode('n2'), parentId: 'z1', position: { x: 40, y: 40 }, data: { ...makeNode('n2').data, parent_id: 'z1' } },
+      ],
+    })
+    useCanvasStore.getState().removeNodesFromGroup('z1', ['n1', 'n2'])
+
+    let nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'n1')!.position).toEqual({ x: 120, y: 120 })
+    expect(nodes.find((n) => n.id === 'n2')!.position).toEqual({ x: 140, y: 140 })
+
+    useCanvasStore.getState().undo()
+    nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBe('z1')
+    expect(nodes.find((n) => n.id === 'n2')!.parentId).toBe('z1')
+  })
+
+  it('removeNodesFromGroup ignores nodes that are not in that group', () => {
+    useCanvasStore.setState({
+      nodes: [
+        zone('z1'),
+        { ...makeNode('n1'), parentId: 'z1', position: { x: 20, y: 20 }, data: { ...makeNode('n1').data, parent_id: 'z1' } },
+        makeNode('free'),
+      ],
+    })
+    useCanvasStore.getState().removeNodesFromGroup('z1', ['n1', 'free', 'ghost'])
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'free')!.position).toEqual(makeNode('free').position)
+  })
+
+  it('removeNodesFromGroup is a no-op when nothing in the batch is attached', () => {
+    useCanvasStore.setState({ nodes: [zone('z1'), makeNode('n1')] })
+    const before = useCanvasStore.getState().nodes
+    useCanvasStore.getState().removeNodesFromGroup('z1', ['n1'])
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+
   it('addNodesToContainer parents every child of a container-mode node', () => {
     useCanvasStore.setState({
       nodes: [

--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -135,6 +135,129 @@ describe('canvasStore — zone (groupRect) parenting', () => {
   })
 })
 
+describe('canvasStore — batch parenting (#365)', () => {
+  beforeEach(resetStore)
+
+  it('addNodesToZone moves the whole selection, not just the first node', () => {
+    useCanvasStore.setState({
+      nodes: [
+        zone('z1'),
+        { ...makeNode('n1'), position: { x: 160, y: 220 } },
+        { ...makeNode('n2'), position: { x: 200, y: 260 } },
+        { ...makeNode('n3'), position: { x: 240, y: 300 } },
+      ],
+    })
+    useCanvasStore.getState().addNodesToZone('z1', ['n1', 'n2', 'n3'])
+
+    const nodes = useCanvasStore.getState().nodes
+    for (const id of ['n1', 'n2', 'n3']) {
+      const child = nodes.find((n) => n.id === id)!
+      expect(child.parentId).toBe('z1')
+      expect(child.data.parent_id).toBe('z1')
+      expect(child.extent).toBeUndefined()
+    }
+    expect(nodes.find((n) => n.id === 'n1')!.position).toEqual({ x: 60, y: 120 })
+    expect(nodes.find((n) => n.id === 'n3')!.position).toEqual({ x: 140, y: 200 })
+  })
+
+  it('undoes a batch add in a single step', () => {
+    useCanvasStore.setState({
+      nodes: [zone('z1'), makeNode('n1'), makeNode('n2')],
+    })
+    useCanvasStore.getState().addNodesToZone('z1', ['n1', 'n2'])
+    useCanvasStore.getState().undo()
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'n2')!.parentId).toBeUndefined()
+  })
+
+  it('skips a child whose own parent is in the same batch', () => {
+    useCanvasStore.setState({
+      nodes: [
+        zone('z1'),
+        { ...makeNode('host'), position: { x: 500, y: 500 } },
+        {
+          ...makeNode('vm'),
+          position: { x: 20, y: 20 },
+          parentId: 'host',
+          data: { ...makeNode('vm').data, parent_id: 'host' },
+        },
+      ],
+    })
+    useCanvasStore.getState().addNodesToZone('z1', ['host', 'vm'])
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'host')!.parentId).toBe('z1')
+    // The VM rides along with its host; re-parenting it would tear it out.
+    expect(nodes.find((n) => n.id === 'vm')!.parentId).toBe('host')
+    expect(nodes.find((n) => n.id === 'vm')!.position).toEqual({ x: 20, y: 20 })
+  })
+
+  it('refuses a node the zone itself descends from', () => {
+    useCanvasStore.setState({
+      nodes: [
+        makeNode('outer'),
+        {
+          ...zone('z1'),
+          parentId: 'outer',
+          data: { ...zone('z1').data, parent_id: 'outer' },
+        },
+        makeNode('n1'),
+      ],
+    })
+    useCanvasStore.getState().addNodesToZone('z1', ['outer', 'n1'])
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'outer')!.parentId).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBe('z1')
+  })
+
+  it('is a no-op when nothing in the batch is eligible', () => {
+    useCanvasStore.setState({ nodes: [zone('z1'), makeNode('n1')] })
+    useCanvasStore.getState().addToZone('z1', 'n1')
+    const before = useCanvasStore.getState().nodes
+    useCanvasStore.getState().addNodesToZone('z1', ['n1', 'z1'])
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+
+  it('addNodesToGroup clamps every child inside the group', () => {
+    useCanvasStore.setState({
+      nodes: [
+        { ...makeNode('g1', { type: 'group' }), type: 'group', position: { x: 100, y: 100 } },
+        { ...makeNode('n1'), position: { x: 160, y: 220 } },
+        { ...makeNode('n2'), position: { x: 100, y: 100 } },
+      ],
+    })
+    useCanvasStore.getState().addNodesToGroup('g1', ['n1', 'n2'])
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.extent).toBe('parent')
+    expect(nodes.find((n) => n.id === 'n1')!.position).toEqual({ x: 60, y: 120 })
+    // Dropped on the group's own corner: clamped to the 8px inset.
+    expect(nodes.find((n) => n.id === 'n2')!.position).toEqual({ x: 8, y: 8 })
+  })
+
+  it('addNodesToContainer parents every child of a container-mode node', () => {
+    useCanvasStore.setState({
+      nodes: [
+        {
+          ...makeNode('px1', { type: 'proxmox', container_mode: true }),
+          position: { x: 100, y: 100 },
+        },
+        { ...makeNode('n1'), position: { x: 160, y: 220 } },
+        { ...makeNode('n2'), position: { x: 180, y: 240 } },
+      ],
+    })
+    useCanvasStore.getState().addNodesToContainer('px1', ['n1', 'n2'])
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes.find((n) => n.id === 'n1')!.parentId).toBe('px1')
+    expect(nodes.find((n) => n.id === 'n2')!.parentId).toBe('px1')
+    expect(nodes.find((n) => n.id === 'n2')!.extent).toBe('parent')
+  })
+})
+
 describe('canvasStore — importZoneSubnet', () => {
   beforeEach(resetStore)
 

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -330,6 +330,8 @@ interface CanvasState {
    *  count moved; 0 for an invalid CIDR or no match. */
   importZoneSubnet: (zoneId: string, cidr: string) => number
   removeFromGroup: (groupId: string, childId: string) => void
+  /** Batch form of removeFromGroup — one history entry for the whole selection. */
+  removeNodesFromGroup: (groupId: string, childIds: string[]) => void
   markSaved: () => void
   markUnsaved: () => void
   loadCanvas: (nodes: Node<NodeData>[], edges: Edge<EdgeData>[]) => void
@@ -1115,14 +1117,22 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
   },
 
   // Release a single child from a group back to the canvas. Group stays.
-  removeFromGroup: (groupId, childId) =>
+  removeFromGroup: (groupId, childId) => get().removeNodesFromGroup(groupId, [childId]),
+
+  // Detach children from their parent, restoring absolute positions. Batched
+  // for the same reason as addNodesToGroup & co: a multi-selection dragged out
+  // of a zone must undo in one step, not one per node.
+  removeNodesFromGroup: (groupId, childIds) =>
     set((state) => {
       const group = state.nodes.find((n) => n.id === groupId)
-      const child = state.nodes.find((n) => n.id === childId)
-      if (!group || !child || child.parentId !== groupId) return state
+      if (!group) return state
+      const detaching = new Set(
+        childIds.filter((id) => state.nodes.some((n) => n.id === id && n.parentId === groupId)),
+      )
+      if (detaching.size === 0) return state
 
       const nodes = state.nodes.map((n) => {
-        if (n.id !== childId) return n
+        if (!detaching.has(n.id)) return n
         return {
           ...n,
           parentId: undefined,

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -56,6 +56,81 @@ function orderParentsFirst(nodes: Node<NodeData>[]): Node<NodeData>[] {
   return out
 }
 
+/** True when `maybeAncestorId` sits on `nodeId`'s parent chain. Cycle-safe. */
+function isAncestorOf(nodes: Node<NodeData>[], maybeAncestorId: string, nodeId: string): boolean {
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const seen = new Set<string>([nodeId])
+  let current = byId.get(nodeId)
+  while (current) {
+    const pid = parentIdOf(current)
+    if (!pid || seen.has(pid)) return false
+    if (pid === maybeAncestorId) return true
+    seen.add(pid)
+    current = byId.get(pid)
+  }
+  return false
+}
+
+/**
+ * Re-parent a batch of nodes under one target in a single history entry —
+ * a multi-selection dropped on a group, a container or a zone.
+ *
+ * `clamp` is the only behavioural difference between the three: a group and a
+ * container pin their children inside the box (`extent: 'parent'`), a zone
+ * deliberately does not, so a node stays draggable back out of it.
+ *
+ * Ineligible children are dropped rather than failing the whole batch: the
+ * target itself, a node already parented to it, a node whose own parent is in
+ * the same batch (it rides along with that parent — re-parenting it would tear
+ * it out), and any node the target descends from (which would create a cycle).
+ */
+function nestNodesUnder(
+  state: CanvasState,
+  targetId: string,
+  childIds: string[],
+  opts: { isValidTarget: (n: Node<NodeData>) => boolean; clamp: boolean },
+): Partial<CanvasState> | CanvasState {
+  const target = state.nodes.find((n) => n.id === targetId)
+  if (!target || !opts.isValidTarget(target)) return state
+
+  const batch = new Set(childIds)
+  const moving = new Set<string>()
+  for (const id of batch) {
+    const child = state.nodes.find((n) => n.id === id)
+    if (!child || child.id === targetId) continue
+    const pid = parentIdOf(child)
+    if (pid === targetId) continue
+    if (pid && batch.has(pid)) continue
+    if (isAncestorOf(state.nodes, child.id, targetId)) continue
+    moving.add(id)
+  }
+  if (moving.size === 0) return state
+
+  const nodes = orderParentsFirst(
+    state.nodes.map((n) => {
+      if (!moving.has(n.id)) return n
+      // Absolute → target-relative.
+      const x = n.position.x - target.position.x
+      const y = n.position.y - target.position.y
+      return {
+        ...n,
+        parentId: targetId,
+        extent: opts.clamp ? ('parent' as const) : undefined,
+        position: opts.clamp ? { x: Math.max(8, x), y: Math.max(8, y) } : { x, y },
+        selected: false,
+        data: { ...n.data, parent_id: targetId },
+      }
+    }),
+  )
+
+  return {
+    nodes,
+    hasUnsavedChanges: true,
+    past: [...state.past.slice(-49), { nodes: state.nodes, edges: state.edges }],
+    future: [],
+  }
+}
+
 // Zone subnet import: the grid the arrivals are packed on, in zone-relative
 // pixels. A cell is one node box plus the gap that follows it.
 const DEFAULT_ZONE_WIDTH = 360
@@ -243,8 +318,14 @@ interface CanvasState {
   createGroup: (nodeIds: string[], name: string) => void
   ungroup: (groupId: string) => void
   addToGroup: (groupId: string, childId: string) => void
+  /** Batch form of addToGroup — one history entry for the whole selection. */
+  addNodesToGroup: (groupId: string, childIds: string[]) => void
   addToContainer: (containerId: string, childId: string) => void
+  /** Batch form of addToContainer. */
+  addNodesToContainer: (containerId: string, childIds: string[]) => void
   addToZone: (zoneId: string, childId: string) => void
+  /** Batch form of addToZone. */
+  addNodesToZone: (zoneId: string, childIds: string[]) => void
   /** Move every free node whose IP falls in `cidr` into the zone. Returns the
    *  count moved; 0 for an invalid CIDR or no match. */
   importZoneSubnet: (zoneId: string, cidr: string) => number
@@ -899,138 +980,46 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
       }
     }),
 
-  // Nest an existing top-level node inside a group. Inverse of removeFromGroup.
-  addToGroup: (groupId, childId) =>
-    set((state) => {
-      const group = state.nodes.find((n) => n.id === groupId)
-      const child = state.nodes.find((n) => n.id === childId)
-      if (!group || !child || group.data.type !== 'group') return state
-      if (child.id === groupId || child.parentId === groupId) return state
+  // Nest existing nodes inside a group. Inverse of removeFromGroup. The
+  // singular form is the batch of one — a multi-selection dropped on a group
+  // lands in a single history entry.
+  addToGroup: (groupId, childId) => get().addNodesToGroup(groupId, [childId]),
 
-      const updatedNodes = state.nodes.map((n) => {
-        if (n.id !== childId) return n
-        return {
-          ...n,
-          parentId: groupId,
-          extent: 'parent' as const,
-          // Absolute → group-relative. Clamp so the node stays inside the box.
-          position: {
-            x: Math.max(8, n.position.x - group.position.x),
-            y: Math.max(8, n.position.y - group.position.y),
-          },
-          selected: false,
-          data: { ...n.data, parent_id: groupId },
-        }
-      })
+  addNodesToGroup: (groupId, childIds) =>
+    set((state) =>
+      nestNodesUnder(state, groupId, childIds, {
+        isValidTarget: (n) => n.data.type === 'group',
+        clamp: true,
+      }),
+    ),
 
-      // React Flow requires the parent to precede its children in the array.
-      const others = updatedNodes.filter((n) => n.id !== childId)
-      const movedChild = updatedNodes.find((n) => n.id === childId)!
-      const groupIdx = others.findIndex((n) => n.id === groupId)
-      const nodes = [
-        ...others.slice(0, groupIdx + 1),
-        movedChild,
-        ...others.slice(groupIdx + 1),
-      ]
+  // Nest existing nodes inside a container node (proxmox / docker_host / … in
+  // container_mode). Mirrors addToGroup but the target is any node with
+  // data.container_mode === true rather than a group.
+  addToContainer: (containerId, childId) => get().addNodesToContainer(containerId, [childId]),
 
-      return {
-        nodes,
-        hasUnsavedChanges: true,
-        past: [...state.past.slice(-49), { nodes: state.nodes, edges: state.edges }],
-        future: [],
-      }
-    }),
+  addNodesToContainer: (containerId, childIds) =>
+    set((state) =>
+      nestNodesUnder(state, containerId, childIds, {
+        isValidTarget: (n) => n.data.container_mode === true,
+        clamp: true,
+      }),
+    ),
 
-  // Nest an existing top-level node inside a container node (proxmox /
-  // docker_host / … in container_mode). Mirrors addToGroup but the target is
-  // any node with data.container_mode === true rather than a group.
-  addToContainer: (containerId, childId) =>
-    set((state) => {
-      const container = state.nodes.find((n) => n.id === containerId)
-      const child = state.nodes.find((n) => n.id === childId)
-      if (!container || !child || container.data.container_mode !== true) return state
-      if (child.id === containerId || child.parentId === containerId) return state
+  // Nest existing nodes inside a groupRect zone. Mirrors addToGroup, with one
+  // deliberate difference: NO `extent: 'parent'`. A zone is a loose visual
+  // area, so a child must stay draggable out of it — the canvas detaches it on
+  // drop (see CanvasContainer). Parenting is what makes moving the zone move
+  // its contents.
+  addToZone: (zoneId, childId) => get().addNodesToZone(zoneId, [childId]),
 
-      const updatedNodes = state.nodes.map((n) => {
-        if (n.id !== childId) return n
-        return {
-          ...n,
-          parentId: containerId,
-          extent: 'parent' as const,
-          // Absolute → container-relative. Clamp so the node stays inside.
-          position: {
-            x: Math.max(8, n.position.x - container.position.x),
-            y: Math.max(8, n.position.y - container.position.y),
-          },
-          selected: false,
-          data: { ...n.data, parent_id: containerId },
-        }
-      })
-
-      // React Flow requires the parent to precede its children in the array.
-      const others = updatedNodes.filter((n) => n.id !== childId)
-      const movedChild = updatedNodes.find((n) => n.id === childId)!
-      const containerIdx = others.findIndex((n) => n.id === containerId)
-      const nodes = [
-        ...others.slice(0, containerIdx + 1),
-        movedChild,
-        ...others.slice(containerIdx + 1),
-      ]
-
-      return {
-        nodes,
-        hasUnsavedChanges: true,
-        past: [...state.past.slice(-49), { nodes: state.nodes, edges: state.edges }],
-        future: [],
-      }
-    }),
-
-  // Nest an existing top-level node inside a groupRect zone. Mirrors
-  // addToGroup, with one deliberate difference: NO `extent: 'parent'`. A zone
-  // is a loose visual area, so a child must stay draggable out of it — the
-  // canvas detaches it on drop (see CanvasContainer). Parenting is what makes
-  // moving the zone move its contents.
-  addToZone: (zoneId, childId) =>
-    set((state) => {
-      const zone = state.nodes.find((n) => n.id === zoneId)
-      const child = state.nodes.find((n) => n.id === childId)
-      if (!zone || !child || zone.data.type !== 'groupRect') return state
-      if (child.id === zoneId || child.parentId === zoneId) return state
-      // A zone cannot become a child of a node it already contains.
-      if (zone.parentId === childId) return state
-
-      const updatedNodes = state.nodes.map((n) => {
-        if (n.id !== childId) return n
-        return {
-          ...n,
-          parentId: zoneId,
-          // Absolute → zone-relative.
-          position: {
-            x: n.position.x - zone.position.x,
-            y: n.position.y - zone.position.y,
-          },
-          selected: false,
-          data: { ...n.data, parent_id: zoneId },
-        }
-      })
-
-      // React Flow requires the parent to precede its children in the array.
-      const others = updatedNodes.filter((n) => n.id !== childId)
-      const movedChild = updatedNodes.find((n) => n.id === childId)!
-      const zoneIdx = others.findIndex((n) => n.id === zoneId)
-      const nodes = [
-        ...others.slice(0, zoneIdx + 1),
-        movedChild,
-        ...others.slice(zoneIdx + 1),
-      ]
-
-      return {
-        nodes,
-        hasUnsavedChanges: true,
-        past: [...state.past.slice(-49), { nodes: state.nodes, edges: state.edges }],
-        future: [],
-      }
-    }),
+  addNodesToZone: (zoneId, childIds) =>
+    set((state) =>
+      nestNodesUnder(state, zoneId, childIds, {
+        isValidTarget: (n) => n.data.type === 'groupRect',
+        clamp: false,
+      }),
+    ),
 
   // Pull every free node whose IP falls inside `cidr` into a zone, laying them
   // out on a grid in the zone's free space. Deliberately additive and one-shot:

--- a/mcp/app/tools.py
+++ b/mcp/app/tools.py
@@ -64,6 +64,18 @@ _NODE_FIELDS = {
     },
 }
 
+# A zone is a groupRect node: canvas furniture that visually groups the nodes
+# parented to it (a VLAN, a site, a rack room). It is deliberately kept out of
+# NODE_TYPES — create_node makes devices, these tools make and fill zones.
+ZONE_TYPE = "groupRect"
+
+_ZONE_COLOR_FIELDS = {
+    "border":       {"type": "string", "description": "Border/label colour, e.g. '#00d4ff'."},
+    "border_style": {"type": "string", "enum": ["solid", "dashed", "dotted"]},
+    "border_width": {"type": "number"},
+    "text_color":   {"type": "string", "description": "Label colour, e.g. '#e6edf3'."},
+}
+
 # Optional design/canvas selector. The backend attaches nodes/edges to the first
 # design when design_id is omitted (see backend nodes.py / edges.py), so these
 # tools stay backward compatible; pass design_id to target a specific canvas.
@@ -178,6 +190,38 @@ def _build_tools() -> list[Tool]:
             "required": ["id"],
             "properties": {"id": {"type": "string"}},
         }),
+        Tool(name="create_zone", description="Create a zone (a groupRect area) on the canvas. A zone visually groups the nodes parented to it — a VLAN, a site, a room. Use add_to_zone to fill it.", inputSchema={
+            "type": "object",
+            "required": ["label"],
+            "properties": {
+                "label":  {"type": "string", "description": "Zone name, shown in its top-left corner."},
+                "pos_x":  {"type": "number", "description": "X position on the canvas. Omit to auto-place."},
+                "pos_y":  {"type": "number", "description": "Y position on the canvas. Omit to auto-place."},
+                "width":  {"type": "number", "description": "Zone width in pixels (default 360)."},
+                "height": {"type": "number", "description": "Zone height in pixels (default 240)."},
+                **_ZONE_COLOR_FIELDS,
+                **_DESIGN_ID_FIELD,
+            },
+        }),
+        Tool(name="list_zones", description="List the zones (groupRect areas) on the canvas with their id, label, position, size and the nodes each one contains.", inputSchema={
+            "type": "object",
+            "properties": {},
+        }),
+        Tool(name="add_to_zone", description="Move one or more nodes into a zone. Positions are rebased on the zone so the nodes keep their place on screen. A node already in the zone, the zone itself, and any node the zone is nested in are skipped.", inputSchema={
+            "type": "object",
+            "required": ["zone_id", "node_ids"],
+            "properties": {
+                "zone_id":  {"type": "string", "description": "Target zone id — call list_zones to discover it."},
+                "node_ids": {"type": "array", "items": {"type": "string"}, "description": "Ids of the nodes to move in."},
+            },
+        }),
+        Tool(name="remove_from_zone", description="Take nodes back out of the zone they are in, restoring their absolute canvas position. Nodes that are not in a zone are left alone.", inputSchema={
+            "type": "object",
+            "required": ["node_ids"],
+            "properties": {
+                "node_ids": {"type": "array", "items": {"type": "string"}, "description": "Ids of the nodes to detach."},
+            },
+        }),
         Tool(name="list_designs", description="List all designs (canvases) with their IDs and node/group/text counts", inputSchema={
             "type": "object",
             "properties": {},
@@ -258,6 +302,34 @@ def _slim_node_summary(n: dict) -> dict:
     return {"id": n.get("id"), "label": n.get("label"), "type": n.get("type"), "status": n.get("status")}
 
 
+def _slim_zone(z: dict, nodes: list[dict]) -> dict:
+    """A zone plus the ids of the nodes parented to it."""
+    return {
+        "id": z.get("id"),
+        "label": z.get("label"),
+        "pos_x": z.get("pos_x"),
+        "pos_y": z.get("pos_y"),
+        "width": z.get("width"),
+        "height": z.get("height"),
+        "node_ids": [n["id"] for n in nodes if n.get("parent_id") == z.get("id")],
+    }
+
+
+def _is_ancestor(nodes_by_id: dict[str, dict], maybe_ancestor_id: str, node_id: str) -> bool:
+    """True when `maybe_ancestor_id` sits on `node_id`'s parent chain. Cycle-safe."""
+    seen = {node_id}
+    current = nodes_by_id.get(node_id)
+    while current:
+        pid = current.get("parent_id")
+        if not pid or pid in seen:
+            return False
+        if pid == maybe_ancestor_id:
+            return True
+        seen.add(pid)
+        current = nodes_by_id.get(pid)
+    return False
+
+
 async def _dispatch(name: str, args: dict) -> dict:
     if name == "create_node":
         return await backend.post("/api/v1/nodes", args)
@@ -330,6 +402,70 @@ async def _dispatch(name: str, args: dict) -> dict:
 
     if name == "restore_device":
         return await backend.post(f"/api/v1/scan/pending/{args['id']}/restore", {})
+
+    if name == "create_zone":
+        colors = {k: args.pop(k) for k in list(_ZONE_COLOR_FIELDS) if k in args}
+        body = {
+            "type": ZONE_TYPE,
+            "status": "unknown",
+            "width": args.pop("width", 360),
+            "height": args.pop("height", 240),
+            **args,
+        }
+        if colors:
+            body["custom_colors"] = colors
+        return await backend.post("/api/v1/nodes", body)
+
+    if name == "list_zones":
+        nodes = await backend.get("/api/v1/nodes")
+        return [_slim_zone(n, nodes) for n in nodes if n.get("type") == ZONE_TYPE]
+
+    if name == "add_to_zone":
+        zone_id = args["zone_id"]
+        nodes = await backend.get("/api/v1/nodes")
+        by_id = {n["id"]: n for n in nodes}
+        zone = by_id.get(zone_id)
+        if zone is None or zone.get("type") != ZONE_TYPE:
+            raise ValueError(f"add_to_zone: {zone_id} is not a zone")
+        moved, skipped = [], []
+        for node_id in args["node_ids"]:
+            node = by_id.get(node_id)
+            if (
+                node is None
+                or node_id == zone_id
+                or node.get("parent_id") == zone_id
+                or _is_ancestor(by_id, node_id, zone_id)
+            ):
+                skipped.append(node_id)
+                continue
+            # The canvas stores a child's position relative to its parent, so
+            # rebase or the node jumps by the zone's offset on the next load.
+            await backend.patch(f"/api/v1/nodes/{node_id}", {
+                "parent_id": zone_id,
+                "pos_x": (node.get("pos_x") or 0) - (zone.get("pos_x") or 0),
+                "pos_y": (node.get("pos_y") or 0) - (zone.get("pos_y") or 0),
+            })
+            moved.append(node_id)
+        return {"zone_id": zone_id, "moved": moved, "skipped": skipped}
+
+    if name == "remove_from_zone":
+        nodes = await backend.get("/api/v1/nodes")
+        by_id = {n["id"]: n for n in nodes}
+        detached, skipped = [], []
+        for node_id in args["node_ids"]:
+            node = by_id.get(node_id)
+            zone = by_id.get(node.get("parent_id") or "") if node else None
+            if node is None or zone is None or zone.get("type") != ZONE_TYPE:
+                skipped.append(node_id)
+                continue
+            # Zone-relative → absolute, so the node stays where it looks.
+            await backend.patch(f"/api/v1/nodes/{node_id}", {
+                "parent_id": None,
+                "pos_x": (node.get("pos_x") or 0) + (zone.get("pos_x") or 0),
+                "pos_y": (node.get("pos_y") or 0) + (zone.get("pos_y") or 0),
+            })
+            detached.append(node_id)
+        return {"detached": detached, "skipped": skipped}
 
     if name == "list_designs":
         return await backend.get("/api/v1/designs")

--- a/mcp/app/tools.py
+++ b/mcp/app/tools.py
@@ -154,7 +154,9 @@ def _build_tools() -> list[Tool]:
         }),
         Tool(name="get_canvas", description="Get the full canvas: all nodes and edges in the homelab topology", inputSchema={
             "type": "object",
-            "properties": {**_DESIGN_ID_FIELD},
+            "properties": {
+                "design_id": {"type": "string", "description": "Only list zones on this design/canvas. Omit to list every design's zones; call list_designs to discover IDs."},
+            },
         }),
         Tool(name="list_nodes", description="List all nodes (devices) in the homelab", inputSchema={
             "type": "object",
@@ -203,11 +205,13 @@ def _build_tools() -> list[Tool]:
                 **_DESIGN_ID_FIELD,
             },
         }),
-        Tool(name="list_zones", description="List the zones (groupRect areas) on the canvas with their id, label, position, size and the nodes each one contains.", inputSchema={
+        Tool(name="list_zones", description="List the zones (groupRect areas) on the canvas with their id, label, position, size and the nodes each one contains. Lists every design's zones unless design_id narrows it.", inputSchema={
             "type": "object",
-            "properties": {},
+            "properties": {
+                "design_id": {"type": "string", "description": "Only list zones on this design/canvas. Omit to list every design's zones; call list_designs to discover IDs."},
+            },
         }),
-        Tool(name="add_to_zone", description="Move one or more nodes into a zone. Positions are rebased on the zone so the nodes keep their place on screen. A node already in the zone, the zone itself, and any node the zone is nested in are skipped.", inputSchema={
+        Tool(name="add_to_zone", description="Move one or more nodes into a zone. Positions are rebased on the zone so the nodes keep their place on screen. A node already in the zone, the zone itself, a node on another design, and any node the zone is nested in are skipped.", inputSchema={
             "type": "object",
             "required": ["zone_id", "node_ids"],
             "properties": {
@@ -307,6 +311,7 @@ def _slim_zone(z: dict, nodes: list[dict]) -> dict:
     return {
         "id": z.get("id"),
         "label": z.get("label"),
+        "design_id": z.get("design_id"),
         "pos_x": z.get("pos_x"),
         "pos_y": z.get("pos_y"),
         "width": z.get("width"),
@@ -417,8 +422,15 @@ async def _dispatch(name: str, args: dict) -> dict:
         return await backend.post("/api/v1/nodes", body)
 
     if name == "list_zones":
+        # /api/v1/nodes has no design filter — it returns every design's nodes,
+        # so narrow here when the caller named one.
+        design_id = args.get("design_id")
         nodes = await backend.get("/api/v1/nodes")
-        return [_slim_zone(n, nodes) for n in nodes if n.get("type") == ZONE_TYPE]
+        return [
+            _slim_zone(n, nodes)
+            for n in nodes
+            if n.get("type") == ZONE_TYPE and (design_id is None or n.get("design_id") == design_id)
+        ]
 
     if name == "add_to_zone":
         zone_id = args["zone_id"]
@@ -434,6 +446,9 @@ async def _dispatch(name: str, args: dict) -> dict:
                 node is None
                 or node_id == zone_id
                 or node.get("parent_id") == zone_id
+                # A zone only groups its own canvas: parenting across designs
+                # would hide the node on the design it belongs to.
+                or node.get("design_id") != zone.get("design_id")
                 or _is_ancestor(by_id, node_id, zone_id)
             ):
                 skipped.append(node_id)

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -530,3 +530,105 @@ async def test_list_hidden_devices(mock_backend):
 async def test_restore_device(mock_backend):
     await _dispatch("restore_device", {"id": "5"})
     mock_backend.post.assert_called_once_with("/api/v1/scan/pending/5/restore", {})
+
+
+# ── Zones (#365) ─────────────────────────────────────────────────────────────
+
+_ZONE_NODES = [
+    {"id": "z1", "type": "groupRect", "label": "DMZ", "pos_x": 100, "pos_y": 100, "width": 400, "height": 300},
+    {"id": "n1", "type": "router", "label": "Router", "pos_x": 160, "pos_y": 220},
+    {"id": "n2", "type": "server", "label": "NAS", "pos_x": 200, "pos_y": 260, "parent_id": "z1"},
+]
+
+
+@pytest.mark.anyio
+async def test_create_zone_posts_a_grouprect_node(mock_backend):
+    await _dispatch("create_zone", {"label": "DMZ", "pos_x": 10, "pos_y": 20})
+    mock_backend.post.assert_called_once_with("/api/v1/nodes", {
+        "type": "groupRect", "status": "unknown", "width": 360, "height": 240,
+        "label": "DMZ", "pos_x": 10, "pos_y": 20,
+    })
+
+
+@pytest.mark.anyio
+async def test_create_zone_folds_colors_into_custom_colors(mock_backend):
+    await _dispatch("create_zone", {"label": "VLAN 10", "border": "#39d353", "border_style": "dashed", "width": 500})
+    body = mock_backend.post.call_args[0][1]
+    assert body["custom_colors"] == {"border": "#39d353", "border_style": "dashed"}
+    assert body["width"] == 500
+    assert "border" not in body
+
+
+def test_create_zone_schema_requires_label():
+    tool = next(t for t in TOOLS if t.name == "create_zone")
+    assert tool.inputSchema["required"] == ["label"]
+
+
+def test_zone_type_is_not_offered_by_create_node():
+    """A zone is canvas furniture — create_node stays a device tool."""
+    tool = next(t for t in TOOLS if t.name == "create_node")
+    assert "groupRect" not in tool.inputSchema["properties"]["type"]["enum"]
+
+
+@pytest.mark.anyio
+async def test_list_zones_returns_only_zones_with_their_children(mock_backend):
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    result = await _dispatch("list_zones", {})
+    assert result == [{
+        "id": "z1", "label": "DMZ", "pos_x": 100, "pos_y": 100,
+        "width": 400, "height": 300, "node_ids": ["n2"],
+    }]
+
+
+@pytest.mark.anyio
+async def test_add_to_zone_rebases_positions_on_the_zone(mock_backend):
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    result = await _dispatch("add_to_zone", {"zone_id": "z1", "node_ids": ["n1"]})
+    mock_backend.patch.assert_called_once_with(
+        "/api/v1/nodes/n1", {"parent_id": "z1", "pos_x": 60, "pos_y": 120}
+    )
+    assert result == {"zone_id": "z1", "moved": ["n1"], "skipped": []}
+
+
+@pytest.mark.anyio
+async def test_add_to_zone_skips_the_zone_itself_and_nodes_already_in_it(mock_backend):
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    result = await _dispatch("add_to_zone", {"zone_id": "z1", "node_ids": ["z1", "n2", "ghost"]})
+    mock_backend.patch.assert_not_called()
+    assert result["moved"] == []
+    assert result["skipped"] == ["z1", "n2", "ghost"]
+
+
+@pytest.mark.anyio
+async def test_add_to_zone_refuses_a_node_the_zone_descends_from(mock_backend):
+    """Parenting a zone's own ancestor under it would build a cycle."""
+    mock_backend.get = AsyncMock(return_value=[
+        {"id": "outer", "type": "groupRect", "pos_x": 0, "pos_y": 0},
+        {"id": "z1", "type": "groupRect", "pos_x": 100, "pos_y": 100, "parent_id": "outer"},
+    ])
+    result = await _dispatch("add_to_zone", {"zone_id": "z1", "node_ids": ["outer"]})
+    mock_backend.patch.assert_not_called()
+    assert result["skipped"] == ["outer"]
+
+
+@pytest.mark.anyio
+async def test_add_to_zone_rejects_a_target_that_is_not_a_zone(mock_backend):
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    with pytest.raises(ValueError, match="is not a zone"):
+        await _dispatch("add_to_zone", {"zone_id": "n1", "node_ids": ["n2"]})
+
+
+@pytest.mark.anyio
+async def test_remove_from_zone_restores_absolute_positions(mock_backend):
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    result = await _dispatch("remove_from_zone", {"node_ids": ["n2", "n1"]})
+    mock_backend.patch.assert_called_once_with(
+        "/api/v1/nodes/n2", {"parent_id": None, "pos_x": 300, "pos_y": 360}
+    )
+    # n1 has no parent — nothing to detach.
+    assert result == {"detached": ["n2"], "skipped": ["n1"]}
+
+
+def test_zone_tools_are_registered():
+    names = {t.name for t in TOOLS}
+    assert {"create_zone", "list_zones", "add_to_zone", "remove_from_zone"} <= names

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -535,9 +535,11 @@ async def test_restore_device(mock_backend):
 # ── Zones (#365) ─────────────────────────────────────────────────────────────
 
 _ZONE_NODES = [
-    {"id": "z1", "type": "groupRect", "label": "DMZ", "pos_x": 100, "pos_y": 100, "width": 400, "height": 300},
-    {"id": "n1", "type": "router", "label": "Router", "pos_x": 160, "pos_y": 220},
-    {"id": "n2", "type": "server", "label": "NAS", "pos_x": 200, "pos_y": 260, "parent_id": "z1"},
+    {"id": "z1", "type": "groupRect", "label": "DMZ", "design_id": "d1", "pos_x": 100, "pos_y": 100, "width": 400, "height": 300},
+    {"id": "n1", "type": "router", "label": "Router", "design_id": "d1", "pos_x": 160, "pos_y": 220},
+    {"id": "n2", "type": "server", "label": "NAS", "design_id": "d1", "pos_x": 200, "pos_y": 260, "parent_id": "z1"},
+    {"id": "z2", "type": "groupRect", "label": "Lab", "design_id": "d2", "pos_x": 0, "pos_y": 0, "width": 200, "height": 200},
+    {"id": "other", "type": "server", "label": "Other canvas", "design_id": "d2", "pos_x": 10, "pos_y": 10},
 ]
 
 
@@ -574,10 +576,35 @@ def test_zone_type_is_not_offered_by_create_node():
 async def test_list_zones_returns_only_zones_with_their_children(mock_backend):
     mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
     result = await _dispatch("list_zones", {})
-    assert result == [{
-        "id": "z1", "label": "DMZ", "pos_x": 100, "pos_y": 100,
-        "width": 400, "height": 300, "node_ids": ["n2"],
-    }]
+    assert result == [
+        {
+            "id": "z1", "label": "DMZ", "design_id": "d1", "pos_x": 100, "pos_y": 100,
+            "width": 400, "height": 300, "node_ids": ["n2"],
+        },
+        {
+            "id": "z2", "label": "Lab", "design_id": "d2", "pos_x": 0, "pos_y": 0,
+            "width": 200, "height": 200, "node_ids": [],
+        },
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_zones_narrows_to_one_design(mock_backend):
+    """/api/v1/nodes has no design filter, so the tool applies it."""
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    result = await _dispatch("list_zones", {"design_id": "d2"})
+    assert [z["id"] for z in result] == ["z2"]
+
+
+@pytest.mark.anyio
+async def test_add_to_zone_skips_a_node_from_another_design(mock_backend):
+    """A zone groups its own canvas; parenting across designs would hide the
+    node on the design it belongs to."""
+    mock_backend.get = AsyncMock(return_value=list(_ZONE_NODES))
+    result = await _dispatch("add_to_zone", {"zone_id": "z1", "node_ids": ["other", "n1"]})
+    assert result["moved"] == ["n1"]
+    assert result["skipped"] == ["other"]
+    assert mock_backend.patch.call_count == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #365.

## What
Dropping a multi-selection on a zone only moved one node, and the MCP server had no way to create a zone or put anything in one. This PR makes a drop move the whole selection (zones, groups and container nodes alike) and adds four zone tools to the MCP server.

## Changes

### Frontend — canvas
- `CanvasContainer` now reads the whole dragged selection (`dragNodes`) on drag stop; the node under the cursor only picks the destination. Dragging a selection out of a zone detaches every dragged child, not just one.
- New batch store actions `addNodesToZone` / `addNodesToGroup` / `addNodesToContainer`, sharing one `nestNodesUnder` helper. The move lands in a single history entry, so one undo takes the whole batch back. The existing singular actions delegate to them and behave as before.
- Nodes that cannot be moved are skipped rather than failing the batch: the destination itself, a node already parented to it, a node whose own parent is in the same selection (it already rides along with that parent — the "children including the parent" case from the issue), and any node the destination descends from, which would create a parent cycle.
- `ConfirmAddToGroupModal` takes `nodeLabels: string[]` instead of `nodeLabel: string` and counts them: "Add 3 nodes (Router, Switch, NAS) to the zone DMZ?", with the tail past five labels summarized as "+N more". Single-node wording is unchanged.

### MCP server
- `create_zone` — creates a `groupRect` node with label, position, size and border/text colours.
- `list_zones` — the zones on the canvas with their position, size and the ids of the nodes each contains.
- `add_to_zone` / `remove_from_zone` — move a list of nodes in or out.
- Both movers fix up coordinates: the canvas stores a child's position relative to its parent, so entering a zone rebases on it and leaving restores absolute coordinates. Without this a node jumps by the zone's offset the next time the canvas loads.
- `add_to_zone` applies the same skip rules as the canvas and returns `{moved, skipped}` instead of failing the whole call.
- All four run on the existing `/api/v1/nodes` endpoints — no backend change. `groupRect` stays out of `NODE_TYPES`, so `create_node` remains a device tool and the enum sync tests are untouched.

No migrations, no breaking changes for users. The only API change is internal: the three `onRequestAddTo*` canvas callbacks and the confirmation modal now take a list of ids/labels.

## Testing
- `npm test` — 2147 passing (153 files), plus `npm run lint` and `npm run typecheck`.
- New store tests in `stores/__tests__/canvasStore/zones.test.ts`: batch add, single-step undo, parent-and-children selection, cycle refusal, group clamping, container batch.
- New `CanvasContainer` tests: multi-drag onto a zone, zones and groups excluded from a selection, the destination never added to itself, an already-parented node left alone, and a selection detached as a whole.
- New `ConfirmAddToGroupModal` tests for the plural wording and the "+N more" truncation.
- `mcp/tests/test_tools.py` — 157 passing, with 10 new cases covering the four tools, the position rebasing in both directions, the skip rules and the non-zone target error.

ha-relevant: maybe

The canvas commit is `ha-relevant: yes` (the store and drag handler are shared with homelable-hacs); the MCP commit is `ha-relevant: no`.
