### PR TITLE
fix: keep a nested container ahead of its children in the node array

### DIFF
--- a/frontend/src/stores/__tests__/canvasStore/zones.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/zones.test.ts
@@ -485,3 +485,87 @@ describe('canvasStore — importZoneSubnet', () => {
     expect(nodes.find((n) => n.id === 'n2')!.parentId).toBeUndefined()
   })
 })
+
+describe('canvasStore — nesting order with a container inside a zone', () => {
+  beforeEach(resetStore)
+
+  // A zone can hold a container, so the tree is two levels deep. React Flow
+  // needs every parent to precede its children in the array; when it doesn't,
+  // it drops the child's parent binding — the child loses its extent clamp and
+  // drags anywhere on the canvas (#366 follow-up).
+  const container = (id: string, parentId?: string) => ({
+    ...makeNode(id, { type: 'proxmox', container_mode: true, ...(parentId ? { parent_id: parentId } : {}) }),
+    position: { x: 50, y: 50 },
+    width: 300,
+    height: 200,
+    ...(parentId ? { parentId } : {}),
+  })
+  const nested = (id: string, parentId: string) => ({
+    ...makeNode(id, { type: 'vm', parent_id: parentId }),
+    position: { x: 20, y: 30 },
+    parentId,
+    extent: 'parent' as const,
+  })
+  const order = () => useCanvasStore.getState().nodes.map((n) => n.id)
+
+  it('addNodesToZone keeps the container ahead of its own children', () => {
+    useCanvasStore.setState({ nodes: [zone('z1'), container('px'), nested('vm1', 'px')] })
+    useCanvasStore.getState().addNodesToZone('z1', ['px'])
+
+    const ids = order()
+    expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('px'))
+    expect(ids.indexOf('px')).toBeLessThan(ids.indexOf('vm1'))
+    // The nested child rides along untouched: still clamped inside its container.
+    const vm = useCanvasStore.getState().nodes.find((n) => n.id === 'vm1')!
+    expect(vm.parentId).toBe('px')
+    expect(vm.extent).toBe('parent')
+  })
+
+  it('loadCanvas reorders a container ahead of its child, not just the parentless nodes', () => {
+    // Server order: the nested child was created before the container it now
+    // sits in, so both land in the "has a parent" bucket child-first.
+    useCanvasStore.getState().loadCanvas([nested('vm1', 'px'), container('px', 'z1'), zone('z1')], [])
+
+    const ids = order()
+    expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('px'))
+    expect(ids.indexOf('px')).toBeLessThan(ids.indexOf('vm1'))
+  })
+
+  it('applyLayout reorders a container ahead of its child', () => {
+    useCanvasStore.getState().applyLayout([nested('vm1', 'px'), container('px', 'z1'), zone('z1')], [])
+
+    const ids = order()
+    expect(ids.indexOf('px')).toBeLessThan(ids.indexOf('vm1'))
+  })
+
+  it('updateNode re-parenting keeps a nested container ahead of its child', () => {
+    useCanvasStore.setState({ nodes: [nested('vm1', 'px'), container('px'), zone('z1')] })
+    useCanvasStore.getState().updateNode('px', { parent_id: 'z1' })
+
+    const ids = order()
+    expect(ids.indexOf('z1')).toBeLessThan(ids.indexOf('px'))
+    expect(ids.indexOf('px')).toBeLessThan(ids.indexOf('vm1'))
+    const vm = useCanvasStore.getState().nodes.find((n) => n.id === 'vm1')!
+    expect(vm.extent).toBe('parent')
+  })
+
+  it('pasteNodes appends a copied container ahead of its copied child', () => {
+    useCanvasStore.setState({
+      nodes: [
+        zone('z1'),
+        { ...container('px', 'z1'), selected: true },
+        { ...nested('vm1', 'px'), selected: true },
+      ],
+      selectedNodeIds: ['px', 'vm1'],
+    })
+    useCanvasStore.getState().copySelectedNodes()
+    useCanvasStore.getState().pasteNodes({ x: 600, y: 600 })
+
+    const nodes = useCanvasStore.getState().nodes
+    const pasted = nodes.filter((n) => n.selected)
+    const parent = pasted.find((n) => n.data.type === 'proxmox')!
+    const child = pasted.find((n) => n.data.type === 'vm')!
+    expect(child.parentId).toBe(parent.id)
+    expect(nodes.indexOf(parent)).toBeLessThan(nodes.indexOf(child))
+  })
+})

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -35,6 +35,13 @@ const parentIdOf = (n: Node<NodeData>): string | undefined => n.parentId ?? n.da
  * resolve nesting — a child listed first renders detached and logs a
  * parent-not-found error. Order is otherwise preserved: a list that is already
  * valid comes back untouched. A parent cycle terminates instead of recursing.
+ *
+ * This is a topological sort, not a "parentless first, the rest after" split.
+ * The split held only while nesting was one level deep; a zone can hold a
+ * container, so a container and its own children now sit in the same bucket and
+ * the child can land ahead of its parent. React Flow then drops the child's
+ * parent binding entirely — no relative position, no `extent: 'parent'` clamp,
+ * so it renders detached and drags anywhere (#366 follow-up).
  */
 function orderParentsFirst(nodes: Node<NodeData>[]): Node<NodeData>[] {
   const byId = new Map(nodes.map((n) => [n.id, n]))
@@ -509,9 +516,7 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
       }))
 
       // React Flow requires parents before children within the appended block.
-      const parents = pasted.filter((n) => !n.parentId)
-      const children = pasted.filter((n) => !!n.parentId)
-      const pastedNodes = [...parents, ...children]
+      const pastedNodes = orderParentsFirst(pasted)
 
       // Deselect everything already on the canvas so only the paste is selected.
       const existing = state.nodes.map((n) => (n.selected ? { ...n, selected: false } : n))
@@ -675,9 +680,7 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
       })
       // React Flow requires parent nodes to precede their children in the array
       if ('parent_id' in data) {
-        const parents = nodes.filter((n) => !n.parentId)
-        const children = nodes.filter((n) => !!n.parentId)
-        nodes = [...parents, ...children]
+        nodes = orderParentsFirst(nodes)
       }
       // Remap edges when any side's handle count is reduced so no edge disappears.
       // Removed handles fall back to the side's slot-0 id, or 'bottom' if the
@@ -833,9 +836,7 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
         return n
       })
       if (enabled) {
-        const parents = nodes.filter((n) => !n.parentId)
-        const children = nodes.filter((n) => !!n.parentId)
-        nodes = [...parents, ...children]
+        nodes = orderParentsFirst(nodes)
       }
       return { nodes, hasUnsavedChanges: true }
     }),
@@ -1233,13 +1234,11 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
   requestFloorMapEdit: () => set((s) => ({ floorMapEditNonce: s.floorMapEditNonce + 1 })),
 
   loadCanvas: (nodes, edges) => {
-    // React Flow requires parents before children in the array
-    const parents = nodes.filter((n) => !n.parentId)
-    const children = nodes.filter((n) => !!n.parentId)
     // NOTE: clipboard is intentionally preserved here so nodes copied in one
     // design can be pasted after switching to another design.
     set({
-      nodes: [...parents, ...children],
+      // React Flow requires parents before children in the array.
+      nodes: orderParentsFirst(nodes),
       edges,
       hasUnsavedChanges: false,
       selectedNodeId: null,
@@ -1253,11 +1252,9 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
 
   applyLayout: (nodes, edges) =>
     set((state) => {
-      // React Flow requires parents before children in the array
-      const parents = nodes.filter((n) => !n.parentId)
-      const children = nodes.filter((n) => !!n.parentId)
       return {
-        nodes: [...parents, ...children],
+        // React Flow requires parents before children in the array.
+        nodes: orderParentsFirst(nodes),
         edges,
         past: [...state.past.slice(-49), { nodes: state.nodes, edges: state.edges }],
         future: [],


### PR DESCRIPTION
## What

Fixes a follow-up to #366: after dropping a container-mode node (Proxmox, docker host, ...) into a zone, its own children lost the box they were pinned inside and could be dragged anywhere on the canvas.

Root cause is node ordering, not node data. React Flow requires every parent to precede its children in the `nodes` array. The store enforced that with a two-bucket split — parentless nodes first, everything else after — which is only correct while nesting is one level deep. A zone can hold a container, so the container and its children now sit in the same bucket, and a child whose row predates its parent's ends up ahead of it. React Flow then drops that child's parent binding completely: no parent-relative position, no `extent: 'parent'` clamp, so it renders detached and drags free. It also logs `Parent node <id> not found. Please make sure that parent nodes are in front of their child nodes in the nodes array.`

The child's stored state (`parentId`, `extent`) was correct throughout, which is why the bug looked like data loss.

## Changes

Frontend (`stores/canvasStore.ts`):
- `orderParentsFirst` — the topological sort that already backed the zone drop — now covers every reorder site: `loadCanvas`, `applyLayout`, `updateNode`'s re-parent path, `setProxmoxContainerMode` and `pasteNodes`. The two-bucket split is gone.
- Its doc comment now records why the split was insufficient, so it is not reintroduced.

No API, schema or persistence change. Existing canvases are fixed on their next load.

## Testing

- 5 regression tests in `frontend/src/stores/__tests__/canvasStore/zones.test.ts` (new describe block covering a container nested inside a zone): the zone drop, `loadCanvas` with server-order child-before-parent, `applyLayout`, `updateNode` re-parenting and paste. 3 of them fail on `main`.
- Ordering behaviour was verified directly against `@xyflow/system`'s `adoptUserNodes`: with the child listed first it resolves to `positionAbsolute {20,30}` (its raw relative position, unparented); with the parent first, `{170,180}`.
- `npm run lint`, `npm run typecheck`, `npm test` — 2155 tests pass.

ha-relevant: yes
