### PR TITLE
feat: native bare-metal install path (no Docker)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:12
     timeout-minutes: 25
+    # Without this the runner hands container steps `sh -e {0}` — dash, where
+    # `set -o pipefail` and `[[ … ]]` are syntax errors.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Install checkout prerequisites
         run: |

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,126 @@
+name: Install smoke test
+
+# Runs scripts/install-baremetal.sh for real, in a clean debian:12 container.
+# ShellCheck reads the script but never executes it, so it cannot catch an
+# unintended `set -euo pipefail` abort — the failure class this job exists for.
+# debian:12 reproduces the two conditions that broke the installer once already:
+# the image carries no Node at all (so the version probe and the nodesource
+# install both run) and the job has no TTY (so the prompt fallbacks run).
+#
+# What it does not cover: systemd. A container has no PID 1 systemd, so
+# `systemctl` is stubbed out and the unit is written but never started. The
+# backend is booted by hand afterwards to prove the generated .env parses.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/install-baremetal.sh'
+      - 'backend/requirements.txt'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - '.github/workflows/install-smoke.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/install-baremetal.sh'
+      - 'backend/requirements.txt'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - '.github/workflows/install-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  baremetal:
+    runs-on: ubuntu-latest
+    container: debian:12
+    timeout-minutes: 25
+    steps:
+      - name: Install checkout prerequisites
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git ca-certificates >/dev/null
+
+      - uses: actions/checkout@v4
+
+      - name: Confirm the container reproduces a fresh host
+        run: |
+          set -euo pipefail
+          node --version || echo "no node — the nodesource path will run"
+          [ -t 0 ] && echo "TTY present (unexpected)" || echo "no TTY — prompt fallbacks will run"
+
+      - name: Stub systemctl
+        # No PID 1 systemd in a container. The stub logs the calls so the run
+        # shows which unit actions the script attempted.
+        run: |
+          printf '#!/bin/sh\necho "[systemctl stub] $*"\n' > /usr/local/bin/systemctl
+          chmod +x /usr/local/bin/systemctl
+
+      - name: Run the installer
+        # INSTALL_DIR is the checkout, so the clone is skipped and the script
+        # installs the tree under test rather than main. SKIP_NGINX because the
+        # front end is not what this job is asserting.
+        run: |
+          INSTALL_DIR="$GITHUB_WORKSPACE" \
+          SKIP_NGINX=1 \
+          ADMIN_PASSWORD=ci-smoke-password \
+          SCANNER_RANGES='["10.0.0.0/24"]' \
+          bash scripts/install-baremetal.sh
+
+      - name: The generated .env is well formed
+        run: |
+          set -euo pipefail
+          test -f backend/.env
+          grep -qE '^SECRET_KEY=[0-9a-f]{64}$' backend/.env
+          grep -qE '^AUTH_PASSWORD_HASH=.\$2b\$' backend/.env
+          # JSON values must stay single-quoted: systemd's EnvironmentFile
+          # parser strips bare double quotes, which would break the JSON.
+          grep -qE "^CORS_ORIGINS='\\[" backend/.env
+          grep -qE "^SCANNER_RANGES='\\[" backend/.env
+          grep -q "^SQLITE_PATH=$GITHUB_WORKSPACE/data/homelab.db$" backend/.env
+          test "$(stat -c '%a' backend/.env)" = "600"
+
+      - name: The build artefacts and service user exist
+        run: |
+          set -euo pipefail
+          test -x backend/.venv/bin/uvicorn
+          test -f frontend/dist/index.html
+          id homelable
+
+      - name: The systemd unit was written
+        run: |
+          set -euo pipefail
+          test -f /etc/systemd/system/homelable.service
+          grep -q 'ExecStart=.*/uvicorn app.main:app --host 127.0.0.1 --port 8000' \
+            /etc/systemd/system/homelable.service
+          grep -q "EnvironmentFile=$GITHUB_WORKSPACE/backend/.env" \
+            /etc/systemd/system/homelable.service
+
+      - name: The backend boots on the generated config
+        # The unit's own ExecStart, run by hand. Proves the .env pydantic reads
+        # is valid — the assertion that catches config drift.
+        run: |
+          set -euo pipefail
+          cd backend
+          .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8000 &
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8000/api/v1/health >/dev/null 2>&1; then
+              echo "backend healthy"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "backend did not answer /api/v1/health within 30s" >&2
+          exit 1
+
+      - name: Re-running is idempotent and keeps .env
+        run: |
+          set -euo pipefail
+          before="$(sha256sum backend/.env)"
+          INSTALL_DIR="$GITHUB_WORKSPACE" SKIP_NGINX=1 \
+            bash scripts/install-baremetal.sh | tee /tmp/run2.log
+          after="$(sha256sum backend/.env)"
+          test "$before" = "$after" || { echo "second run rewrote backend/.env" >&2; exit 1; }
+          grep -q 'keeping existing values' /tmp/run2.log

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -89,6 +89,152 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/Proxmo
 
 ---
 
+## Bare metal — no Docker
+
+`scripts/install-baremetal.sh` installs Homelable natively on a Debian 12+ /
+Ubuntu 22.04+ host (physical, VM or LXC): a Python venv and a `homelable`
+systemd unit for the backend on `127.0.0.1:8000`, the built frontend served by
+nginx on port 3000.
+
+```bash
+git clone https://github.com/Pouzor/homelable.git /opt/homelable
+sudo bash /opt/homelable/scripts/install-baremetal.sh
+```
+
+The script can also clone for you — run it from anywhere and it fetches the repo
+into `INSTALL_DIR` if that directory is empty:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Pouzor/homelable/main/scripts/install-baremetal.sh \
+  | sudo bash
+```
+
+It prompts for the admin password and the CIDR range to scan, then writes
+`backend/.env` with a generated `SECRET_KEY` and bcrypt hash. Open
+**http://\<host-ip\>:3000**.
+
+Re-running is safe and is how you upgrade — an existing `backend/.env` is kept
+untouched, everything else is rebuilt:
+
+```bash
+cd /opt/homelable && git pull
+sudo bash scripts/install-baremetal.sh
+```
+
+### Options
+
+Every setting is an environment variable, so a non-interactive install is one line:
+
+```bash
+sudo HTTP_PORT=8080 ADMIN_PASSWORD=hunter2 SCANNER_RANGES='["10.0.0.0/24"]' \
+  bash scripts/install-baremetal.sh
+```
+
+| Variable | Default | What |
+|---|---|---|
+| `INSTALL_DIR` | `/opt/homelable` | Repo root |
+| `REPO_URL` / `REPO_REF` | upstream / `main` | Used only when `INSTALL_DIR` is empty |
+| `SERVICE_USER` | `homelable` | systemd `User=` |
+| `BACKEND_PORT` | `8000` | uvicorn port, bound to loopback |
+| `HTTP_PORT` | `3000` | nginx port |
+| `SERVER_NAME` | `_` | nginx `server_name` |
+| `ADMIN_PASSWORD` | prompt (`admin`) | Initial password for user `admin` |
+| `SCANNER_RANGES` | prompt (guessed) | JSON array of CIDRs |
+| `SKIP_NGINX=1` | off | Do not install or touch nginx |
+
+### Afterwards
+
+```bash
+systemctl status homelable
+journalctl -u homelable -f
+```
+
+- Config: `/opt/homelable/backend/.env` — every other option (OIDC, MCP,
+  Proxmox, Zigbee, Z-Wave, live view) is documented in `.env.example`.
+  `systemctl restart homelable` after an edit.
+- Data: `/opt/homelable/data` — SQLite DB and uploads. Back up this folder.
+- nginx site: `/etc/nginx/sites-available/homelable`.
+
+Change the password later:
+
+```bash
+/opt/homelable/backend/.venv/bin/python -c \
+  'import bcrypt; print(bcrypt.hashpw(b"newpassword", bcrypt.gensalt()).decode())'
+# put it in backend/.env as AUTH_PASSWORD_HASH='$2b$12$...' (keep the single quotes)
+systemctl restart homelable
+```
+
+⚠️ Keep JSON values in `backend/.env` single-quoted — `CORS_ORIGINS='["http://…"]'`.
+systemd's `EnvironmentFile` parser strips bare double quotes, which breaks the
+JSON before the backend parses it. This does not apply to the Docker install.
+
+### Scanning as a non-root service
+
+The unit runs as `homelable`, not root, so nmap has no raw sockets and silently
+falls back to a TCP connect scan: hosts and open ports are still found, OS
+detection (`-O`) and SYN scan (`-sS`) are not. To grant them, uncomment in
+`/etc/systemd/system/homelable.service`:
+
+```ini
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+```
+
+then `systemctl daemon-reload && systemctl restart homelable`.
+
+### Your own reverse proxy
+
+With `SKIP_NGINX=1` the script leaves the front end to you: serve
+`/opt/homelable/frontend/dist` as a static SPA and proxy the API to the backend.
+The nginx translation of `docker/nginx.conf` — what the script writes, with
+`backend:8000` replaced by `127.0.0.1:8000`:
+
+```nginx
+server {
+    listen 3000;
+    server_name _;
+    root /opt/homelable/frontend/dist;
+    index index.html;
+
+    client_max_body_size 20M;
+
+    # WebSocket — must come before /api/ to take priority
+    location /api/v1/status/ws/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Legacy /ws/ path
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+Terminating TLS in front of it means adding your own hostname to
+`CORS_ORIGINS` in `backend/.env` (`https://homelable.example`) and restarting
+the service.
+
+---
+
 ## Configuration
 
 All configuration is done via `.env` (copied from `.env.example`):

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -101,17 +101,22 @@ git clone https://github.com/Pouzor/homelable.git /opt/homelable
 sudo bash /opt/homelable/scripts/install-baremetal.sh
 ```
 
-The script can also clone for you — run it from anywhere and it fetches the repo
-into `INSTALL_DIR` if that directory is empty:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Pouzor/homelable/main/scripts/install-baremetal.sh \
-  | sudo bash
-```
-
 It prompts for the admin password and the CIDR range to scan, then writes
 `backend/.env` with a generated `SECRET_KEY` and bcrypt hash. Open
 **http://\<host-ip\>:3000**.
+
+The script can also clone for you — run it from anywhere and it fetches the repo
+into `INSTALL_DIR` when that directory is empty. Piped into `bash` there is no
+terminal to prompt on, so pass the two answers as environment variables:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Pouzor/homelable/main/scripts/install-baremetal.sh \
+  | sudo ADMIN_PASSWORD=hunter2 SCANNER_RANGES='["192.168.1.0/24"]' bash
+```
+
+Without them the prompts are skipped and their defaults apply — the password
+becomes `admin` and the range is guessed from the primary interface. The script
+warns when that happens; change the password before exposing the host.
 
 Re-running is safe and is how you upgrade — an existing `backend/.env` is kept
 untouched, everything else is rebuilt:
@@ -123,7 +128,8 @@ sudo bash scripts/install-baremetal.sh
 
 ### Options
 
-Every setting is an environment variable, so a non-interactive install is one line:
+Every setting is an environment variable. Setting them all skips every prompt,
+which is what makes an unattended install possible:
 
 ```bash
 sudo HTTP_PORT=8080 ADMIN_PASSWORD=hunter2 SCANNER_RANGES='["10.0.0.0/24"]' \
@@ -138,8 +144,8 @@ sudo HTTP_PORT=8080 ADMIN_PASSWORD=hunter2 SCANNER_RANGES='["10.0.0.0/24"]' \
 | `BACKEND_PORT` | `8000` | uvicorn port, bound to loopback |
 | `HTTP_PORT` | `3000` | nginx port |
 | `SERVER_NAME` | `_` | nginx `server_name` |
-| `ADMIN_PASSWORD` | prompt (`admin`) | Initial password for user `admin` |
-| `SCANNER_RANGES` | prompt (guessed) | JSON array of CIDRs |
+| `ADMIN_PASSWORD` | prompt, else `admin` | Initial password for user `admin` |
+| `SCANNER_RANGES` | prompt, else guessed | JSON array of CIDRs |
 | `SKIP_NGINX=1` | off | Do not install or touch nginx |
 
 ### Afterwards

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Every feature, with how to turn it on and use it, is described in **[FEATURES.md
 
 ## Installation
 
-Docker (from the **[pre-built GHCR images](./INSTALLATION.md#pre-built-docker-images)**), Proxmox LXC, build from source, configuration, and development setup are all covered in **[INSTALLATION.md](./INSTALLATION.md)**.
+Docker (from the **[pre-built GHCR images](./INSTALLATION.md#pre-built-docker-images)**), Proxmox LXC, **[bare metal without Docker](./INSTALLATION.md#bare-metal--no-docker)** (`sudo bash scripts/install-baremetal.sh` — systemd unit plus nginx on a Debian/Ubuntu host), build from source, configuration, and development setup are all covered in **[INSTALLATION.md](./INSTALLATION.md)**.
 
 ---
 

--- a/scripts/install-baremetal.sh
+++ b/scripts/install-baremetal.sh
@@ -22,6 +22,9 @@
 #   ADMIN_PASSWORD  initial admin password (default: prompt, "admin" on empty)
 #   SCANNER_RANGES  JSON array of CIDRs to scan (default: prompt, guessed from
 #                   the primary interface)
+#
+# The two prompts are skipped when stdin is not a TTY (`curl … | sudo bash`);
+# set the matching variables to control them there, or take the defaults.
 #   SKIP_NGINX=1    do not install or touch nginx (bring your own reverse proxy)
 set -euo pipefail
 
@@ -54,9 +57,15 @@ if [[ "$SKIP_NGINX" != "1" ]]; then
 fi
 
 # Node 20+ — Debian 12 ships 18, too old for Vite 7 / React 19.
-node_major="$(node --version 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')"
-if [[ -z "$node_major" || "$node_major" -lt "$NODE_MAJOR" ]]; then
-  log "Installing Node.js $NODE_MAJOR (found: ${node_major:-none})"
+# `|| true`: with no node installed the substitution exits 127, and under
+# `set -euo pipefail` that aborts the script before we get to install it.
+node_major="$(node --version 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/' || true)"
+node_major="${node_major//[^0-9]/}"   # `-lt` errors on anything non-numeric
+node_major="${node_major:-0}"
+if [[ "$node_major" -lt "$NODE_MAJOR" ]]; then
+  found="$node_major"
+  if [[ "$found" == "0" ]]; then found="none"; fi
+  log "Installing Node.js $NODE_MAJOR (found: $found)"
   curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - >/dev/null
   DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nodejs >/dev/null
 fi
@@ -104,7 +113,11 @@ else
 
   admin_password="${ADMIN_PASSWORD:-}"
   if [[ -z "$admin_password" ]]; then
-    read -rsp "Initial admin password [default: admin]: " admin_password; echo
+    if [[ -t 0 ]]; then
+      read -rsp "Initial admin password [default: admin]: " admin_password; echo
+    else
+      warn "No TTY (piped install) and ADMIN_PASSWORD unset — defaulting to 'admin'."
+    fi
     admin_password="${admin_password:-admin}"
   fi
 
@@ -112,9 +125,13 @@ else
   if [[ -z "$scanner_ranges" ]]; then
     guess="$(ip -o -f inet addr show scope global 2>/dev/null \
       | awk '{print $4}' | head -n1 \
-      | awk -F/ '{split($1,o,"."); print o[1]"."o[2]"."o[3]".0/"$2}')"
+      | awk -F/ '{split($1,o,"."); print o[1]"."o[2]"."o[3]".0/"$2}' || true)"
     guess="${guess:-192.168.1.0/24}"
-    read -rp "CIDR range to scan [$guess]: " scanner_ranges
+    if [[ -t 0 ]]; then
+      read -rp "CIDR range to scan [$guess]: " scanner_ranges
+    else
+      warn "No TTY (piped install) and SCANNER_RANGES unset — defaulting to $guess."
+    fi
     scanner_ranges="[\"${scanner_ranges:-$guess}\"]"
   fi
 
@@ -123,9 +140,11 @@ else
   password_hash="$(HL_PW="$admin_password" "$VENV/bin/python" -c \
     'import os, bcrypt; print(bcrypt.hashpw(os.environ["HL_PW"].encode(), bcrypt.gensalt()).decode())')"
 
-  host_ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  host_ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
   origins="[\"http://localhost:${HTTP_PORT}\""
-  [[ -n "$host_ip" ]] && origins="${origins},\"http://${host_ip}:${HTTP_PORT}\""
+  if [[ -n "$host_ip" ]]; then
+    origins="${origins},\"http://${host_ip}:${HTTP_PORT}\""
+  fi
   origins="${origins}]"
 
   umask 077
@@ -263,7 +282,7 @@ else
   log "Backend is up."
 fi
 
-HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
 
 cat <<EOF
 

--- a/scripts/install-baremetal.sh
+++ b/scripts/install-baremetal.sh
@@ -49,7 +49,7 @@ command -v apt-get >/dev/null || fail "This script targets Debian/Ubuntu (apt-ge
 log "Installing OS dependencies"
 apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-  git curl ca-certificates python3 python3-venv python3-pip \
+  git curl ca-certificates gnupg python3 python3-venv python3-pip \
   build-essential nmap iputils-ping iproute2 openssl >/dev/null
 
 if [[ "$SKIP_NGINX" != "1" ]]; then

--- a/scripts/install-baremetal.sh
+++ b/scripts/install-baremetal.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+# Install Homelable (backend + frontend) natively on a Debian/Ubuntu host — no Docker.
+#
+# Run interactively as root on any Debian 12+/Ubuntu 22.04+ host, VM or LXC.
+# Installs:
+#   - a Python venv + systemd unit for the FastAPI backend on 127.0.0.1:8000
+#   - the built Vite frontend, served by nginx on $HTTP_PORT with /api and /ws
+#     proxied to the backend
+#
+# Idempotent: re-running is safe. An existing backend/.env is kept untouched;
+# only the venv, the frontend build, the systemd unit and the nginx site are
+# refreshed. Use it to upgrade: pull (or re-clone) then re-run.
+#
+# Optional env vars (override defaults / skip the matching prompt):
+#   INSTALL_DIR     repo root (default: /opt/homelable)
+#   REPO_URL        clone URL if $INSTALL_DIR is empty (default: https://github.com/Pouzor/homelable.git)
+#   REPO_REF        branch/tag/commit when cloning (default: main)
+#   SERVICE_USER    systemd User= (default: homelable)
+#   BACKEND_PORT    uvicorn listen port, loopback only (default: 8000)
+#   HTTP_PORT       nginx listen port (default: 3000)
+#   SERVER_NAME     nginx server_name (default: _)
+#   ADMIN_PASSWORD  initial admin password (default: prompt, "admin" on empty)
+#   SCANNER_RANGES  JSON array of CIDRs to scan (default: prompt, guessed from
+#                   the primary interface)
+#   SKIP_NGINX=1    do not install or touch nginx (bring your own reverse proxy)
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-/opt/homelable}"
+REPO_URL="${REPO_URL:-https://github.com/Pouzor/homelable.git}"
+REPO_REF="${REPO_REF:-main}"
+SERVICE_USER="${SERVICE_USER:-homelable}"
+SERVICE_NAME="homelable"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+HTTP_PORT="${HTTP_PORT:-3000}"
+SERVER_NAME="${SERVER_NAME:-_}"
+SKIP_NGINX="${SKIP_NGINX:-0}"
+NODE_MAJOR=20
+
+log()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[1;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || fail "Run as root (sudo bash $0)."
+command -v apt-get >/dev/null || fail "This script targets Debian/Ubuntu (apt-get not found)."
+
+log "Installing OS dependencies"
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+  git curl ca-certificates python3 python3-venv python3-pip \
+  build-essential nmap iputils-ping iproute2 openssl >/dev/null
+
+if [[ "$SKIP_NGINX" != "1" ]]; then
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nginx >/dev/null
+fi
+
+# Node 20+ — Debian 12 ships 18, too old for Vite 7 / React 19.
+node_major="$(node --version 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')"
+if [[ -z "$node_major" || "$node_major" -lt "$NODE_MAJOR" ]]; then
+  log "Installing Node.js $NODE_MAJOR (found: ${node_major:-none})"
+  curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - >/dev/null
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nodejs >/dev/null
+fi
+
+BACKEND_DIR="$INSTALL_DIR/backend"
+FRONTEND_DIR="$INSTALL_DIR/frontend"
+
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  log "Cloning $REPO_URL ($REPO_REF) → $INSTALL_DIR"
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  git clone --depth 1 --branch "$REPO_REF" "$REPO_URL" "$INSTALL_DIR"
+fi
+[[ -f "$BACKEND_DIR/requirements.txt" ]] || fail "Missing $BACKEND_DIR/requirements.txt — repo layout unexpected."
+[[ -f "$FRONTEND_DIR/package.json" ]]    || fail "Missing $FRONTEND_DIR/package.json — repo layout unexpected."
+
+for port in "$BACKEND_PORT" "$HTTP_PORT"; do
+  if ss -ltn 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${port}$"; then
+    warn "Port $port already in use. Fine if it's a previous Homelable instance; otherwise abort and free it."
+  fi
+done
+
+if ! id -u "$SERVICE_USER" >/dev/null 2>&1; then
+  log "Creating service user '$SERVICE_USER'"
+  useradd --system --home "$INSTALL_DIR" --shell /usr/sbin/nologin "$SERVICE_USER"
+fi
+
+DATA_DIR="$INSTALL_DIR/data"
+mkdir -p "$DATA_DIR"
+
+VENV="$BACKEND_DIR/.venv"
+if [[ ! -d "$VENV" ]]; then
+  log "Creating venv at $VENV"
+  python3 -m venv "$VENV"
+fi
+log "Installing Python deps (this takes a few minutes)"
+"$VENV/bin/pip" install --quiet --upgrade pip
+"$VENV/bin/pip" install --quiet -r "$BACKEND_DIR/requirements.txt"
+
+ENV_FILE="$BACKEND_DIR/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  log ".env already present at $ENV_FILE — keeping existing values"
+else
+  [[ -f "$INSTALL_DIR/.env.example" ]] || fail "Missing $INSTALL_DIR/.env.example"
+  log "No .env found — generating one (press Enter to accept defaults)"
+
+  admin_password="${ADMIN_PASSWORD:-}"
+  if [[ -z "$admin_password" ]]; then
+    read -rsp "Initial admin password [default: admin]: " admin_password; echo
+    admin_password="${admin_password:-admin}"
+  fi
+
+  scanner_ranges="${SCANNER_RANGES:-}"
+  if [[ -z "$scanner_ranges" ]]; then
+    guess="$(ip -o -f inet addr show scope global 2>/dev/null \
+      | awk '{print $4}' | head -n1 \
+      | awk -F/ '{split($1,o,"."); print o[1]"."o[2]"."o[3]".0/"$2}')"
+    guess="${guess:-192.168.1.0/24}"
+    read -rp "CIDR range to scan [$guess]: " scanner_ranges
+    scanner_ranges="[\"${scanner_ranges:-$guess}\"]"
+  fi
+
+  secret_key="$(openssl rand -hex 32)"
+  # Passed through the environment, not argv — argv is world-readable in ps.
+  password_hash="$(HL_PW="$admin_password" "$VENV/bin/python" -c \
+    'import os, bcrypt; print(bcrypt.hashpw(os.environ["HL_PW"].encode(), bcrypt.gensalt()).decode())')"
+
+  host_ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  origins="[\"http://localhost:${HTTP_PORT}\""
+  [[ -n "$host_ip" ]] && origins="${origins},\"http://${host_ip}:${HTTP_PORT}\""
+  origins="${origins}]"
+
+  umask 077
+  cat >"$ENV_FILE" <<EOF
+# Generated by scripts/install-baremetal.sh
+# JSON values are single-quoted: systemd's EnvironmentFile parser strips
+# bare double quotes, which would break the JSON before pydantic sees it.
+SECRET_KEY=$secret_key
+SQLITE_PATH=$DATA_DIR/homelab.db
+
+# Set this to the URL(s) you use to reach Homelable in your browser.
+# Behind a TLS reverse proxy, replace these with https://homelable.example.
+CORS_ORIGINS='$origins'
+
+AUTH_MODE=local
+AUTH_USERNAME=admin
+AUTH_PASSWORD_HASH='$password_hash'
+
+SCANNER_RANGES='$scanner_ranges'
+SCANNER_HTTP_RANGES='[]'
+SCANNER_HTTP_PROBE_ENABLED=false
+SCANNER_HTTP_VERIFY_TLS=false
+STATUS_CHECKER_INTERVAL=60
+EOF
+  umask 022
+  log "Wrote $ENV_FILE (mode 600)"
+  warn "Every other setting (OIDC, MCP, Proxmox, Zigbee, Z-Wave, live view) is documented in .env.example."
+fi
+
+log "Building the frontend"
+if [[ -f "$FRONTEND_DIR/package-lock.json" ]]; then
+  ( cd "$FRONTEND_DIR" && npm ci --silent )
+else
+  ( cd "$FRONTEND_DIR" && npm install --silent )
+fi
+( cd "$FRONTEND_DIR" && npm run build )
+[[ -d "$FRONTEND_DIR/dist" ]] || fail "Frontend build produced no $FRONTEND_DIR/dist."
+
+chown -R "$SERVICE_USER":"$SERVICE_USER" "$INSTALL_DIR"
+chmod 600 "$ENV_FILE"
+# nginx (www-data) needs to traverse the tree down to dist/.
+chmod o+x "$INSTALL_DIR" "$FRONTEND_DIR"
+
+UNIT="/etc/systemd/system/${SERVICE_NAME}.service"
+log "Writing $UNIT"
+cat >"$UNIT" <<EOF
+[Unit]
+Description=Homelable backend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$BACKEND_DIR
+EnvironmentFile=$ENV_FILE
+ExecStart=$VENV/bin/uvicorn app.main:app --host 127.0.0.1 --port $BACKEND_PORT
+Restart=on-failure
+RestartSec=5
+
+# The scanner shells out to nmap. Without raw sockets nmap silently falls back
+# to a TCP connect scan: hosts and open ports are still found, but OS detection
+# (-O) and SYN scan (-sS) do not work. Uncomment to grant them.
+#AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+#CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now "$SERVICE_NAME"
+systemctl restart "$SERVICE_NAME"
+
+if [[ "$SKIP_NGINX" != "1" ]]; then
+  SITE="/etc/nginx/sites-available/homelable"
+  log "Writing $SITE"
+  cat >"$SITE" <<EOF
+server {
+    listen $HTTP_PORT;
+    server_name $SERVER_NAME;
+    root $FRONTEND_DIR/dist;
+    index index.html;
+
+    client_max_body_size 20M;
+
+    # WebSocket (must come before /api/ to take priority)
+    location /api/v1/status/ws/ {
+        proxy_pass http://127.0.0.1:$BACKEND_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:$BACKEND_PORT;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+
+    # Legacy /ws/ path
+    location /ws/ {
+        proxy_pass http://127.0.0.1:$BACKEND_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$host;
+    }
+
+    # SPA fallback
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+}
+EOF
+  ln -sf "$SITE" /etc/nginx/sites-enabled/homelable
+  if [[ "$HTTP_PORT" == "80" ]]; then rm -f /etc/nginx/sites-enabled/default; fi
+  nginx -t
+  systemctl reload nginx || systemctl restart nginx
+fi
+
+log "Waiting for the backend on :$BACKEND_PORT"
+ok=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  if curl -fsS "http://127.0.0.1:${BACKEND_PORT}/api/v1/health" >/dev/null 2>&1; then
+    ok=1; break
+  fi
+  sleep 1
+done
+if [[ "$ok" -ne 1 ]]; then
+  warn "Backend did not answer /api/v1/health within 15s. Check: journalctl -u $SERVICE_NAME -n 50"
+else
+  log "Backend is up."
+fi
+
+HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+
+cat <<EOF
+
+----------------------------------------------------------------
+Homelable installed.
+
+  Service:     $SERVICE_NAME  (systemctl status $SERVICE_NAME)
+  Backend:     http://127.0.0.1:$BACKEND_PORT  (loopback only)
+  Env file:    $ENV_FILE
+  Data:        $DATA_DIR  (SQLite DB + uploads)
+  Logs:        journalctl -u $SERVICE_NAME -f
+EOF
+if [[ "$SKIP_NGINX" != "1" ]]; then
+  cat <<EOF
+  Web UI:      http://${HOST_IP:-<host-ip>}:${HTTP_PORT}
+  nginx site:  /etc/nginx/sites-available/homelable
+EOF
+else
+  cat <<EOF
+  nginx:       skipped — proxy your own front end to 127.0.0.1:$BACKEND_PORT
+               and serve $FRONTEND_DIR/dist. See INSTALLATION.md.
+EOF
+fi
+cat <<EOF
+
+Log in as 'admin' with the password you set. Change it later by regenerating
+AUTH_PASSWORD_HASH in $ENV_FILE:
+
+  $VENV/bin/python -c "import bcrypt; print(bcrypt.hashpw(b'newpassword', bcrypt.gensalt()).decode())"
+  systemctl restart $SERVICE_NAME
+
+Upgrade: git -C $INSTALL_DIR pull && bash $INSTALL_DIR/scripts/install-baremetal.sh
+----------------------------------------------------------------
+EOF


### PR DESCRIPTION
## What

Adds a documented way to run Homelable in production without Docker. Until now `INSTALLATION.md` offered four routes, all of them Docker or the Proxmox LXC helper; `scripts/lxc-mcp-install.sh` did a native install, but only for the optional MCP sidecar.

`scripts/install-baremetal.sh` installs the backend and frontend natively on a Debian 12+ / Ubuntu 22.04+ host: a Python venv and a `homelable` systemd unit for the backend on `127.0.0.1:8000`, the built frontend served by nginx on `:3000`. It is modeled on `scripts/lxc-mcp-install.sh`, with the install steps taken from the community-scripts/ProxmoxVE recipe so both installs stay recognisably the same.

Closes #333.

## Changes

**scripts/install-baremetal.sh** (new)

- Installs `git curl python3-venv build-essential nmap iputils-ping openssl` and nginx. Node 20 comes from nodesource only when the host's is older — Debian 12 ships 18, too old for Vite 7 / React 19.
- Clones into `INSTALL_DIR` when that directory is empty, otherwise uses the tree in place.
- Creates the `homelable` service user, builds `backend/.venv` from `requirements.txt`, runs `npm ci && npm run build`.
- Generates `backend/.env` (mode 600) with an `openssl rand -hex 32` `SECRET_KEY`, a bcrypt `AUTH_PASSWORD_HASH`, `CORS_ORIGINS` built from `hostname -I`, and a scan CIDR guessed from the primary interface. Prompts for the admin password and the range; both have environment overrides.
- Writes `/etc/systemd/system/homelable.service` bound to loopback, and an nginx site that is `docker/nginx.conf` with `backend:8000` replaced by `127.0.0.1:8000`. Validates with `nginx -t` before reloading.
- Waits on `/api/v1/health`, then prints the URLs, the log command and the password-rotation snippet.
- Idempotent: an existing `backend/.env` is kept untouched and everything else is rebuilt, so re-running is the upgrade path. Every prompt has an env-var override (`INSTALL_DIR`, `REPO_URL`, `REPO_REF`, `SERVICE_USER`, `BACKEND_PORT`, `HTTP_PORT`, `SERVER_NAME`, `ADMIN_PASSWORD`, `SCANNER_RANGES`, `SKIP_NGINX`), making a non-interactive install a single line.

Two details that are easy to get wrong:

- JSON values in the generated `.env` are single-quoted. systemd's `EnvironmentFile` parser strips bare double quotes, so `CORS_ORIGINS=["http://x"]` would reach pydantic as `[http://x]` and fail startup.
- The admin password reaches Python through the environment rather than argv, which is world-readable in `ps`.

The unit runs unprivileged, so nmap falls back to a TCP connect scan: hosts and open ports are still found, OS detection (`-O`) and SYN scan (`-sS`) are not. `AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN` ships commented out, with the trade-off spelled out in the unit and in the docs.

**INSTALLATION.md** — new "Bare metal — no Docker" section: quick start, upgrade, option table, post-install paths, the non-root scan trade-off, and the full host-nginx blocks for anyone bringing their own reverse proxy or running with `SKIP_NGINX=1`.

**README.md** — the install line now links the bare-metal path.

No breaking changes; nothing existing is touched.

## Testing

No test suite: shell installers have none in this repo (`scripts/lxc-mcp-install.sh` set the precedent), and CI's `lint-scripts` job shellchecks `scripts/`.

- `shellcheck` clean (`koalaman/shellcheck:stable`), `bash -n` clean.
- The generated `.env` block was simulated locally to confirm the `$2b$12$` bcrypt hash survives the heredoc intact and the JSON values stay quoted.
- Full end-to-end verification needs a Debian host and has not been run.

ha-relevant: no
