### PR TITLE
fix(canvas): make the basic edge animation direction independent of geometry

### DIFF
--- a/frontend/src/components/canvas/edges/__tests__/HomelableEdge.animation.test.tsx
+++ b/frontend/src/components/canvas/edges/__tests__/HomelableEdge.animation.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { render } from '@testing-library/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import type { EdgeProps, Edge } from '@xyflow/react'
@@ -13,15 +15,18 @@ import type { EdgeData } from '@/types'
  * CSS animations pause when the tab is hidden and don't leak — so the rendered
  * output must contain a CSS `animation` on the path and zero <animate> nodes.
  */
-function renderEdge(data: Partial<EdgeData> = {}) {
+function renderEdge(
+  data: Partial<EdgeData> = {},
+  coords: { sourceY?: number; targetY?: number } = {},
+) {
   const props = {
     id: 'e1',
     source: 'a',
     target: 'b',
     sourceX: 0,
-    sourceY: 0,
+    sourceY: coords.sourceY ?? 0,
     targetX: 100,
-    targetY: 100,
+    targetY: coords.targetY ?? 100,
     sourcePosition: 'bottom',
     targetPosition: 'top',
     data: { type: 'ethernet', ...data } as EdgeData,
@@ -63,6 +68,53 @@ describe('HomelableEdge animation', () => {
       (p.getAttribute('style') ?? '').includes('homelable-snake'),
     )
     expect(animated).toBeTruthy()
+  })
+
+  /**
+   * Regression (#395): the basic dash used to flip to `animation-direction:
+   * reverse` whenever the source sat below the target on screen, so an edge
+   * drawn bottom-to-top animated as if it went target→source. Direction comes
+   * from the data (the path is built source→target), never from the geometry.
+   */
+  it('basic dash animates source→target when the target is below', () => {
+    const { container } = renderEdge({ animated: 'basic' }, { sourceY: 0, targetY: 100 })
+    const dashed = Array.from(container.querySelectorAll('path')).find((p) =>
+      (p.getAttribute('style') ?? '').includes('homelable-basic-dash'),
+    )
+    expect(dashed).toBeTruthy()
+    expect(dashed!.getAttribute('style') ?? '').not.toContain('reverse')
+  })
+
+  it('basic dash keeps the same direction when the target is above', () => {
+    const { container } = renderEdge({ animated: 'basic' }, { sourceY: 100, targetY: 0 })
+    const dashed = Array.from(container.querySelectorAll('path')).find((p) =>
+      (p.getAttribute('style') ?? '').includes('homelable-basic-dash'),
+    )
+    expect(dashed).toBeTruthy()
+    expect(dashed!.getAttribute('style') ?? '').not.toContain('reverse')
+  })
+
+  /**
+   * Regression (#395): the basic dash marched against snake and flow because
+   * its keyframes decreased stroke-dashoffset while theirs increase it. All
+   * three must move the same way along the path.
+   */
+  it('basic dash keyframes march the same way as snake and flow', () => {
+    const css = readFileSync(resolve(__dirname, '../../../../index.css'), 'utf8')
+    const offsets = (name: string) => {
+      const block = css.match(new RegExp(`@keyframes ${name} \\{([^}]*\\}[^}]*)\\}`))
+      expect(block, `${name} keyframes not found`).toBeTruthy()
+      const values = [...block![1].matchAll(/stroke-dashoffset:\s*(-?\d+)/g)].map((m) => Number(m[1]))
+      expect(values).toHaveLength(2)
+      return values
+    }
+    const rising = (name: string) => {
+      const [from, to] = offsets(name)
+      return to > from
+    }
+    expect(rising('homelable-basic-dash')).toBe(true)
+    expect(rising('homelable-snake')).toBe(true)
+    expect(rising('homelable-flow')).toBe(true)
   })
 
   it('non-animated edge has no flow animation and no <animate>', () => {

--- a/frontend/src/components/canvas/edges/index.tsx
+++ b/frontend/src/components/canvas/edges/index.tsx
@@ -442,8 +442,11 @@ export function HomelableEdge({ id, source, target, sourceHandleId, targetHandle
           strokeDasharray="5"
           style={{
             pointerEvents: 'none',
+            // Direction comes from the keyframes alone (see index.css), never
+            // from the endpoints' screen positions: an edge drawn bottom-to-top
+            // marches the same way as one drawn top-to-bottom, like the snake
+            // and flow modes.
             animation: 'homelable-basic-dash 0.5s linear infinite',
-            animationDirection: sourceY <= targetY ? 'normal' : 'reverse',
           }}
         />
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,9 +6,14 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* The dashes must march the same way as homelable-snake and homelable-flow
+   below, which both increase the offset. This one used to decrease it and so
+   ran against the other two; HomelableEdge papered over that with an
+   `animation-direction: reverse` keyed on the endpoints' Y coordinates, which
+   made the basic dash follow screen geometry instead of the edge itself. */
 @keyframes homelable-basic-dash {
-  from { stroke-dashoffset: 10; }
-  to   { stroke-dashoffset: 0; }
+  from { stroke-dashoffset: 0; }
+  to   { stroke-dashoffset: 10; }
 }
 
 /* Edge flow animations — CSS (not SVG SMIL) so the browser pauses them when the


### PR DESCRIPTION
Closes #395.

## The bug

The basic dash flipped to `animation-direction: reverse` whenever the source sat below the target on screen:

```js
animationDirection: sourceY <= targetY ? 'normal' : 'reverse',
```

So the same edge marched one way or the other depending only on where its nodes had been dragged.

## Why the flip was there

The keyframes disagree. `homelable-basic-dash` decreased `stroke-dashoffset` while `homelable-snake` and `homelable-flow` increase it, so the basic dash ran against the other two modes. The geometry test was compensating for that — and by the author's own comment ("always animate physically downward") it didn't even achieve what it aimed at.

Fix: flip the keyframes to match snake and flow, drop the geometry test.

## Known limitation, not fixed here

All three modes now march target to source. That looks right on screen because of a separate bug: in `SideHandles` the invisible 20×20 target handle is rendered after the visible 6×6 source handle and both get `pointer-events: all`, so it wins the `pointerdown`. React Flow then reads `isTarget` from the handle the drag *started* on (`@xyflow/system`), and a drag from A to B is stored as `source=B, target=A` — `ConnectionMode.Loose` does not change this.

Consequence: an edge created through the MCP server or the API with correct source/target animates backwards, and an end arrow marker lands on the wrong node. Deliberately left for its own PR — fixing it means `isConnectableStart={false}` on the invisible handles plus flipping all three keyframes back, which changes how every already-saved edge animates.

## Tests

`frontend/src/components/canvas/edges/__tests__/HomelableEdge.animation.test.tsx`:
- basic dash carries no `reverse` with the target below **and** with the target above (the reverse branch had no coverage)
- keyframe-sign test over `index.css` — fails if any of the three modes ever flips direction on its own

Full suite: 2190 passed, lint 0 errors, typecheck clean.

ha-relevant: yes — `edges/index.tsx` and the keyframes both exist in homelable-hacs.