### PR TITLE
feat: add the Homelable logo to the brand icon picker

### DIFF
--- a/frontend/public/brand/homelable.svg
+++ b/frontend/public/brand/homelable.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <radialGradient id="bg-glow" cx="50%" cy="35%" r="55%">
+      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#0d1117" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="node-glow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <circle cx="32" cy="32" r="32" fill="#0d1117"/>
+  <circle cx="32" cy="32" r="32" fill="url(#bg-glow)"/>
+
+  <!-- House body -->
+  <path d="M32 11 L53 30 L48 30 L48 53 L16 53 L16 30 L11 30 Z"
+        fill="#161b22" stroke="#00d4ff" stroke-width="1.5" stroke-linejoin="round"/>
+
+  <!-- Floor line (subtle) -->
+  <line x1="16" y1="30" x2="48" y2="30" stroke="#00d4ff" stroke-width="0.5" opacity="0.25"/>
+
+  <!-- Door -->
+  <rect x="27" y="40" width="10" height="13" rx="1.5"
+        fill="#0d1117" stroke="#00d4ff" stroke-width="1" opacity="0.9"/>
+
+  <!-- Network lines (drawn under nodes) -->
+  <line x1="32" y1="23" x2="32" y2="30" stroke="#a855f7" stroke-width="1.2" opacity="0.7" stroke-linecap="round"/>
+  <line x1="21" y1="38" x2="29" y2="33" stroke="#39d353" stroke-width="1.2" opacity="0.7" stroke-linecap="round"/>
+  <line x1="43" y1="38" x2="35" y2="33" stroke="#39d353" stroke-width="1.2" opacity="0.7" stroke-linecap="round"/>
+
+  <!-- Center hub glow -->
+  <circle cx="32" cy="33" r="5" fill="#00d4ff" opacity="0.12"/>
+  <!-- Center hub -->
+  <circle cx="32" cy="33" r="3" fill="#00d4ff" filter="url(#node-glow)"/>
+
+  <!-- Left node -->
+  <circle cx="21" cy="38" r="2.5" fill="#39d353" filter="url(#node-glow)"/>
+
+  <!-- Right node -->
+  <circle cx="43" cy="38" r="2.5" fill="#39d353" filter="url(#node-glow)"/>
+
+  <!-- Top node -->
+  <circle cx="32" cy="23" r="2" fill="#a855f7" filter="url(#node-glow)"/>
+</svg>

--- a/frontend/src/components/modals/BrandIconPicker.tsx
+++ b/frontend/src/components/modals/BrandIconPicker.tsx
@@ -1,9 +1,13 @@
 import { useMemo, useState } from 'react'
 import { Input } from '@/components/ui/input'
-import { brandIconUrl, BRAND_ICON_PREFIX } from '@/utils/nodeIcons'
+import { brandIconUrl, BRAND_ICON_PREFIX, LOCAL_BRAND_ICONS } from '@/utils/nodeIcons'
 import dashboardIcons from '@/data/dashboardIcons.json'
 
-const SLUGS: string[] = dashboardIcons as string[]
+// Locally-served logos first, then the generated dashboard-icons manifest.
+const SLUGS: string[] = [
+  ...LOCAL_BRAND_ICONS,
+  ...(dashboardIcons as string[]).filter((s) => !(LOCAL_BRAND_ICONS as readonly string[]).includes(s)),
+]
 const PAGE = 120
 
 interface BrandIconPickerProps {

--- a/frontend/src/components/modals/__tests__/IconPickerPanel.test.tsx
+++ b/frontend/src/components/modals/__tests__/IconPickerPanel.test.tsx
@@ -43,6 +43,17 @@ describe('IconPickerPanel', () => {
     expect(onSelect).toHaveBeenCalledWith('brand:plex')
   })
 
+  it('offers the Homelable logo first in the Brand tab, served locally', () => {
+    const onSelect = vi.fn()
+    render(<IconPickerPanel onSelect={onSelect} />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Brand' }))
+    const first = screen.getAllByRole('button')[0]
+    expect(first.getAttribute('aria-label')).toBe('homelable')
+    expect(first.querySelector('img')?.getAttribute('src')).toBe('/brand/homelable.svg')
+    fireEvent.click(first)
+    expect(onSelect).toHaveBeenCalledWith('brand:homelable')
+  })
+
   it('keeps the generic search box out of the Brand tab', () => {
     render(<IconPickerPanel onSelect={vi.fn()} />)
     fireEvent.click(screen.getByRole('tab', { name: 'Brand' }))

--- a/frontend/src/utils/__tests__/brandIcons.test.ts
+++ b/frontend/src/utils/__tests__/brandIcons.test.ts
@@ -5,6 +5,8 @@ import {
   brandIconSlug,
   brandIconUrl,
   resolveCustomIcon,
+  isLocalBrandIcon,
+  LOCAL_BRAND_ICONS,
   ICON_MAP,
 } from '../nodeIcons'
 
@@ -27,6 +29,16 @@ describe('brand icon helpers', () => {
       'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/plex.svg',
     )
   })
+
+  it('brandIconUrl serves local brand icons from public/brand', () => {
+    expect(brandIconUrl('homelable')).toBe('/brand/homelable.svg')
+  })
+
+  it('isLocalBrandIcon only matches the locally-served slugs', () => {
+    expect(LOCAL_BRAND_ICONS).toContain('homelable')
+    expect(isLocalBrandIcon('homelable')).toBe(true)
+    expect(isLocalBrandIcon('plex')).toBe(false)
+  })
 })
 
 describe('resolveCustomIcon', () => {
@@ -48,6 +60,15 @@ describe('resolveCustomIcon', () => {
       expect(r.slug).toBe('plex')
       expect(r.url).toContain('cdn.jsdelivr.net')
       expect(r.url).toContain('/plex.svg')
+    }
+  })
+
+  it('resolves the homelable key to the local asset', () => {
+    const r = resolveCustomIcon('brand:homelable')
+    expect(r?.kind).toBe('brand')
+    if (r?.kind === 'brand') {
+      expect(r.slug).toBe('homelable')
+      expect(r.url).toBe('/brand/homelable.svg')
     }
   })
 

--- a/frontend/src/utils/nodeIcons.ts
+++ b/frontend/src/utils/nodeIcons.ts
@@ -225,7 +225,18 @@ export function brandIconSlug(key: string): string {
   return key.slice(BRAND_ICON_PREFIX.length)
 }
 
+/** Brand slugs served from `public/brand/` instead of the dashboard-icons CDN —
+ *  logos the upstream catalog does not carry. Kept sorted; the picker prepends
+ *  them to the generated manifest, which `scripts/fetch-dashboard-icons.mjs`
+ *  overwrites and must never be hand-edited. */
+export const LOCAL_BRAND_ICONS = ['homelable'] as const
+
+export function isLocalBrandIcon(slug: string): boolean {
+  return (LOCAL_BRAND_ICONS as readonly string[]).includes(slug)
+}
+
 export function brandIconUrl(slug: string): string {
+  if (isLocalBrandIcon(slug)) return `/brand/${slug}.svg`
   return `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/${slug}.svg`
 }
 


### PR DESCRIPTION
## What

The brand icon tab is fed by the generated `homarr-labs/dashboard-icons` manifest, which carries no Homelable mark, so users could not label the app itself on a canvas (requested in #397). Locally-served logos are now supported and the Homelable icon is the first entry of the brand catalog, in both the node and the service icon picker.

## Changes

Frontend:
- `public/brand/homelable.svg` — the official mark, copied from `docs/logo/icon.svg`.
- `utils/nodeIcons.ts` — new `LOCAL_BRAND_ICONS` list and `isLocalBrandIcon` helper; `brandIconUrl` resolves those slugs to `/brand/<slug>.svg` and keeps every other slug on the jsDelivr CDN. `resolveCustomIcon` needed no change, so nodes, services and rack plates pick the local asset up for free.
- `components/modals/BrandIconPicker.tsx` — the local slugs are prepended to the generated manifest (deduplicated), so the logo is searchable and shows first.

`src/data/dashboardIcons.json` is deliberately untouched: `scripts/fetch-dashboard-icons.mjs` overwrites it wholesale on every refresh, so a hand-added entry would not survive.

The second half of #397 (Docker host polling) is not addressed here.

## Testing

- `utils/__tests__/brandIcons.test.ts` — local slugs resolve to `/brand/homelable.svg`, CDN slugs are unchanged, `resolveCustomIcon('brand:homelable')` returns the local URL.
- `components/modals/__tests__/IconPickerPanel.test.tsx` — the Brand tab lists `homelable` first, renders it from the local path, and emits `brand:homelable` on click.
- `npm run lint`, `npm run typecheck` and the full `npm test` suite pass (160 files, 2275 tests).

ha-relevant: yes