### PR TITLE
feat: reach a document's history and its backlinks, and document the section

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -196,10 +196,10 @@ Nodes: `proxmox` (host) / `vm` / `lxc`, linked host→guest by a `virtual` edge.
 - Sidebar → **Documentation**. The **Devices** root re-pivots instantly by zone, group, type, physical/virtual, subnet, rack, vendor, discovery source, status, tag or A–Z; picking a device with no document writes one from its facts.
 - The **Library** is folders you make. **New page** / **New folder** in the header, drag an item to file it. Templates: blank, runbook, service, network overview, incident, procedure, decision (ADR), zone.
 - Editing is plain markdown and **saving is explicit**, like the canvas. An unsaved body is kept in your browser and offered back if you close the tab. `/` in the editor inserts a freshly generated block — services, hardware, network, rack — from the device's current data.
-- **Link documents** with `[[VLAN plan]]`, `[[device:nas-01]]` or `[[doc:slug|label]]`. A link to a document that does not exist yet renders red and offers to create it, and every document lists **Linked from** at the bottom — who points here.
+- **Link documents** with `[[VLAN plan]]`, `[[device:nas-01]]` or `[[doc:slug|label]]`. Typing `[[` opens a picker that writes the link for you. A link to a document that does not exist yet renders red and offers to create it, and every document lists **Linked from** at the bottom — who points here.
 - **History**: the clock-arrow button in the header lists earlier versions, up to 50 per document. Read one, hit **Changes** for a line-by-line diff against the current body, **Restore** to bring it back — the body it replaces is saved to the history first.
 - **Keeping it honest**: `review_every: 6m` in a document's frontmatter badges it "due for review" when it lapses; a **device data changed** banner appears when the device has moved on since the document was written; **Regenerate** rebuilds a device document from scratch (old body kept in the history). Tags are chips under the title.
-- **Search** the whole space from the box above the tree — title, tags and body.
+- **Search** the whole space from the box above the tree — title, tags and body. The canvas' own search (Ctrl/Cmd+K) finds documents too, and picking one jumps here.
 - Coming from the old per-device **Notes** field? A banner offers to migrate every device that has one into a document. It copies, it does not move: the `notes` field is left exactly as it was.
 
 > **Full documentation:** [docs/documentation.md](./docs/documentation.md)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,13 +24,14 @@ Here's what Homelable can do. One line on what each feature is, then how to swit
 10. [Z-Wave Import](#10-z-wave-import-)
 11. [Proxmox VE Import](#11-proxmox-ve-import-)
 12. [Device Inventory](#12-device-inventory-)
-13. [Live Status Monitoring](#13-live-status-monitoring-)
-14. [Export (PNG / SVG / YAML / Markdown)](#14-export)
-15. [Live View (read-only public canvas)](#15-live-view-)
-16. [Gethomepage Widget](#16-gethomepage-widget-)
-17. [MCP Server (AI integration)](#17-mcp-server-)
-18. [Settings & Shortcuts](#18-settings--shortcuts)
-19. [Authentication (Local / OpenID Connect)](#19-authentication-local--openid-connect-)
+13. [Documentation](#13-documentation-)
+14. [Live Status Monitoring](#14-live-status-monitoring-)
+15. [Export (PNG / SVG / YAML / Markdown)](#15-export)
+16. [Live View (read-only public canvas)](#16-live-view-)
+17. [Gethomepage Widget](#17-gethomepage-widget-)
+18. [MCP Server (AI integration)](#18-mcp-server-)
+19. [Settings & Shortcuts](#19-settings--shortcuts)
+20. [Authentication (Local / OpenID Connect)](#20-authentication-local--openid-connect-)
 
 ---
 
@@ -187,7 +188,25 @@ Nodes: `proxmox` (host) / `vm` / `lxc`, linked host→guest by a `virtual` edge.
 
 ---
 
-## 13. Live Status Monitoring 🔒
+## 13. Documentation 🔒
+
+**What:** A markdown documentation space for the whole lab. Every device gets a document written once from what the scan actually found — identity, hardware, services, network, operations, troubleshooting — and it is yours from there; nothing rewrites it behind you. Next to it, a Library of pages you write yourself: runbooks, incidents, decisions, a network overview.
+
+**Use:**
+- Sidebar → **Documentation**. The **Devices** root re-pivots instantly by zone, group, type, physical/virtual, subnet, rack, vendor, discovery source, status, tag or A–Z; picking a device with no document writes one from its facts.
+- The **Library** is folders you make. **New page** / **New folder** in the header, drag an item to file it. Templates: blank, runbook, service, network overview, incident, procedure, decision (ADR), zone.
+- Editing is plain markdown and **saving is explicit**, like the canvas. An unsaved body is kept in your browser and offered back if you close the tab. `/` in the editor inserts a freshly generated block — services, hardware, network, rack — from the device's current data.
+- **Link documents** with `[[VLAN plan]]`, `[[device:nas-01]]` or `[[doc:slug|label]]`. A link to a document that does not exist yet renders red and offers to create it, and every document lists **Linked from** at the bottom — who points here.
+- **History**: the clock-arrow button in the header lists earlier versions, up to 50 per document. Read one, hit **Changes** for a line-by-line diff against the current body, **Restore** to bring it back — the body it replaces is saved to the history first.
+- **Keeping it honest**: `review_every: 6m` in a document's frontmatter badges it "due for review" when it lapses; a **device data changed** banner appears when the device has moved on since the document was written; **Regenerate** rebuilds a device document from scratch (old body kept in the history). Tags are chips under the title.
+- **Search** the whole space from the box above the tree — title, tags and body.
+- Coming from the old per-device **Notes** field? A banner offers to migrate every device that has one into a document. It copies, it does not move: the `notes` field is left exactly as it was.
+
+> **Full documentation:** [docs/documentation.md](./docs/documentation.md)
+
+---
+
+## 14. Live Status Monitoring 🔒
 
 **What:** Keeps checking each node and shows its status (🟢 online / 🔴 offline / ⚫ unknown) right on the canvas.
 
@@ -208,7 +227,7 @@ Nodes: `proxmox` (host) / `vm` / `lxc`, linked host→guest by a `virtual` edge.
 
 ---
 
-## 14. Export
+## 15. Export
 
 **What:** Get your canvas out as a picture or as structured data.
 
@@ -220,7 +239,7 @@ Nodes: `proxmox` (host) / `vm` / `lxc`, linked host→guest by a `virtual` edge.
 
 ---
 
-## 15. Live View 🔒
+## 16. Live View 🔒
 
 **What:** A read-only, no-login snapshot of a canvas you can share on your LAN. Off by default.
 
@@ -232,7 +251,7 @@ Pan and zoom only, no editing. Click a node with an IP and it opens in a new tab
 
 ---
 
-## 16. Gethomepage Widget 🔒
+## 17. Gethomepage Widget 🔒
 
 **What:** A tiny JSON stats endpoint for [gethomepage](https://gethomepage.dev)'s `customapi` widget. Off by default.
 
@@ -244,7 +263,7 @@ Widget snippet lives in the [README](./README.md#gethomepage-widget-read-only-st
 
 ---
 
-## 17. MCP Server 🔒
+## 18. MCP Server 🔒
 
 **What:** A [Model Context Protocol](https://modelcontextprotocol.io) server so an MCP client (Claude Code, Claude Desktop, Open WebUI…) can read and change your topology. Optional, runs as its own service.
 
@@ -262,7 +281,7 @@ The AI can list nodes/edges/canvas/zones/designs/inventory/scans, add/update/del
 
 ---
 
-## 18. Settings & Shortcuts
+## 19. Settings & Shortcuts
 
 **What:** App config and keyboard shortcuts.
 
@@ -273,7 +292,7 @@ The AI can list nodes/edges/canvas/zones/designs/inventory/scans, add/update/del
 
 ---
 
-## 19. Authentication (Local / OpenID Connect) 🔒
+## 20. Authentication (Local / OpenID Connect) 🔒
 
 **What:** Homelable protects the app behind a login. Two exclusive modes, set once in `.env` with `AUTH_MODE`:
 - **`local`** (default) — a single username + bcrypt-hashed password. Nothing changes for existing installs.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Homelable is a self-hosted infrastructure visualization solution. It provides a 
 
 Homelable also offers a healthcheck system through multiple methods (ping/TCP, /health API, etc.) to get a global overview of online/offline services.
 
+Every device also gets a **document** — written for you from what the scan found, and yours to maintain from there — next to a Library of pages you write yourself: runbooks, incidents, a network overview. Your homelab stops being documented in a wiki somewhere else.
+
 You can also select some pre-built design styles, or personalize each device in your diagram.
 
 If you just like the design, you can only run the frontend and export your design as PNG.
@@ -57,7 +59,7 @@ If you are running  <img width="22" height="22" align="top" alt="New_Home_Assist
 
 ## Features
 
-From one-click **network scans** and **Proxmox / Zigbee / Z-Wave** imports to **live status monitoring**, floor plans, **rack canvases** with port-to-port patching, multi-canvas layouts and an **MCP server** for AI assistants — Homelable maps and watches your whole homelab.
+From one-click **network scans** and **Proxmox / Zigbee / Z-Wave** imports to **live status monitoring**, floor plans, **rack canvases** with port-to-port patching, a **markdown documentation space** for the whole lab, multi-canvas layouts and an **MCP server** for AI assistants — Homelable maps, documents and watches your whole homelab.
 
 Every feature, with how to turn it on and use it, is described in **[FEATURES.md](./FEATURES.md)**.
 
@@ -84,6 +86,28 @@ Next to the network diagram, Homelable draws the **physical** side of your lab: 
 Gear sits in a U range and part of a 12-column width grid, so half- and third-width machines share a U; a drop snaps to the nearest free slot. A mount can follow the status check of its matching diagram node, and **Import links** derives patches from the links already drawn on your diagrams.
 
 > **Full documentation:** [docs/rack-canvas.md](./docs/rack-canvas.md)
+
+---
+
+## Documentation
+
+Homelable keeps its own markdown documentation space, so the lab is described where it is drawn. Sidebar → **Documentation**.
+
+Every device has a document, generated once from what the scan actually found — identity, hardware, one section per service, network, operations, troubleshooting — and never rewritten behind you. Beside it, a **Library** of pages you write: runbooks, incidents, decisions, a network overview, from a template or blank.
+
+### Usage
+
+1. **Pick a device** in the tree — one with no document yet gets one written from its facts. Re-pivot the tree by zone, subnet, type, rack, vendor, tag… at no cost; it is grouped from data the app already holds
+2. **Write markdown**, save explicitly — nothing is ever saved behind your back. `/` inserts a freshly generated block (services, hardware, network, rack) from the device's current data
+3. **Link things**: `[[VLAN plan]]`, `[[device:nas-01]]`. Each document lists **Linked from** at the bottom, so you can see what points at it
+4. **History**: up to 50 versions per document. Read one, diff it against the current body, restore it — what it replaces is kept too
+5. **Search** the whole space, tag documents, and set `review_every: 6m` on the ones that rot; a document past its interval is badged as due
+
+A device that changes after its document was written raises a **device data changed** banner, and **Regenerate** rebuilds the document from scratch when you want that. Old per-device **Notes** migrate into documents from a banner, non-destructively.
+
+Full mode only — documents need the backend to store, index and search them.
+
+> **Full documentation:** [docs/documentation.md](./docs/documentation.md)
 
 ---
 

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -25,6 +25,7 @@ from app.api.deps import get_current_user
 from app.db.database import get_db
 from app.db.models import Document, DocumentRevision, Edge, InventoryDevice, Node, Rack, RackDevice
 from app.schemas.documents import (
+    BacklinkHit,
     CoverageResponse,
     DocumentCreate,
     DocumentResponse,
@@ -37,7 +38,7 @@ from app.schemas.documents import (
     SearchHit,
     SearchResponse,
 )
-from app.services import doc_search
+from app.services import doc_backlinks, doc_search
 from app.services.doc_template import (
     BLOCKS,
     TEMPLATE_DEVICE,
@@ -386,6 +387,54 @@ async def list_revisions(
             size=len(r.body or ""),
         )
         for r in revisions
+    ]
+
+
+@router.get("/{document_id}/backlinks", response_model=list[BacklinkHit])
+async def list_backlinks(
+    document_id: str,
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(get_current_user),
+) -> list[BacklinkHit]:
+    """The documents whose body links here.
+
+    Answered on the server because the browser only holds document *metadata* —
+    the list endpoint carries no bodies, and loading every body to invert the
+    links client-side would trade a small query for a large download on every
+    open.
+    """
+    doc = await db.get(Document, document_id)
+    if not doc:
+        raise HTTPException(404, "Document not found")
+
+    # Every document is loaded because every one is a possible *target* of a
+    # link — a bare `[[VLAN plan]]` resolves by title. Only the bodies carrying
+    # `[[` are walked as sources, and the inventory is fetched only when a
+    # `[[device:…]]` is actually in play.
+    docs = list(
+        (
+            await db.execute(select(Document).order_by(Document.sort_order, Document.title))
+        ).scalars().all()
+    )
+    devices = (
+        list((await db.execute(select(InventoryDevice))).scalars().all())
+        if doc_backlinks.has_device_link(docs)
+        else []
+    )
+
+    titles = {d.id: d for d in docs}
+    return [
+        BacklinkHit(
+            doc_id=hit.doc_id,
+            title=titles[hit.doc_id].title,
+            kind=titles[hit.doc_id].kind,
+            device_id=titles[hit.doc_id].device_id,
+            label=hit.label,
+            context=hit.context,
+            count=hit.count,
+        )
+        for hit in doc_backlinks.backlinks_for(document_id, docs, devices)
+        if hit.doc_id in titles
     ]
 
 

--- a/backend/app/schemas/documents.py
+++ b/backend/app/schemas/documents.py
@@ -127,6 +127,20 @@ class SearchResponse(BaseModel):
     hits: list[SearchHit]
 
 
+class BacklinkHit(BaseModel):
+    """A document that links here, and the line it does it on."""
+
+    doc_id: str
+    title: str
+    kind: str
+    device_id: str | None = None
+    # What the link was written as, so a `[[…|label]]` reads back as the author
+    # meant it rather than as the target's own title.
+    label: str
+    context: str
+    count: int = 1
+
+
 class ScaffoldRequest(BaseModel):
     """Create the missing device documents.
 

--- a/backend/app/services/doc_backlinks.py
+++ b/backend/app/services/doc_backlinks.py
@@ -1,0 +1,158 @@
+"""Backlinks — the documents pointing at a given document.
+
+A wiki-link is one-way in the body: `[[device:nas-01]]` says where to go, not
+where it came from. This walks every body once and inverts that.
+
+The parsing and resolution rules **mirror `frontend/src/documentation/
+wikilinks.ts` exactly** — same prefixes, same fallback order, same
+case-insensitivity — the way `doc_template.service_url` mirrors
+`utils/serviceUrl.ts`. They are duplicated rather than shared because the
+forward direction has to resolve while the user types, with only what the
+browser already holds, and the reverse direction needs every body, which the
+browser does not hold: the list endpoint is metadata-only on purpose.
+
+Change one side and change the other; `test_doc_backlinks.py` pins the rules.
+"""
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+_LINK = re.compile(r"\[\[([^\]]+)\]\]")
+_TARGETS = {"device", "doc", "node"}
+
+# How much of the line the link sits on is worth showing next to it.
+_CONTEXT_CHARS = 160
+
+
+@dataclass(frozen=True)
+class WikiLink:
+    """`[[device:nas-01|the NAS]]` → target=device, key=nas-01, label=the NAS."""
+
+    target: str
+    key: str
+    label: str
+
+
+@dataclass(frozen=True)
+class Backlink:
+    """One document pointing at another, and the line it does it on."""
+
+    doc_id: str
+    label: str
+    context: str
+    count: int
+
+
+def parse_link(inner: str) -> WikiLink | None:
+    """Parse the inside of a `[[…]]`. An unknown prefix is part of the key."""
+    address, _, label_part = inner.partition("|")
+    address = address.strip()
+    label = label_part.strip()
+    if not address:
+        return None
+    target = "doc"
+    key = address
+    prefix, sep, rest = address.partition(":")
+    if sep and prefix.lower() in _TARGETS:
+        target = prefix.lower()
+        key = rest.strip()
+    if not key:
+        return None
+    return WikiLink(target=target, key=key, label=label or key)
+
+
+def iter_links(body: str) -> Iterator[tuple[str, WikiLink]]:
+    """Every link in a body, with the line it was written on."""
+    for line in (body or "").splitlines():
+        for match in _LINK.finditer(line):
+            link = parse_link(match.group(1))
+            if link:
+                yield line, link
+
+
+def device_label(device: Any) -> str:
+    """Mirrors `deviceLabel` in `documentation/tree.ts`."""
+    return (
+        device.label
+        or device.friendly_name
+        or device.hostname
+        or device.ip
+        or "Unnamed device"
+    )
+
+
+def resolve(link: WikiLink, docs: list[Any], devices: list[Any]) -> str | None:
+    """The document a link points at, or None when nothing matches yet."""
+    key = link.key.lower()
+    if link.target == "device":
+        device = next(
+            (d for d in devices if d.id == link.key or device_label(d).lower() == key),
+            None,
+        )
+        if device is None:
+            return None
+        return next((doc.id for doc in docs if doc.device_id == device.id), None)
+    if link.target == "node":
+        return next((doc.id for doc in docs if doc.node_id == link.key), None)
+    # A bare or `doc:` link: id, then slug, then title.
+    return (
+        next((doc.id for doc in docs if doc.id == link.key), None)
+        or next((doc.id for doc in docs if (doc.slug or "").lower() == key), None)
+        or next((doc.id for doc in docs if (doc.title or "").lower() == key), None)
+    )
+
+
+def _context(line: str, label: str) -> str:
+    """The line the link is on, trimmed to a readable window around it."""
+    text = " ".join(line.split())
+    if len(text) <= _CONTEXT_CHARS:
+        return text
+    at = text.find(label)
+    if at < 0:
+        return text[:_CONTEXT_CHARS].rstrip() + "…"
+    start = max(0, at - _CONTEXT_CHARS // 2)
+    end = min(len(text), start + _CONTEXT_CHARS)
+    return ("…" if start else "") + text[start:end].strip() + ("…" if end < len(text) else "")
+
+
+def backlinks_for(target_id: str, docs: list[Any], devices: list[Any]) -> list[Backlink]:
+    """Which of `docs` link to `target_id`, in the order the tree lists them.
+
+    One entry per source document however many times it links, because the
+    reader wants the documents, not the occurrences; `count` keeps the rest.
+    A document linking to itself is not a backlink.
+    """
+    found: dict[str, Backlink] = {}
+    for doc in docs:
+        # Every document is a resolution target, but only one carrying `[[`
+        # can be a source — skipping the rest early keeps this one cheap pass.
+        if doc.id == target_id or "[[" not in (doc.body or ""):
+            continue
+        for line, link in iter_links(doc.body or ""):
+            if resolve(link, docs, devices) != target_id:
+                continue
+            existing = found.get(doc.id)
+            if existing is None:
+                found[doc.id] = Backlink(
+                    doc_id=doc.id,
+                    label=link.label,
+                    context=_context(line, link.label),
+                    count=1,
+                )
+            else:
+                found[doc.id] = Backlink(
+                    doc_id=existing.doc_id,
+                    label=existing.label,
+                    context=existing.context,
+                    count=existing.count + 1,
+                )
+    return list(found.values())
+
+
+def has_device_link(docs: list[Any]) -> bool:
+    """Whether any body carries a `[[device:…]]`, so the devices load is skippable."""
+    return any(
+        link.target == "device" for doc in docs for _, link in iter_links(doc.body or "")
+    )

--- a/backend/tests/test_doc_backlinks.py
+++ b/backend/tests/test_doc_backlinks.py
@@ -1,0 +1,254 @@
+"""Backlinks — the inverse of a wiki-link.
+
+Two halves. The pure resolution rules, which must stay identical to
+`frontend/src/documentation/wikilinks.ts`, and the route, which has to find a
+target document that carries no links of its own and must not pay for the
+inventory when nothing links to a device.
+"""
+
+from dataclasses import dataclass
+
+from httpx import AsyncClient
+
+from app.services import doc_backlinks
+
+
+@dataclass
+class FakeDoc:
+    id: str
+    slug: str = ""
+    title: str = ""
+    body: str = ""
+    device_id: str | None = None
+    node_id: str | None = None
+
+
+@dataclass
+class FakeDevice:
+    id: str
+    label: str | None = None
+    friendly_name: str | None = None
+    hostname: str | None = None
+    ip: str | None = None
+
+
+# ── parsing ─────────────────────────────────────────────────────────────────
+
+
+def test_a_bare_link_is_a_document_link():
+    link = doc_backlinks.parse_link("VLAN plan")
+    assert link is not None
+    assert (link.target, link.key, link.label) == ("doc", "VLAN plan", "VLAN plan")
+
+
+def test_a_prefix_picks_the_target():
+    assert doc_backlinks.parse_link("device:nas-01").target == "device"
+    assert doc_backlinks.parse_link("NODE:abc").target == "node"
+    assert doc_backlinks.parse_link("doc:vlan-plan").target == "doc"
+
+
+def test_an_unknown_prefix_stays_part_of_the_key():
+    link = doc_backlinks.parse_link("http://nas.lan")
+    assert link is not None
+    assert (link.target, link.key) == ("doc", "http://nas.lan")
+
+
+def test_a_pipe_sets_the_label():
+    link = doc_backlinks.parse_link("device:nas-01|the big NAS")
+    assert link is not None
+    assert (link.key, link.label) == ("nas-01", "the big NAS")
+
+
+def test_an_empty_link_is_not_a_link():
+    assert doc_backlinks.parse_link("") is None
+    assert doc_backlinks.parse_link("device:") is None
+
+
+def test_links_are_collected_with_their_line():
+    body = "intro\nsee [[a]] and [[b]]\n"
+    found = list(doc_backlinks.iter_links(body))
+    assert [link.key for _, link in found] == ["a", "b"]
+    assert {line for line, _ in found} == {"see [[a]] and [[b]]"}
+
+
+# ── resolution ──────────────────────────────────────────────────────────────
+
+
+def _resolve(inner: str, docs: list[FakeDoc], devices: list[FakeDevice] | None = None):
+    link = doc_backlinks.parse_link(inner)
+    assert link is not None
+    return doc_backlinks.resolve(link, docs, devices or [])
+
+
+def test_a_document_resolves_by_id_then_slug_then_title():
+    docs = [
+        FakeDoc(id="d1", slug="vlan-plan", title="VLAN plan"),
+        FakeDoc(id="d2", slug="other", title="Other"),
+    ]
+    assert _resolve("d1", docs) == "d1"
+    assert _resolve("vlan-plan", docs) == "d1"
+    assert _resolve("VLAN PLAN", docs) == "d1"
+
+
+def test_an_unmatched_document_link_resolves_to_nothing():
+    assert _resolve("nowhere", [FakeDoc(id="d1", slug="s", title="t")]) is None
+
+
+def test_a_device_link_resolves_by_id_or_label():
+    docs = [FakeDoc(id="d1", device_id="dev1")]
+    devices = [FakeDevice(id="dev1", label="nas-01")]
+    assert _resolve("device:dev1", docs, devices) == "d1"
+    assert _resolve("device:NAS-01", docs, devices) == "d1"
+
+
+def test_a_device_label_falls_back_the_way_the_tree_does():
+    assert doc_backlinks.device_label(FakeDevice(id="x", hostname="h")) == "h"
+    assert doc_backlinks.device_label(FakeDevice(id="x", ip="10.0.0.1")) == "10.0.0.1"
+    assert doc_backlinks.device_label(FakeDevice(id="x")) == "Unnamed device"
+
+
+def test_a_device_with_no_document_resolves_to_nothing():
+    assert _resolve("device:dev1", [], [FakeDevice(id="dev1", label="nas")]) is None
+
+
+def test_a_node_link_resolves_through_node_id():
+    docs = [FakeDoc(id="d1", node_id="n1")]
+    assert _resolve("node:n1", docs) == "d1"
+    assert _resolve("node:n2", docs) is None
+
+
+# ── inversion ───────────────────────────────────────────────────────────────
+
+
+def test_a_document_that_links_here_is_a_backlink():
+    docs = [
+        FakeDoc(id="d1", slug="a", title="A", body="see [[B]]"),
+        FakeDoc(id="d2", slug="b", title="B", body="no links"),
+    ]
+    hits = doc_backlinks.backlinks_for("d2", docs, [])
+    assert [h.doc_id for h in hits] == ["d1"]
+    assert hits[0].context == "see [[B]]"
+
+
+def test_a_document_does_not_link_to_itself():
+    docs = [FakeDoc(id="d1", slug="a", title="A", body="[[A]] again")]
+    assert doc_backlinks.backlinks_for("d1", docs, []) == []
+
+
+def test_two_links_from_one_document_are_one_backlink_with_a_count():
+    docs = [
+        FakeDoc(id="d1", slug="a", title="A", body="[[B]] and later [[b]]"),
+        FakeDoc(id="d2", slug="b", title="B"),
+    ]
+    hits = doc_backlinks.backlinks_for("d2", docs, [])
+    assert len(hits) == 1
+    assert hits[0].count == 2
+
+
+def test_the_written_label_is_kept():
+    docs = [
+        FakeDoc(id="d1", slug="a", title="A", body="[[B|the other one]]"),
+        FakeDoc(id="d2", slug="b", title="B"),
+    ]
+    assert doc_backlinks.backlinks_for("d2", docs, [])[0].label == "the other one"
+
+
+def test_a_long_line_is_windowed_around_the_link():
+    filler = "word " * 60
+    docs = [
+        FakeDoc(id="d1", slug="a", title="A", body=f"{filler}[[B]]{filler}"),
+        FakeDoc(id="d2", slug="b", title="B"),
+    ]
+    context = doc_backlinks.backlinks_for("d2", docs, [])[0].context
+    assert "[[B]]" in context
+    assert len(context) < 200
+
+
+def test_has_device_link_only_fires_on_a_device_link():
+    assert doc_backlinks.has_device_link([FakeDoc(id="d", body="[[device:x]]")])
+    assert not doc_backlinks.has_device_link([FakeDoc(id="d", body="[[plain]]")])
+
+
+# ── route ───────────────────────────────────────────────────────────────────
+
+
+async def test_backlinks_requires_auth(client: AsyncClient):
+    assert (await client.get("/api/v1/documents/x/backlinks")).status_code == 401
+
+
+async def test_backlinks_404_on_an_unknown_document(client: AsyncClient, headers: dict):
+    res = await client.get("/api/v1/documents/nope/backlinks", headers=headers)
+    assert res.status_code == 404
+
+
+async def test_the_route_finds_a_target_that_carries_no_links(client: AsyncClient, headers: dict):
+    """The target's own body has no `[[`, so it is only ever a resolution target."""
+    target = (
+        await client.post("/api/v1/documents", json={"title": "VLAN plan"}, headers=headers)
+    ).json()
+    source = (
+        await client.post("/api/v1/documents", json={"title": "Runbook"}, headers=headers)
+    ).json()
+    await client.patch(
+        f"/api/v1/documents/{source['id']}",
+        json={"body": "Read the [[VLAN plan]] first."},
+        headers=headers,
+    )
+
+    res = await client.get(f"/api/v1/documents/{target['id']}/backlinks", headers=headers)
+    assert res.status_code == 200
+    hits = res.json()
+    assert [h["doc_id"] for h in hits] == [source["id"]]
+    assert hits[0]["title"] == "Runbook"
+    assert hits[0]["label"] == "VLAN plan"
+    assert hits[0]["context"] == "Read the [[VLAN plan]] first."
+
+
+async def test_a_device_document_is_reachable_by_its_device_link(client: AsyncClient, headers: dict):
+    res = await client.post(
+        "/api/v1/scan/pending",
+        json={
+            "label": "nas-01",
+            "hostname": "nas-01.lan",
+            "ip": "192.168.1.20",
+            "discovery_source": "manual",
+        },
+        headers=headers,
+    )
+    assert res.status_code in (200, 201), res.text
+    device = res.json()
+    doc = (
+        await client.post(
+            "/api/v1/documents",
+            json={"title": "nas-01", "kind": "device", "device_id": device["id"]},
+            headers=headers,
+        )
+    ).json()
+    source = (
+        await client.post("/api/v1/documents", json={"title": "Backups"}, headers=headers)
+    ).json()
+    await client.patch(
+        f"/api/v1/documents/{source['id']}",
+        json={"body": "Runs on [[device:nas-01]]."},
+        headers=headers,
+    )
+
+    hits = (await client.get(f"/api/v1/documents/{doc['id']}/backlinks", headers=headers)).json()
+    assert [h["doc_id"] for h in hits] == [source["id"]]
+    assert hits[0]["device_id"] is None  # the *source* is a page, not a device
+
+
+async def test_an_unresolved_link_is_not_a_backlink(client: AsyncClient, headers: dict):
+    target = (
+        await client.post("/api/v1/documents", json={"title": "Target"}, headers=headers)
+    ).json()
+    source = (
+        await client.post("/api/v1/documents", json={"title": "Source"}, headers=headers)
+    ).json()
+    await client.patch(
+        f"/api/v1/documents/{source['id']}",
+        json={"body": "Points at [[Something else]]."},
+        headers=headers,
+    )
+    hits = (await client.get(f"/api/v1/documents/{target['id']}/backlinks", headers=headers)).json()
+    assert hits == []

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -108,6 +108,15 @@ revert a change made elsewhere.
 `/` at the start of a line opens the insert menu: the generated blocks above,
 plus table, checklist, callout, wiki-link and date.
 
+`[[` opens the link picker, anywhere in the line: filter by title, pick, and the
+finished link is written for you. It offers documents only — a device with no
+document is not a link target yet — and it addresses a document by title, or by
+`[[doc:<id>]]` when another document shares that title, since a bare link
+resolves by title and an ambiguous one would silently pick the first. The second
+bracket is held back while the menu is open (opening it moves focus, and a
+keystroke landing mid-move belongs to neither box) and given back if you cancel,
+so what you typed survives either way.
+
 ---
 
 ## Links between documents
@@ -171,6 +180,12 @@ wholly different bodies degrades to "replaced wholesale" instead of building a
 
 `GET /api/v1/documents/search?q=` over title, tags and body.
 
+The same index answers the canvas' own search modal (Ctrl/Cmd+K), which lists
+matching documents under the nodes and pending devices; picking one switches to
+Documentation and opens it. The request is debounced and skipped below two
+characters, and a failure there costs only the document rows — the node and
+device halves filter lists already in memory.
+
 FTS5 is **not** assumed: the SQLite shipped in the LXC and Docker images may be
 built without it, the same reason `database.py` avoids JSON1. `doc_search.py`
 probes once and falls back to `LIKE`, and the response says which engine
@@ -230,6 +245,5 @@ into `localStorage` with no search and no history.
 
 Export/import of the tree as `.md` files, a print/handbook view, an aggregated
 open-tasks view, image upload inside a document (would reuse
-`api/routes/media.py`, full-mode only), documents in the canvas-wide search
-modal, `[[` autocompletion in the editor, and the MCP tools — those are the
+`api/routes/media.py`, full-mode only), and the MCP tools — those are the
 planned second lot.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -124,6 +124,47 @@ ordinary markdown for anything else that reads it.
 **Raw HTML is deliberately not rendered** — `rehype-raw` is absent — so a
 document cannot inject markup and no sanitiser is needed.
 
+### Backlinks
+
+Every document lists what points at it, under **Linked from**, with the line the
+link was written on and the label it was written as.
+
+The inversion is done **server-side** (`services/doc_backlinks.py`,
+`GET /documents/{id}/backlinks`), because the browser holds no bodies but the
+open one: `GET /documents` is metadata-only so the tree can badge without
+downloading the space. That service mirrors the resolution rules in
+`wikilinks.ts` — same prefixes, same id → slug → title fallback, same
+case-insensitivity — the way the generator's `service_url` mirrors
+`utils/serviceUrl.ts`. Change one and change the other;
+`test_doc_backlinks.py` pins the rules.
+
+Repeated links from the same document collapse into one entry with a count, and
+a document never backlinks itself. The inventory is only loaded when some body
+actually carries a `[[device:…]]`.
+
+---
+
+## History
+
+Every explicit save that changes the body snapshots the previous one, capped at
+`REVISION_LIMIT` (50) per document; so do restore, regenerate, scaffold and the
+notes migration, each recording why.
+
+The clock-arrow button in the header opens the history rail: what each version
+was (Saved, Regenerated, Restored, Migrated from notes…), when, and how big.
+Selecting one replaces the body with that version — same title, same chips, same
+rail — and **Changes** turns it into a line diff against the current body, with
+long unchanged runs collapsed. **Restore** brings it back, snapshotting the body
+it replaces first, so a restore is itself undoable.
+
+A revision's body is fetched only when it is opened: the list carries a size, not
+the text, so fifty versions cost one small request.
+
+The diff is a plain LCS over lines (`documentation/diff.ts`), after the common
+head and tail are trimmed — no diff library, and a pathological pair of long,
+wholly different bodies degrades to "replaced wholesale" instead of building a
+250k-cell matrix.
+
 ---
 
 ## Search
@@ -166,6 +207,7 @@ Non-destructive and repeatable.
 | `PATCH` | `/api/v1/documents/{id}` |
 | `DELETE` | `/api/v1/documents/{id}` — a folder takes its subtree |
 | `GET` | `/api/v1/documents/{id}/revisions`, `/revisions/{rev_id}` |
+| `GET` | `/api/v1/documents/{id}/backlinks` — the documents linking here |
 | `POST` | `/api/v1/documents/{id}/revisions/{rev_id}/restore` |
 | `POST` | `/api/v1/documents/{id}/regenerate` — erase the body and scaffold it again |
 | `GET` | `/api/v1/documents/search?q=&limit=` |
@@ -188,5 +230,6 @@ into `localStorage` with no search and no history.
 
 Export/import of the tree as `.md` files, a print/handbook view, an aggregated
 open-tasks view, image upload inside a document (would reuse
-`api/routes/media.py`, full-mode only), and the MCP tools — those are the
+`api/routes/media.py`, full-mode only), documents in the canvas-wide search
+modal, `[[` autocompletion in the editor, and the MCP tools — those are the
 planned second lot.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1429,6 +1429,14 @@ export default function App() {
           open={searchOpen}
           onClose={() => setSearchOpen(false)}
           onOpenInventory={(deviceId) => openInventoryModal(deviceId)}
+          onOpenDocument={
+            STANDALONE
+              ? undefined
+              : (docId) => {
+                  setAppView('documentation')
+                  void useDocsStore.getState().open(docId)
+                }
+          }
         />
         <ShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,8 @@ import { getCenteredPosition } from '@/utils/viewportCenter'
 import { resolveVirtualEdgeParent } from '@/utils/virtualEdgeParent'
 import { generateMarkdownTable } from '@/utils/exportMarkdown'
 import { copyToClipboard } from '@/utils/clipboard'
-import { getDesignIdFromUrl, setDesignIdInUrl, getDocIdFromUrl, isDocsViewInUrl, setDocsViewInUrl } from '@/utils/designUrl'
+import { getDesignIdFromUrl, setDesignIdInUrl } from '@/utils/designUrl'
+import { useDocsUrlSync } from '@/hooks/useDocsUrlSync'
 import { withBase } from '@/utils/basePath'
 import { ExportModal } from '@/components/modals/ExportModal'
 import { exportCanvasToYaml, downloadYaml } from '@/utils/exportYaml'
@@ -488,10 +489,22 @@ export default function App() {
     if (activeDesignId) setDesignIdInUrl(activeDesignId)
   }, [activeDesignId])
 
-  // A document is linkable in the same way: `?view=docs&doc=<id>`.
-  useEffect(() => {
-    setDocsViewInUrl(appView === 'documentation', openDocId)
-  }, [appView, openDocId])
+  // A document is linkable in the same way: `?view=docs&doc=<id>` — written on
+  // every change, and read back on boot so a refresh reopens it.
+  const restoreDocsUrl = useCallback(
+    async (docId: string | null) => {
+      setAppView('documentation')
+      if (docId) await useDocsStore.getState().open(docId)
+    },
+    [setAppView],
+  )
+  useDocsUrlSync({
+    view: appView,
+    openDocId,
+    ready: isAuthenticated,
+    enabled: !STANDALONE,
+    onRestore: restoreDocsUrl,
+  })
 
   // The canvas' way into Documentation: it knows a device id, and the section
   // resolves that to a document — writing one from the device's facts when
@@ -504,16 +517,6 @@ export default function App() {
     },
     [setAppView],
   )
-
-  // Reopen the section, and the document, the URL asks for. Once, on boot.
-  const docsUrlApplied = useRef(false)
-  useEffect(() => {
-    if (docsUrlApplied.current || STANDALONE || !isDocsViewInUrl()) return
-    docsUrlApplied.current = true
-    setAppView('documentation')
-    const docId = getDocIdFromUrl()
-    if (docId) void useDocsStore.getState().open(docId)
-  }, [setAppView])
 
   // Keep refs for store actions so keydown handler is always up-to-date without re-registering
   const undoRef = useRef(undo)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -337,6 +337,8 @@ export const documentsApi = {
     ),
   restore: (id: string, revisionId: string) =>
     api.post<import('@/documentation/types').Doc>(`/documents/${id}/revisions/${revisionId}/restore`),
+  backlinks: (id: string) =>
+    api.get<import('@/documentation/types').DocBacklink[]>(`/documents/${id}/backlinks`),
   regenerate: (id: string) =>
     api.post<import('@/documentation/types').Doc>(`/documents/${id}/regenerate`),
   search: (q: string, limit = 25) =>

--- a/frontend/src/components/modals/SearchModal.tsx
+++ b/frontend/src/components/modals/SearchModal.tsx
@@ -2,18 +2,29 @@ import { useState, useCallback, useEffect } from 'react'
 import { useReactFlow } from '@xyflow/react'
 import { Search } from 'lucide-react'
 import { useCanvasStore } from '@/stores/canvasStore'
-import { scanApi } from '@/api/client'
+import { documentsApi, scanApi } from '@/api/client'
+import type { DocSearchHit } from '@/documentation/types'
 import type { InventoryEntry } from '@/components/modals/InventoryDeviceModal'
+
+const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
+
+/** Long enough that a stray keystroke does not hit the server. */
+const DOC_SEARCH_DEBOUNCE = 250
 
 interface SearchModalProps {
   open: boolean
   onClose: () => void
   onOpenInventory: (deviceId: string) => void
+  /** Omitted in standalone, where there are no documents to open. */
+  onOpenDocument?: (docId: string) => void
 }
 
-export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps) {
+export function SearchModal({ open, onClose, onOpenInventory, onOpenDocument }: SearchModalProps) {
   const [query, setQuery] = useState('')
   const [inventoryDevices, setInventoryEntrys] = useState<InventoryEntry[]>([])
+  // Kept with the query it answered, so a stale answer is never shown against a
+  // newer query and no effect has to clear it.
+  const [docHits, setDocHits] = useState<{ query: string; hits: DocSearchHit[] }>({ query: '', hits: [] })
   const nodes = useCanvasStore((s) => s.nodes)
   const setSelectedNode = useCanvasStore((s) => s.setSelectedNode)
   const { fitView } = useReactFlow()
@@ -23,8 +34,32 @@ export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps
     scanApi.pending().then((res) => setInventoryEntrys(res.data)).catch(() => {})
   }, [open])
 
-  const searchable = nodes.filter((n) => n.data.type !== 'groupRect')
   const q = query.toLowerCase()
+
+  // Documents are not in memory — the tree only ever holds their metadata, and
+  // the body is what makes a search worth running — so this one goes to the
+  // server's index rather than filtering a local list.
+  useEffect(() => {
+    if (!open || STANDALONE || !onOpenDocument) return
+    const needle = query.trim()
+    if (needle.length < 2) return
+    let live = true
+    const timer = setTimeout(async () => {
+      try {
+        const { data } = await documentsApi.search(needle, 5)
+        if (live) setDocHits({ query: needle, hits: data.hits })
+      } catch {
+        // The rest of the modal still works without the index.
+        if (live) setDocHits({ query: needle, hits: [] })
+      }
+    }, DOC_SEARCH_DEBOUNCE)
+    return () => {
+      live = false
+      clearTimeout(timer)
+    }
+  }, [open, query, onOpenDocument])
+
+  const searchable = nodes.filter((n) => n.data.type !== 'groupRect')
 
   const nodeResults = q.length === 0 ? [] : searchable.filter((n) =>
     n.data.label?.toLowerCase().includes(q) ||
@@ -43,7 +78,9 @@ export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps
     )
   ).slice(0, 4)
 
-  const totalResults = nodeResults.length + pendingResults.length
+  const documentResults = docHits.query && docHits.query === query.trim() ? docHits.hits : []
+
+  const totalResults = nodeResults.length + pendingResults.length + documentResults.length
 
   const handleSelectNode = useCallback((nodeId: string) => {
     setSelectedNode(nodeId)
@@ -57,6 +94,12 @@ export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps
     onClose()
     setQuery('')
   }, [onOpenInventory, onClose])
+
+  const handleSelectDocument = useCallback((docId: string) => {
+    onOpenDocument?.(docId)
+    onClose()
+    setQuery('')
+  }, [onOpenDocument, onClose])
 
   if (!open) return null
 
@@ -72,12 +115,14 @@ export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps
             autoFocus
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search nodes, pending devices by IP or service…"
+            placeholder="Search nodes, devices and documents…"
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
             onKeyDown={(e) => {
               if (e.key === 'Escape') { onClose(); setQuery('') }
+              // Enter takes the first result in the order they are listed.
               if (e.key === 'Enter' && nodeResults.length > 0) handleSelectNode(nodeResults[0].id)
-              if (e.key === 'Enter' && nodeResults.length === 0 && pendingResults.length > 0) handleSelectInventoryDevice(pendingResults[0].id)
+              else if (e.key === 'Enter' && pendingResults.length > 0) handleSelectInventoryDevice(pendingResults[0].id)
+              else if (e.key === 'Enter' && documentResults.length > 0) handleSelectDocument(documentResults[0].doc_id)
             }}
           />
           <kbd className="text-[10px] text-muted-foreground border border-border rounded px-1">ESC</kbd>
@@ -117,6 +162,30 @@ export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps
                 </li>
               )
             })}
+            {documentResults.length > 0 && nodeResults.length + pendingResults.length > 0 && (
+              <li className="px-4 py-1">
+                <div className="h-px bg-border" />
+              </li>
+            )}
+            {documentResults.map((hit) => (
+              <li
+                key={hit.doc_id}
+                className="flex items-center gap-3 px-4 py-2 hover:bg-[#21262d] cursor-pointer"
+                onClick={() => handleSelectDocument(hit.doc_id)}
+              >
+                <span className="text-xs font-mono text-[#a855f7] w-16 shrink-0">
+                  {hit.kind === 'device' ? 'doc·dev' : 'doc'}
+                </span>
+                <span className="text-sm text-foreground font-medium flex-1 truncate">{hit.title}</span>
+                {/* The snippet is the line the match sits on; it is the only
+                    reason a body search beats scanning the tree by eye. */}
+                {hit.snippet && (
+                  <span className="text-xs text-muted-foreground shrink-0 max-w-[45%] truncate">
+                    {hit.snippet}
+                  </span>
+                )}
+              </li>
+            ))}
           </ul>
         )}
 
@@ -125,7 +194,9 @@ export function SearchModal({ open, onClose, onOpenInventory }: SearchModalProps
         )}
 
         {q.length === 0 && (
-          <p className="px-4 py-3 text-xs text-muted-foreground">Type to search nodes and pending devices…</p>
+          <p className="px-4 py-3 text-xs text-muted-foreground">
+            Type to search nodes, pending devices{onOpenDocument && !STANDALONE ? ' and documents' : ''}…
+          </p>
         )}
       </div>
     </div>

--- a/frontend/src/components/modals/__tests__/SearchModalDocuments.test.tsx
+++ b/frontend/src/components/modals/__tests__/SearchModalDocuments.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Documents in the global search.
+ *
+ * Nodes and pending devices filter a list already in memory; documents cannot —
+ * the tree holds their metadata and never their bodies — so this half goes to
+ * the server's index, debounced, and has to behave when it is slow, when it
+ * fails, and when the query has moved on.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { SearchModal } from '../SearchModal'
+import { documentsApi } from '@/api/client'
+import { useCanvasStore } from '@/stores/canvasStore'
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({ fitView: vi.fn() }),
+}))
+
+vi.mock('@/api/client', () => ({
+  scanApi: { pending: vi.fn().mockResolvedValue({ data: [] }) },
+  documentsApi: { search: vi.fn() },
+}))
+
+const api = vi.mocked(documentsApi)
+
+function hit(overrides: Partial<{ doc_id: string; title: string; kind: string; snippet: string }> = {}) {
+  return {
+    doc_id: 'doc-1',
+    title: 'VLAN plan',
+    kind: 'page',
+    snippet: 'the VLAN plan for the lab',
+    device_id: null,
+    ...overrides,
+  }
+}
+
+function open(onOpenDocument = vi.fn()) {
+  render(<SearchModal open onClose={vi.fn()} onOpenInventory={vi.fn()} onOpenDocument={onOpenDocument} />)
+  return { onOpenDocument, input: screen.getByPlaceholderText(/search nodes/i) }
+}
+
+/** Type, then let the debounce fire and the promise settle. */
+async function search(input: HTMLElement, text: string) {
+  fireEvent.change(input, { target: { value: text } })
+  await act(async () => {
+    vi.advanceTimersByTime(300)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.clearAllMocks()
+  useCanvasStore.setState({ nodes: [], edges: [], selectedNodeId: null })
+  api.search.mockResolvedValue({ data: { engine: 'fts5', hits: [hit()] } } as never)
+})
+
+afterEach(() => vi.useRealTimers())
+
+describe('SearchModal — documents', () => {
+  it('lists a matching document with its snippet', async () => {
+    const { input } = open()
+
+    await search(input, 'vlan')
+
+    expect(api.search).toHaveBeenCalledWith('vlan', 5)
+    await waitFor(() => expect(screen.getByText('VLAN plan')).toBeTruthy())
+    expect(screen.getByText('the VLAN plan for the lab')).toBeTruthy()
+  })
+
+  it('opens the document that was picked', async () => {
+    const { input, onOpenDocument } = open()
+
+    await search(input, 'vlan')
+    await waitFor(() => screen.getByText('VLAN plan'))
+    fireEvent.click(screen.getByText('VLAN plan'))
+
+    expect(onOpenDocument).toHaveBeenCalledWith('doc-1')
+  })
+
+  it('marks a device document apart from a page', async () => {
+    api.search.mockResolvedValue({
+      data: { engine: 'fts5', hits: [hit({ kind: 'device', title: 'nas-01' })] },
+    } as never)
+    const { input } = open()
+
+    await search(input, 'nas')
+
+    await waitFor(() => expect(screen.getByText('doc·dev')).toBeTruthy())
+  })
+
+  it('does not ask the server for a one-character query', async () => {
+    const { input } = open()
+
+    await search(input, 'v')
+
+    expect(api.search).not.toHaveBeenCalled()
+  })
+
+  it('asks once for a query typed in one go, not once per keystroke', async () => {
+    const { input } = open()
+
+    fireEvent.change(input, { target: { value: 'vl' } })
+    fireEvent.change(input, { target: { value: 'vla' } })
+    await search(input, 'vlan')
+
+    expect(api.search).toHaveBeenCalledTimes(1)
+    expect(api.search).toHaveBeenCalledWith('vlan', 5)
+  })
+
+  it('drops an answer once the query has moved on', async () => {
+    const { input } = open()
+    await search(input, 'vlan')
+    await waitFor(() => screen.getByText('VLAN plan'))
+
+    // Answers are kept with the query they answered, so this one stops applying.
+    fireEvent.change(input, { target: { value: 'vlan switch' } })
+
+    expect(screen.queryByText('VLAN plan')).toBeNull()
+  })
+
+  it('keeps working when the index is unavailable', async () => {
+    api.search.mockRejectedValue(new Error('no fts'))
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'n1',
+          type: 'server',
+          position: { x: 0, y: 0 },
+          data: { label: 'vlan-router', type: 'server', status: 'unknown', services: [] },
+        },
+      ],
+    } as never)
+    const { input } = open()
+
+    await search(input, 'vlan')
+
+    expect(screen.getByText('vlan-router')).toBeTruthy()
+    expect(screen.queryByText('VLAN plan')).toBeNull()
+  })
+
+  it('asks for nothing at all when the host offers no way to open a document', async () => {
+    render(<SearchModal open onClose={vi.fn()} onOpenInventory={vi.fn()} />)
+
+    await search(screen.getByPlaceholderText(/search nodes/i), 'vlan')
+
+    expect(api.search).not.toHaveBeenCalled()
+    expect(screen.getByText(/no results match/i)).toBeTruthy()
+  })
+
+  it('opens the first document on Enter when nothing else matched', async () => {
+    const { input, onOpenDocument } = open()
+
+    await search(input, 'vlan')
+    await waitFor(() => screen.getByText('VLAN plan'))
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onOpenDocument).toHaveBeenCalledWith('doc-1')
+  })
+})

--- a/frontend/src/documentation/__tests__/DocEditorLinks.test.tsx
+++ b/frontend/src/documentation/__tests__/DocEditorLinks.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * The `[[` picker.
+ *
+ * Wiki-links were unusable unless you remembered a title or a slug exactly.
+ * What matters here is the arithmetic: the two brackets stay in the body while
+ * the menu is open, and choosing a target replaces exactly those two.
+ */
+import { useState } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DocEditor } from '../components/DocEditor'
+import type { LinkableDevice, LinkableDoc } from '../wikilinks'
+
+vi.mock('@/api/client', () => ({
+  documentsApi: { block: vi.fn() },
+}))
+
+const DOCS: LinkableDoc[] = [
+  { id: 'd1', slug: 'vlan-plan', title: 'VLAN plan' },
+  { id: 'd2', slug: 'nas-01', title: 'nas-01', device_id: 'dev-1' },
+  { id: 'd3', slug: 'backup-runbook', title: 'Backup runbook' },
+]
+
+const DEVICES: LinkableDevice[] = [{ id: 'dev-1', label: 'nas-01' }]
+
+/** A stateful host, so the brackets really land in the textarea's value. */
+function setup(initial = '', docs: LinkableDoc[] = DOCS, devices = DEVICES) {
+  const onChange = vi.fn()
+  function Host() {
+    const [body, setBody] = useState(initial)
+    return (
+      <DocEditor
+        body={body}
+        onChange={(next) => {
+          onChange(next)
+          setBody(next)
+        }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        dirty={false}
+        saving={false}
+        docs={docs}
+        devices={devices}
+      />
+    )
+  }
+  render(<Host />)
+  return { onChange, textarea: screen.getByLabelText('Document source') as HTMLTextAreaElement }
+}
+
+// userEvent reads `[…]` as a key code, so a literal bracket is doubled: the
+// four characters below type exactly `[[`.
+const TWO_BRACKETS = '[[[['
+
+async function openPicker(textarea: HTMLTextAreaElement, user = userEvent.setup()) {
+  await user.click(textarea)
+  await user.keyboard(TWO_BRACKETS)
+  return user
+}
+
+describe('DocEditor — the [[ picker', () => {
+  it('opens on the second bracket and lists the documents', async () => {
+    const { textarea } = setup('Runs on ')
+
+    await openPicker(textarea)
+
+    expect(screen.getByLabelText('Link to a document')).toBeTruthy()
+    expect(screen.getByText('VLAN plan')).toBeTruthy()
+    expect(screen.getByText('Backup runbook')).toBeTruthy()
+  })
+
+  it('holds the second bracket back while it is open', async () => {
+    const { textarea } = setup('Runs on ')
+
+    await openPicker(textarea)
+
+    // The picker owns the second bracket until it inserts or is cancelled.
+    expect(textarea.value).toBe('Runs on [')
+  })
+
+  it('does not open on a single bracket', async () => {
+    const { textarea } = setup('')
+    const user = userEvent.setup()
+
+    await user.click(textarea)
+    await user.keyboard('[[')
+
+    expect(textarea.value).toBe('[')
+    expect(screen.queryByLabelText('Link to a document')).toBeNull()
+  })
+
+  it('replaces both brackets with the finished link', async () => {
+    const { textarea } = setup('Runs on ')
+    const user = await openPicker(textarea)
+
+    await user.click(screen.getByText('VLAN plan'))
+
+    await waitFor(() => expect(textarea.value).toBe('Runs on [[VLAN plan]]'))
+  })
+
+  it('filters as you type, and Enter takes the first match', async () => {
+    const { textarea } = setup('')
+    const user = await openPicker(textarea)
+
+    await user.type(screen.getByLabelText('Link to a document'), 'backup')
+    expect(screen.queryByText('VLAN plan')).toBeNull()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(textarea.value).toBe('[[Backup runbook]]'))
+  })
+
+  it('says which document belongs to a device', async () => {
+    const { textarea } = setup('')
+
+    await openPicker(textarea)
+
+    expect(screen.getByText('Device · nas-01')).toBeTruthy()
+  })
+
+  it('addresses a document by id when its title is ambiguous', async () => {
+    const { textarea } = setup('', [
+      { id: 'd1', slug: 'incident-1', title: 'Incident' },
+      { id: 'd2', slug: 'incident-2', title: 'Incident' },
+    ])
+    const user = await openPicker(textarea)
+
+    await user.click(screen.getAllByText('Incident')[0])
+
+    // A bare `[[Incident]]` resolves by title and would pick whichever came
+    // first, so an ambiguous title is written as an id instead.
+    await waitFor(() => expect(textarea.value).toBe('[[doc:d1]]'))
+  })
+
+  it('closes on Escape and leaves what was typed', async () => {
+    const { textarea } = setup('Runs on ')
+    const user = await openPicker(textarea)
+
+    await user.type(screen.getByLabelText('Link to a document'), '{Escape}')
+
+    expect(screen.queryByLabelText('Link to a document')).toBeNull()
+    expect(textarea.value).toBe('Runs on [[')
+  })
+
+  it('says so when there is nothing to link to yet', async () => {
+    const { textarea } = setup('', [])
+
+    await openPicker(textarea)
+
+    expect(screen.getByText('No document to link to yet.')).toBeTruthy()
+  })
+
+  it('still opens the slash menu on a new line', async () => {
+    const { textarea } = setup('')
+    const user = userEvent.setup()
+
+    await user.click(textarea)
+    await user.keyboard('/')
+
+    expect(screen.getByLabelText('Insert a block')).toBeTruthy()
+    expect(screen.queryByLabelText('Link to a document')).toBeNull()
+  })
+})

--- a/frontend/src/documentation/__tests__/DocHistory.test.tsx
+++ b/frontend/src/documentation/__tests__/DocHistory.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * The two panels a document grew: the versions it used to have, and the
+ * documents that point at it. Both existed in the API from the start and
+ * neither had a way in, so what these assert first is that the wiring is there.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { DocViewer, type HistoryControls } from '../components/DocViewer'
+import type { Doc, DocBacklink, DocRevision } from '../types'
+
+function makeDoc(overrides: Partial<Doc> = {}): Doc {
+  return {
+    id: 'doc-1',
+    kind: 'page',
+    title: 'NAS',
+    slug: 'nas',
+    sort_order: 0,
+    tags: [],
+    frontmatter: {},
+    starred: false,
+    body: 'the current body\nsecond line',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Doc
+}
+
+function revision(overrides: Partial<DocRevision> = {}): DocRevision {
+  return {
+    id: 'rev-1',
+    document_id: 'doc-1',
+    title: 'NAS',
+    reason: 'edit',
+    saved_at: '2026-01-01T00:00:00Z',
+    size: 2048,
+    ...overrides,
+  }
+}
+
+function backlink(overrides: Partial<DocBacklink> = {}): DocBacklink {
+  return {
+    doc_id: 'doc-2',
+    title: 'Backup runbook',
+    kind: 'page',
+    label: 'NAS',
+    context: 'Runs nightly against [[NAS]].',
+    count: 1,
+    ...overrides,
+  }
+}
+
+function controls(overrides: Partial<HistoryControls> = {}): HistoryControls {
+  return {
+    open: false,
+    loading: false,
+    revisions: [],
+    preview: null,
+    onToggle: vi.fn(),
+    onSelect: vi.fn(),
+    onClosePreview: vi.fn(),
+    onRestore: vi.fn(),
+    ...overrides,
+  }
+}
+
+const base = {
+  docs: [],
+  devices: [],
+  drifted: false,
+  onEdit: vi.fn(),
+  onToggleStar: vi.fn(),
+  onMarkReviewed: vi.fn(),
+  onRegenerate: vi.fn(),
+  onDelete: vi.fn(),
+  onOpenDoc: vi.fn(),
+  onCreateFromLink: vi.fn(),
+  onToggleTask: vi.fn(),
+  onSetTags: vi.fn(),
+}
+
+describe('DocViewer — history', () => {
+  it('offers no history when the host keeps none', () => {
+    render(<DocViewer {...base} doc={makeDoc()} />)
+    expect(screen.queryByLabelText('Version history')).toBeNull()
+  })
+
+  it('opens the rail from the header button', () => {
+    const history = controls()
+    render(<DocViewer {...base} doc={makeDoc()} history={history} />)
+
+    fireEvent.click(screen.getByLabelText('Version history'))
+
+    expect(history.onToggle).toHaveBeenCalled()
+  })
+
+  it('says the button is pressed while the rail is open', () => {
+    render(<DocViewer {...base} doc={makeDoc()} history={controls({ open: true })} />)
+    expect(screen.getByLabelText('Version history')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('lists a revision by what caused it, and selects it on click', () => {
+    const history = controls({ open: true, revisions: [revision({ reason: 'regenerate' })] })
+    render(<DocViewer {...base} doc={makeDoc()} history={history} />)
+
+    fireEvent.click(screen.getByText('Regenerated'))
+
+    expect(history.onSelect).toHaveBeenCalledWith('rev-1')
+    expect(screen.getByText(/2 kB/)).toBeTruthy()
+  })
+
+  it('explains an empty history rather than showing an empty list', () => {
+    render(<DocViewer {...base} doc={makeDoc()} history={controls({ open: true })} />)
+    expect(screen.getByText(/No earlier version yet/)).toBeTruthy()
+  })
+
+  it('replaces the body with the version being read', () => {
+    const history = controls({
+      open: true,
+      revisions: [revision()],
+      preview: { revision: revision(), body: 'what it said before' },
+    })
+    render(<DocViewer {...base} doc={makeDoc()} history={history} />)
+
+    expect(screen.getByText('what it said before')).toBeTruthy()
+    expect(screen.queryByText(/the current body/)).toBeNull()
+  })
+
+  it('restores the version being read, and can go back to the current one', () => {
+    const history = controls({
+      open: true,
+      revisions: [revision()],
+      preview: { revision: revision(), body: 'what it said before' },
+    })
+    render(<DocViewer {...base} doc={makeDoc()} history={history} />)
+
+    fireEvent.click(screen.getByText('Restore'))
+    expect(history.onRestore).toHaveBeenCalledWith('rev-1')
+
+    fireEvent.click(screen.getByLabelText('Back to the current version'))
+    expect(history.onClosePreview).toHaveBeenCalled()
+  })
+
+  it('shows what changed since that version', () => {
+    const history = controls({
+      preview: { revision: revision(), body: 'the current body\nold second line' },
+    })
+    render(<DocViewer {...base} doc={makeDoc()} history={history} />)
+
+    // The summary is on screen before anything is clicked: one line each way.
+    expect(screen.getByText('+1')).toBeTruthy()
+    expect(screen.getByText('−1')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Changes'))
+
+    expect(screen.getByText(/− old second line/)).toBeTruthy()
+    expect(screen.getByText(/\+ second line/)).toBeTruthy()
+  })
+
+  it('says so when a version is identical to the current body', () => {
+    const doc = makeDoc()
+    const history = controls({ preview: { revision: revision(), body: doc.body } })
+    render(<DocViewer {...base} doc={doc} history={history} />)
+
+    expect(screen.getByText('Identical to the current version')).toBeTruthy()
+  })
+})
+
+describe('DocViewer — backlinks', () => {
+  it('lists what links here, with the line it links from', () => {
+    render(<DocViewer {...base} doc={makeDoc()} backlinks={[backlink()]} />)
+
+    expect(screen.getByText('Linked from (1)')).toBeTruthy()
+    expect(screen.getByText('Backup runbook')).toBeTruthy()
+    expect(screen.getByText('Runs nightly against [[NAS]].')).toBeTruthy()
+  })
+
+  it('opens the linking document', () => {
+    const onOpenDoc = vi.fn()
+    render(<DocViewer {...base} doc={makeDoc()} backlinks={[backlink()]} onOpenDoc={onOpenDoc} />)
+
+    fireEvent.click(screen.getByText('Backup runbook'))
+
+    expect(onOpenDoc).toHaveBeenCalledWith('doc-2')
+  })
+
+  it('counts repeated links from the same document once, and says how many', () => {
+    render(<DocViewer {...base} doc={makeDoc()} backlinks={[backlink({ count: 3 })]} />)
+
+    expect(screen.getAllByText('Backup runbook')).toHaveLength(1)
+    expect(screen.getByText('×3')).toBeTruthy()
+  })
+
+  it('shows nothing at all when nothing links here', () => {
+    render(<DocViewer {...base} doc={makeDoc()} backlinks={[]} />)
+    expect(screen.queryByText(/Linked from/)).toBeNull()
+  })
+
+  it('waits for the answer rather than claiming nothing links here', () => {
+    render(<DocViewer {...base} doc={makeDoc()} backlinks={[backlink()]} backlinksLoading />)
+    expect(screen.queryByText(/Linked from/)).toBeNull()
+  })
+})

--- a/frontend/src/documentation/__tests__/NewDocMenu.test.tsx
+++ b/frontend/src/documentation/__tests__/NewDocMenu.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The template picker opens from a button at the right edge of a narrow,
+ * scrolling, resizable column. It used to be absolutely positioned inside that
+ * column, where it was clipped by the scroll container and painted under the
+ * app sidebar; it is portalled to the body now, so what these pin is that it
+ * leaves the column and stays inside the viewport.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { NewDocMenu } from '../components/NewDocMenu'
+
+function open(placement: 'up' | 'down' = 'down', onCreate = vi.fn()) {
+  const view = render(
+    <div style={{ overflow: 'auto', width: 260 }}>
+      <NewDocMenu placement={placement} onCreate={onCreate} trigger={<button>New</button>} />
+    </div>,
+  )
+  fireEvent.click(screen.getByText('New'))
+  return { ...view, onCreate }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('NewDocMenu', () => {
+  it('opens on the trigger and lists every template', () => {
+    open()
+    expect(screen.getByRole('menu')).toBeTruthy()
+    expect(screen.getByText('Runbook')).toBeTruthy()
+    expect(screen.getByText('Decision (ADR)')).toBeTruthy()
+  })
+
+  it('renders outside the scrolling column that would clip it', () => {
+    const { container } = open()
+    // Portalled: the menu is in the body, not under the component's own tree.
+    expect(container.querySelector('[role="menu"]')).toBeNull()
+    expect(document.body.querySelector('[role="menu"]')).toBeTruthy()
+  })
+
+  it('keeps its left edge inside the viewport', () => {
+    open()
+    const menu = screen.getByRole('menu') as HTMLElement
+    // Tailwind's `fixed` is a class, and jsdom loads no stylesheet to resolve it.
+    expect(menu.className).toContain('fixed')
+    expect(parseFloat(menu.style.left)).toBeGreaterThanOrEqual(0)
+  })
+
+  it('hangs below the trigger when it opens downwards', () => {
+    open('down')
+    const menu = screen.getByRole('menu') as HTMLElement
+    expect(menu.style.top).not.toBe('')
+    expect(menu.style.bottom).toBe('')
+  })
+
+  it('sits above the trigger when it opens upwards', () => {
+    open('up')
+    const menu = screen.getByRole('menu') as HTMLElement
+    expect(menu.style.bottom).not.toBe('')
+    expect(menu.style.top).toBe('')
+  })
+
+  it('closes on Escape', () => {
+    open()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('closes on a click outside itself', () => {
+    open()
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('stays open while the click is inside it', () => {
+    open()
+    fireEvent.mouseDown(screen.getByText('Runbook'))
+    expect(screen.queryByRole('menu')).toBeTruthy()
+  })
+
+  it('closes rather than floating away when the page scrolls', () => {
+    open()
+    fireEvent.scroll(document, {})
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('creates from the picked template with the typed title', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('  Switch upgrade  ')
+    const { onCreate } = open()
+
+    fireEvent.click(screen.getByText('Runbook'))
+
+    expect(onCreate).toHaveBeenCalledWith({
+      title: 'Switch upgrade',
+      templateId: 'runbook',
+      parentId: undefined,
+    })
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('creates nothing when the title is cancelled or blank', () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('   ')
+    const { onCreate } = open()
+
+    fireEvent.click(screen.getByText('Blank page'))
+
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/documentation/__tests__/diff.test.ts
+++ b/frontend/src/documentation/__tests__/diff.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { collapseDiff, diffLines, diffStat, type DiffLine } from '../diff'
+
+const text = (lines: DiffLine[], kind: DiffLine['kind']) =>
+  lines.filter((line) => line.kind === kind).map((line) => line.text)
+
+describe('diffLines', () => {
+  it('marks an unchanged body as all the same', () => {
+    const body = 'one\ntwo\nthree'
+    expect(diffLines(body, body).every((line) => line.kind === 'same')).toBe(true)
+  })
+
+  it('finds an inserted line', () => {
+    const lines = diffLines('one\nthree', 'one\ntwo\nthree')
+    expect(text(lines, 'add')).toEqual(['two'])
+    expect(text(lines, 'del')).toEqual([])
+  })
+
+  it('finds a removed line', () => {
+    const lines = diffLines('one\ntwo\nthree', 'one\nthree')
+    expect(text(lines, 'del')).toEqual(['two'])
+    expect(text(lines, 'add')).toEqual([])
+  })
+
+  it('reads a changed line as one removal and one addition', () => {
+    const lines = diffLines('one\ntwo\nthree', 'one\nTWO\nthree')
+    expect(text(lines, 'del')).toEqual(['two'])
+    expect(text(lines, 'add')).toEqual(['TWO'])
+  })
+
+  it('keeps every line of both bodies', () => {
+    const lines = diffLines('a\nb', 'a\nc\nd')
+    expect(lines.map((line) => line.text)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('handles an empty body on either side', () => {
+    expect(text(diffLines('', 'new'), 'add')).toEqual(['new'])
+    expect(text(diffLines('old', ''), 'del')).toEqual(['old'])
+  })
+
+  it('degrades to a wholesale replacement rather than hanging on two huge bodies', () => {
+    const before = Array.from({ length: 700 }, (_, i) => `before ${i}`).join('\n')
+    const after = Array.from({ length: 700 }, (_, i) => `after ${i}`).join('\n')
+    const lines = diffLines(before, after)
+    expect(text(lines, 'del')).toHaveLength(700)
+    expect(text(lines, 'add')).toHaveLength(700)
+  })
+})
+
+describe('diffStat', () => {
+  it('counts what changed', () => {
+    expect(diffStat(diffLines('a\nb\nc', 'a\nB\nc\nd'))).toEqual({ added: 2, removed: 1 })
+  })
+
+  it('counts nothing for an identical body', () => {
+    expect(diffStat(diffLines('a', 'a'))).toEqual({ added: 0, removed: 0 })
+  })
+})
+
+describe('collapseDiff', () => {
+  it('collapses a long unchanged run into a gap', () => {
+    const before = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n')
+    const after = before.replace('line 15', 'line fifteen')
+    const rows = collapseDiff(diffLines(before, after))
+    const gaps = rows.filter((row) => row.kind === 'gap')
+    expect(gaps).toHaveLength(2)
+    expect(rows.some((row) => row.kind === 'add' && row.text === 'line fifteen')).toBe(true)
+  })
+
+  it('keeps the lines around a change as context', () => {
+    const rows = collapseDiff(diffLines('a\nb\nc\nd\ne', 'a\nb\nC\nd\ne'), 1)
+    expect(rows.filter((row) => row.kind === 'same').map((row) => row.text)).toEqual(['b', 'd'])
+  })
+
+  it('says how many lines a gap hides', () => {
+    const before = Array.from({ length: 20 }, (_, i) => `l${i}`).join('\n')
+    const after = `${before}\nnew`
+    const [gap] = collapseDiff(diffLines(before, after)).filter((row) => row.kind === 'gap')
+    expect(gap).toMatchObject({ skipped: 17 })
+    expect(gap.text).toBe('17 unchanged lines')
+  })
+
+  it('leaves a diff with no change as a single gap', () => {
+    const rows = collapseDiff(diffLines('a\nb', 'a\nb'))
+    expect(rows).toEqual([{ kind: 'gap', text: '2 unchanged lines', skipped: 2 }])
+  })
+})

--- a/frontend/src/documentation/__tests__/storeHistory.test.ts
+++ b/frontend/src/documentation/__tests__/storeHistory.test.ts
@@ -1,0 +1,266 @@
+/**
+ * The two halves of a document's context: what it used to say, and what points
+ * at it. Both were reachable in the API and in the store long before anything
+ * rendered them, so these pin the wiring as much as the logic.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { documentsApi } from '@/api/client'
+import { useDocsStore } from '../store'
+import type { Doc, DocBacklink, DocRevision } from '../types'
+
+vi.mock('@/api/client', () => ({
+  documentsApi: {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    revisions: vi.fn(),
+    revision: vi.fn(),
+    restore: vi.fn(),
+    regenerate: vi.fn(),
+    backlinks: vi.fn(),
+    search: vi.fn(),
+    block: vi.fn(),
+    coverage: vi.fn(),
+    scaffold: vi.fn(),
+  },
+}))
+
+const api = vi.mocked(documentsApi)
+
+function doc(overrides: Partial<Doc> = {}): Doc {
+  return {
+    id: 'doc-1',
+    kind: 'page',
+    title: 'Page',
+    slug: 'page',
+    sort_order: 0,
+    tags: [],
+    frontmatter: {},
+    starred: false,
+    body: 'current body',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Doc
+}
+
+function revision(overrides: Partial<DocRevision> = {}): DocRevision {
+  return {
+    id: 'rev-1',
+    document_id: 'doc-1',
+    title: 'Page',
+    reason: 'edit',
+    saved_at: '2026-01-02T00:00:00Z',
+    size: 12,
+    ...overrides,
+  }
+}
+
+function backlink(overrides: Partial<DocBacklink> = {}): DocBacklink {
+  return {
+    doc_id: 'doc-2',
+    title: 'Runbook',
+    kind: 'page',
+    label: 'Page',
+    context: 'see [[Page]]',
+    count: 1,
+    ...overrides,
+  }
+}
+
+const INITIAL = useDocsStore.getState()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  useDocsStore.setState({
+    ...INITIAL,
+    docs: [],
+    openDoc: null,
+    draft: null,
+    revisions: [],
+    revisionsLoading: false,
+    revisionPreview: null,
+    backlinks: [],
+    backlinksLoading: false,
+    loadError: null,
+  })
+})
+
+// ── revisions ───────────────────────────────────────────────────────────────
+
+describe('loadRevisions', () => {
+  it('stores the list and clears the loading flag', async () => {
+    useDocsStore.setState({ openDoc: doc() })
+    api.revisions.mockResolvedValue({ data: [revision()] } as never)
+
+    await useDocsStore.getState().loadRevisions('doc-1')
+
+    expect(useDocsStore.getState().revisions).toHaveLength(1)
+    expect(useDocsStore.getState().revisionsLoading).toBe(false)
+  })
+
+  it('drops an answer for a document the user has already left', async () => {
+    useDocsStore.setState({ openDoc: doc({ id: 'doc-9' }) })
+    api.revisions.mockResolvedValue({ data: [revision()] } as never)
+
+    await useDocsStore.getState().loadRevisions('doc-1')
+
+    expect(useDocsStore.getState().revisions).toEqual([])
+  })
+
+  it('reports a failure instead of spinning forever', async () => {
+    useDocsStore.setState({ openDoc: doc() })
+    api.revisions.mockRejectedValue(new Error('boom'))
+
+    await useDocsStore.getState().loadRevisions('doc-1')
+
+    expect(useDocsStore.getState().revisionsLoading).toBe(false)
+    expect(useDocsStore.getState().loadError).toBe('Could not load the history')
+  })
+})
+
+describe('previewRevision', () => {
+  it('fetches the body of a revision already in the list', async () => {
+    useDocsStore.setState({ openDoc: doc(), revisions: [revision()] })
+    api.revision.mockResolvedValue({ data: { ...revision(), body: 'old body' } } as never)
+
+    await useDocsStore.getState().previewRevision('rev-1')
+
+    expect(api.revision).toHaveBeenCalledWith('rev-1')
+    expect(useDocsStore.getState().revisionPreview).toEqual({
+      revision: revision(),
+      body: 'old body',
+    })
+  })
+
+  it('asks for nothing when the revision is not in the list', async () => {
+    await useDocsStore.getState().previewRevision('rev-nope')
+
+    expect(api.revision).not.toHaveBeenCalled()
+    expect(useDocsStore.getState().revisionPreview).toBeNull()
+  })
+
+  it('surfaces a failed read', async () => {
+    useDocsStore.setState({ revisions: [revision()] })
+    api.revision.mockRejectedValue(new Error('boom'))
+
+    await useDocsStore.getState().previewRevision('rev-1')
+
+    expect(useDocsStore.getState().revisionPreview).toBeNull()
+    expect(useDocsStore.getState().loadError).toBe('Could not read that version')
+  })
+
+  it('closes on demand', () => {
+    useDocsStore.setState({ revisionPreview: { revision: revision(), body: 'old' } })
+    useDocsStore.getState().closeRevisionPreview()
+    expect(useDocsStore.getState().revisionPreview).toBeNull()
+  })
+})
+
+describe('restore', () => {
+  it('takes the restored body and closes the version being read', async () => {
+    useDocsStore.setState({
+      openDoc: doc(),
+      docs: [doc()],
+      revisions: [revision()],
+      revisionPreview: { revision: revision(), body: 'old body' },
+    })
+    api.restore.mockResolvedValue({ data: doc({ body: 'old body' }) } as never)
+    api.revisions.mockResolvedValue({ data: [revision({ id: 'rev-2', reason: 'restore' })] } as never)
+
+    await useDocsStore.getState().restore('doc-1', 'rev-1')
+
+    expect(useDocsStore.getState().openDoc?.body).toBe('old body')
+    expect(useDocsStore.getState().revisionPreview).toBeNull()
+    // The restore itself became a revision, so the list is re-read.
+    expect(useDocsStore.getState().revisions[0].reason).toBe('restore')
+  })
+
+  it('keeps the editor on the restored body when one was open', async () => {
+    useDocsStore.setState({ openDoc: doc(), docs: [doc()], draft: 'half-typed' })
+    api.restore.mockResolvedValue({ data: doc({ body: 'old body' }) } as never)
+    api.revisions.mockResolvedValue({ data: [] } as never)
+
+    await useDocsStore.getState().restore('doc-1', 'rev-1')
+
+    expect(useDocsStore.getState().draft).toBe('old body')
+    expect(useDocsStore.getState().dirty).toBe(false)
+  })
+})
+
+// ── backlinks ───────────────────────────────────────────────────────────────
+
+describe('loadBacklinks', () => {
+  it('stores what links here', async () => {
+    useDocsStore.setState({ openDoc: doc() })
+    api.backlinks.mockResolvedValue({ data: [backlink()] } as never)
+
+    await useDocsStore.getState().loadBacklinks('doc-1')
+
+    expect(useDocsStore.getState().backlinks).toEqual([backlink()])
+    expect(useDocsStore.getState().backlinksLoading).toBe(false)
+  })
+
+  it('drops an answer for a document the user has already left', async () => {
+    useDocsStore.setState({ openDoc: doc({ id: 'doc-9' }) })
+    api.backlinks.mockResolvedValue({ data: [backlink()] } as never)
+
+    await useDocsStore.getState().loadBacklinks('doc-1')
+
+    expect(useDocsStore.getState().backlinks).toEqual([])
+  })
+
+  it('stays quiet on a failure — the panel is a bonus, not the document', async () => {
+    useDocsStore.setState({ openDoc: doc() })
+    api.backlinks.mockRejectedValue(new Error('boom'))
+
+    await useDocsStore.getState().loadBacklinks('doc-1')
+
+    expect(useDocsStore.getState().backlinks).toEqual([])
+    expect(useDocsStore.getState().backlinksLoading).toBe(false)
+    expect(useDocsStore.getState().loadError).toBeNull()
+  })
+
+  it('leaves the document now on screen alone when an older request fails', async () => {
+    useDocsStore.setState({ openDoc: doc({ id: 'doc-2' }), backlinks: [backlink()] })
+    api.backlinks.mockRejectedValue(new Error('boom'))
+
+    await useDocsStore.getState().loadBacklinks('doc-1')
+
+    expect(useDocsStore.getState().backlinks).toEqual([backlink()])
+  })
+})
+
+describe('open', () => {
+  it('asks for the backlinks of the document it opened', async () => {
+    api.get.mockResolvedValue({ data: doc() } as never)
+    api.backlinks.mockResolvedValue({ data: [backlink()] } as never)
+
+    await useDocsStore.getState().open('doc-1')
+    // `open` does not await the backlinks; let the microtask queue drain.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(api.backlinks).toHaveBeenCalledWith('doc-1')
+    expect(useDocsStore.getState().backlinks).toEqual([backlink()])
+  })
+
+  it('clears the previous document’s history and backlinks first', async () => {
+    useDocsStore.setState({
+      revisions: [revision()],
+      revisionPreview: { revision: revision(), body: 'old' },
+      backlinks: [backlink()],
+    })
+    api.get.mockRejectedValue(new Error('boom'))
+
+    await useDocsStore.getState().open('doc-2')
+
+    expect(useDocsStore.getState().revisions).toEqual([])
+    expect(useDocsStore.getState().revisionPreview).toBeNull()
+    expect(useDocsStore.getState().backlinks).toEqual([])
+  })
+})

--- a/frontend/src/documentation/__tests__/wikilinks.test.ts
+++ b/frontend/src/documentation/__tests__/wikilinks.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  backlinkIndex,
   collectWikiLinks,
   parseWikiLink,
   resolveWikiLink,
@@ -114,26 +113,5 @@ describe('collectWikiLinks', () => {
 
   it('finds none in a body with none', () => {
     expect(collectWikiLinks('# Heading\n\nplain text')).toEqual([])
-  })
-})
-
-describe('backlinkIndex', () => {
-  it('maps a document to the documents that link to it', () => {
-    const bodies = [
-      { ...docs[0], body: 'see [[doc:vlan-plan]]' },
-      { ...docs[1], body: 'no links' },
-      { ...docs[2], body: 'also [[VLAN plan]]' },
-    ]
-    expect(backlinkIndex(bodies)).toEqual({ d2: ['d1', 'd3'] })
-  })
-
-  it('ignores a document linking to itself', () => {
-    const bodies = [{ ...docs[1], body: 'see [[VLAN plan]]' }]
-    expect(backlinkIndex(bodies)).toEqual({})
-  })
-
-  it('does not list the same source twice', () => {
-    const bodies = [{ ...docs[0], body: '[[VLAN plan]] and [[doc:vlan-plan]]' }, { ...docs[1], body: '' }]
-    expect(backlinkIndex(bodies)).toEqual({ d2: ['d1'] })
   })
 })

--- a/frontend/src/documentation/components/DocEditor.tsx
+++ b/frontend/src/documentation/components/DocEditor.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Markdown } from '../markdown/Markdown'
 import type { LinkableDevice, LinkableDoc } from '../wikilinks'
+import { EditorMenu, type EditorMenuItem } from './EditorMenu'
 
 /**
  * Source on the left, rendered on the right.
@@ -34,6 +35,8 @@ interface Props {
   saving: boolean
   /** Set when the document describes a device — enables the generated blocks. */
   deviceId?: string | null
+  /** The document being edited, so `[[` does not offer a link to itself. */
+  currentDocId?: string | null
   docs?: LinkableDoc[]
   devices?: LinkableDevice[]
 }
@@ -64,6 +67,7 @@ export function DocEditor({
   dirty,
   saving,
   deviceId,
+  currentDocId,
   docs = [],
   devices = [],
 }: Props) {
@@ -78,6 +82,13 @@ export function DocEditor({
   const [slashOpen, setSlashOpen] = useState(false)
   const [slashQuery, setSlashQuery] = useState('')
   const [inserting, setInserting] = useState(false)
+  // The `[[` picker. Same machinery as the slash menu, anchored on the first
+  // of the two brackets, because both of them are replaced by the finished link.
+  const linkIndex = useRef<number | null>(null)
+  const linkMenu = useRef<HTMLDivElement>(null)
+  const [linkOpen, setLinkOpen] = useState(false)
+  const [linkQuery, setLinkQuery] = useState('')
+  const [linkAt, setLinkAt] = useState<Placement | null>(null)
   // Null until measured: the menu is rendered to be measured, and placing it
   // needs its height, so the first paint would otherwise flash at 0,0.
   const [slashAt, setSlashAt] = useState<Placement | null>(null)
@@ -105,20 +116,60 @@ export function DocEditor({
   }, [commands, slashQuery])
 
   /**
+   * What `[[` can point at: the documents that exist.
+   *
+   * Only documents, deliberately. A device with no document is not a link
+   * target yet — writing `[[device:nas-01]]` at one would render red — and
+   * creating a document from inside an unsaved editor is a different feature.
+   * A device that *is* documented is in this list through its document.
+   *
+   * The text inserted is the title when no other document shares it, and
+   * `[[doc:<id>]]` when one does: a bare link resolves by title, so an
+   * ambiguous one would silently point at whichever came first.
+   */
+  const linkTargets = useMemo<(EditorMenuItem & { text: string })[]>(() => {
+    const byTitle = new Map<string, number>()
+    for (const doc of docs) {
+      const key = doc.title.toLowerCase()
+      byTitle.set(key, (byTitle.get(key) ?? 0) + 1)
+    }
+    const deviceLabels = new Map(devices.map((device) => [device.id, device.label]))
+    return docs.filter((doc) => doc.id !== currentDocId).map((doc) => {
+      const unique = (byTitle.get(doc.title.toLowerCase()) ?? 0) < 2
+      const device = doc.device_id ? deviceLabels.get(doc.device_id) : undefined
+      return {
+        id: doc.id,
+        label: doc.title,
+        hint: device ? `Device · ${device}` : doc.slug,
+        text: unique ? `[[${doc.title}]]` : `[[doc:${doc.id}]]`,
+      }
+    })
+  }, [docs, devices, currentDocId])
+
+  const linkVisible = useMemo(() => {
+    const needle = linkQuery.trim().toLowerCase()
+    if (!needle) return linkTargets.slice(0, 50)
+    return linkTargets
+      .filter((item) => `${item.label} ${item.hint}`.toLowerCase().includes(needle))
+      .slice(0, 50)
+  }, [linkTargets, linkQuery])
+
+  /**
    * Insert `text`, either at the live caret or over the `/` at `replacing`.
    *
-   * The `/` is the only thing the menu ever put in the document — the query was
-   * typed into the menu's own field — so replacing it consumes exactly that one
-   * character. The index is passed in rather than read from the textarea:
+   * The `/` is the only thing the slash menu ever put in the document — the
+   * query was typed into the menu's own field — so replacing it consumes
+   * exactly that one character; the `[[` picker passes 2 for its two brackets.
+   * The index is passed in rather than read from the textarea:
    * opening the menu moves focus, which freezes the textarea's selection
    * wherever it happened to be, and every later keystroke widens the gap.
    */
   const insertAtCursor = useCallback(
-    (text: string, replacing: number | null) => {
+    (text: string, replacing: number | null, replacedLength = 1) => {
       const el = textarea.current
       if (!el) return
       const start = replacing ?? el.selectionStart
-      const end = replacing === null ? el.selectionEnd : Math.min(replacing + 1, body.length)
+      const end = replacing === null ? el.selectionEnd : Math.min(replacing + replacedLength, body.length)
       const next = `${body.slice(0, start)}${text}${body.slice(end)}`
       history.record('edit')
       onChange(next)
@@ -146,6 +197,26 @@ export function DocEditor({
     },
     [insertAtCursor],
   )
+
+  const runLink = useCallback(
+    (item: EditorMenuItem) => {
+      const target = linkTargets.find((entry) => entry.id === item.id)
+      // Read before closing: the reset effect clears the index.
+      const at = linkIndex.current
+      setLinkOpen(false)
+      setLinkQuery('')
+      if (target) insertAtCursor(target.text, at)
+    },
+    [insertAtCursor, linkTargets],
+  )
+
+  /** Close without picking, giving back the bracket the menu held. */
+  const cancelLink = useCallback(() => {
+    const at = linkIndex.current
+    setLinkOpen(false)
+    setLinkQuery('')
+    if (at !== null) insertAtCursor('[[', at)
+  }, [insertAtCursor])
 
   const wrapSelection = useCallback(
     (before: string, after = before) => {
@@ -185,13 +256,32 @@ export function DocEditor({
       return
     }
     if (event.key === 'Escape') {
-      if (slashOpen) {
+      if (slashOpen || linkOpen) {
         event.preventDefault()
         setSlashOpen(false)
+        if (linkOpen) cancelLink()
         return
       }
       event.preventDefault()
       onCancel()
+      return
+    }
+    if (event.key === '[') {
+      const el = event.currentTarget
+      // Typing over a selection replaces it; that is not an opening bracket.
+      if (el.selectionStart !== el.selectionEnd) return
+      if (!body.slice(0, el.selectionStart).endsWith('[')) return
+      // The second bracket is swallowed on purpose. Opening the menu moves
+      // focus to its filter field, and a character typed as focus moves is not
+      // reliably delivered to either box — so the body is left holding exactly
+      // one `[`, which is what the insertion replaces. Cancelling puts the
+      // second one back, so what the user typed survives either way.
+      event.preventDefault()
+      caretRef.current = caretPoint(el, el.selectionStart)
+      linkIndex.current = el.selectionStart - 1
+      setSlashOpen(false)
+      setLinkOpen(true)
+      setLinkQuery('')
       return
     }
     if (event.key === '/') {
@@ -216,6 +306,29 @@ export function DocEditor({
       slashIndex.current = null
     }
   }, [slashOpen])
+
+  useEffect(() => {
+    if (!linkOpen) {
+      setLinkQuery('')
+      setLinkAt(null)
+      linkIndex.current = null
+    }
+  }, [linkOpen])
+
+  useEffect(() => {
+    if (!linkOpen) return
+    const caret = caretRef.current
+    const paneEl = pane.current
+    const menuEl = linkMenu.current
+    if (!caret || !paneEl || !menuEl) return
+    setLinkAt(
+      placeMenu({
+        caret,
+        pane: { width: paneEl.clientWidth, height: paneEl.clientHeight },
+        menu: { width: menuEl.offsetWidth, height: menuEl.offsetHeight },
+      }),
+    )
+  }, [linkOpen, linkVisible.length])
 
   // Place the menu once it (and the filtered list) have a height. Re-runs as the
   // query narrows the list, so a menu that shrank stops hanging off the bottom.
@@ -256,7 +369,8 @@ export function DocEditor({
           <Link2 />
         </Button>
         <span className="ml-2 text-[10px] text-muted-foreground/70">
-          Type <kbd className="rounded border border-border px-1">/</kbd> on a new line to insert
+          <kbd className="rounded border border-border px-1">/</kbd> on a new line to insert,{' '}
+          <kbd className="rounded border border-border px-1">[[</kbd> to link
         </span>
         <div className="ml-auto flex items-center gap-2">
           {dirty && <span className="text-[10px] text-muted-foreground">Unsaved</span>}
@@ -284,48 +398,36 @@ export function DocEditor({
             className="h-full w-full resize-none bg-transparent p-4 font-mono text-xs leading-relaxed outline-none"
           />
           {slashOpen && (
-            <div
-              ref={menu}
-              style={slashAt ? { top: slashAt.top, left: slashAt.left } : undefined}
-              className={cn(
-                'absolute z-20 w-72 overflow-hidden rounded-lg border border-border bg-popover shadow-lg',
-                // Hidden, not unmounted, for the frame it takes to measure it —
-                // placing it needs the height it only has once rendered.
-                !slashAt && 'invisible',
-              )}
-            >
-              <input
-                autoFocus
-                value={slashQuery}
-                onChange={(event) => setSlashQuery(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Escape') setSlashOpen(false)
-                  if (event.key === 'Enter' && visible[0]) {
-                    event.preventDefault()
-                    void runCommand(visible[0])
-                  }
-                }}
-                placeholder="Insert…"
-                aria-label="Insert a block"
-                className="w-full border-b border-border bg-transparent px-3 py-2 text-xs outline-none"
-              />
-              <div className="max-h-56 overflow-y-auto">
-                {visible.length === 0 && (
-                  <p className="px-3 py-2 text-xs text-muted-foreground">Nothing matches.</p>
-                )}
-                {visible.map((command) => (
-                  <button
-                    key={command.id}
-                    type="button"
-                    onClick={() => void runCommand(command)}
-                    className="flex w-full cursor-pointer flex-col items-start px-3 py-1.5 text-left hover:bg-muted"
-                  >
-                    <span className="font-mono text-xs">{command.label}</span>
-                    <span className="text-[10px] text-muted-foreground">{command.hint}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
+            <EditorMenu
+              items={visible}
+              query={slashQuery}
+              onQuery={setSlashQuery}
+              placeholder="Insert…"
+              ariaLabel="Insert a block"
+              emptyText="Nothing matches."
+              at={slashAt}
+              menuRef={menu}
+              monoLabels
+              onPick={(item) => {
+                const command = commands.find((entry) => entry.id === item.id)
+                if (command) void runCommand(command)
+              }}
+              onClose={() => setSlashOpen(false)}
+            />
+          )}
+          {linkOpen && (
+            <EditorMenu
+              items={linkVisible}
+              query={linkQuery}
+              onQuery={setLinkQuery}
+              placeholder="Link to…"
+              ariaLabel="Link to a document"
+              emptyText="No document to link to yet."
+              at={linkAt}
+              menuRef={linkMenu}
+              onPick={runLink}
+              onClose={cancelLink}
+            />
           )}
           {inserting && (
             <span className="absolute bottom-2 right-3 text-[10px] text-muted-foreground">Inserting…</span>

--- a/frontend/src/documentation/components/DocHistory.tsx
+++ b/frontend/src/documentation/components/DocHistory.tsx
@@ -1,0 +1,198 @@
+import { useMemo, useState } from 'react'
+import { RotateCcw, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { formatRelative, formatTimestamp } from '@/utils/timeFormat'
+import { collapseDiff, diffLines, diffStat } from '../diff'
+import { Markdown } from '../markdown/Markdown'
+import type { DocRevision } from '../types'
+import type { LinkableDevice, LinkableDoc } from '../wikilinks'
+
+/**
+ * Reading a document's history.
+ *
+ * The server has kept up to fifty revisions per document since the section
+ * shipped and every destructive action says so — regenerate in particular
+ * promises the old body "is in its history" — but nothing reached them. The
+ * rail lists what is there, and the preview answers the question a list cannot:
+ * what did this version actually say, and how does it differ from the one on
+ * screen.
+ */
+
+/** Why a revision was taken, said in the words the action used. */
+const REASONS: Record<DocRevision['reason'], string> = {
+  edit: 'Saved',
+  restore: 'Restored',
+  import: 'Imported',
+  migrate: 'Migrated from notes',
+  scaffold: 'Generated',
+  regenerate: 'Regenerated',
+}
+
+function size(bytes: number): string {
+  return bytes < 1024 ? `${bytes} B` : `${Math.round(bytes / 1024)} kB`
+}
+
+interface RailProps {
+  revisions: DocRevision[]
+  activeId: string | null
+  loading: boolean
+  onSelect: (revisionId: string) => void
+  onClose: () => void
+}
+
+export function DocHistoryRail({ revisions, activeId, loading, onSelect, onClose }: RailProps) {
+  return (
+    <nav
+      aria-label="Document history"
+      className="flex w-60 shrink-0 flex-col overflow-y-auto border-l border-border"
+    >
+      <div className="flex items-center gap-1 px-3 py-4">
+        <p className="flex-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+          History
+        </p>
+        <Button size="icon-xs" variant="ghost" aria-label="Close history" onClick={onClose} className="cursor-pointer">
+          <X />
+        </Button>
+      </div>
+
+      {loading && <p className="px-3 text-xs text-muted-foreground">Loading…</p>}
+      {!loading && revisions.length === 0 && (
+        <p className="px-3 text-xs text-muted-foreground">
+          No earlier version yet. One is kept every time you save a change.
+        </p>
+      )}
+
+      <ul className="pb-6">
+        {revisions.map((revision) => (
+          <li key={revision.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(revision.id)}
+              title={formatTimestamp(revision.saved_at)}
+              aria-current={revision.id === activeId}
+              className={cn(
+                'w-full cursor-pointer px-3 py-1.5 text-left hover:bg-muted/60',
+                revision.id === activeId && 'bg-muted',
+              )}
+            >
+              <span className="block truncate text-xs text-foreground">
+                {REASONS[revision.reason] ?? revision.reason}
+              </span>
+              <span className="block truncate text-[10px] text-muted-foreground">
+                {formatRelative(revision.saved_at)} · {size(revision.size)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+interface PreviewProps {
+  revision: DocRevision
+  body: string
+  currentBody: string
+  docs: LinkableDoc[]
+  devices: LinkableDevice[]
+  onOpenDoc: (id: string) => void
+  onRestore: () => void
+  onClose: () => void
+}
+
+export function RevisionPreview({
+  revision,
+  body,
+  currentBody,
+  docs,
+  devices,
+  onOpenDoc,
+  onRestore,
+  onClose,
+}: PreviewProps) {
+  const [showChanges, setShowChanges] = useState(false)
+  // The diff reads old → new, so the current body is the "after" side: what the
+  // reader wants is "what happened since this version", not how to undo it.
+  const rows = useMemo(() => collapseDiff(diffLines(body, currentBody)), [body, currentBody])
+  const stat = useMemo(() => diffStat(diffLines(body, currentBody)), [body, currentBody])
+  const identical = stat.added === 0 && stat.removed === 0
+
+  return (
+    <div className="min-w-0 flex-1 overflow-y-auto">
+      <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 border-b border-border bg-[var(--surface,#161b22)] px-6 py-2.5">
+        <span className="text-xs text-foreground">
+          {REASONS[revision.reason] ?? revision.reason}{' '}
+          <span className="text-muted-foreground" title={formatTimestamp(revision.saved_at)}>
+            {formatRelative(revision.saved_at)}
+          </span>
+        </span>
+        <span className="text-[10px] text-muted-foreground">
+          {identical ? (
+            'Identical to the current version'
+          ) : (
+            <>
+              <span className="text-[var(--status-online,#39d353)]">+{stat.added}</span>{' '}
+              <span className="text-[var(--status-offline,#f85149)]">−{stat.removed}</span> since
+            </>
+          )}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setShowChanges((on) => !on)}
+            className="cursor-pointer"
+            aria-pressed={showChanges}
+          >
+            {showChanges ? 'Read it' : 'Changes'}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onRestore} className="cursor-pointer gap-1">
+            <RotateCcw size={13} /> Restore
+          </Button>
+          <Button size="icon-xs" variant="ghost" aria-label="Back to the current version" onClick={onClose} className="cursor-pointer">
+            <X />
+          </Button>
+        </div>
+      </div>
+
+      {showChanges ? (
+        <div className="px-6 pb-16 pt-3 font-mono text-xs">
+          {rows.map((row, index) => {
+            if (row.kind === 'gap') {
+              return (
+                <p key={index} className="my-1 text-[10px] text-muted-foreground/60">
+                  ⋯ {row.text}
+                </p>
+              )
+            }
+            return (
+              <p
+                key={index}
+                className={cn(
+                  'whitespace-pre-wrap break-words border-l-2 py-px pl-2',
+                  row.kind === 'add' && 'border-[var(--status-online,#39d353)] bg-[var(--status-online,#39d353)]/10',
+                  row.kind === 'del' &&
+                    'border-[var(--status-offline,#f85149)] bg-[var(--status-offline,#f85149)]/10',
+                  row.kind === 'same' && 'border-transparent text-muted-foreground',
+                )}
+              >
+                {row.kind === 'add' ? '+ ' : row.kind === 'del' ? '− ' : '  '}
+                {row.text || ' '}
+              </p>
+            )
+          })}
+        </div>
+      ) : (
+        <Markdown
+          body={body}
+          docs={docs}
+          devices={devices}
+          onOpenDoc={onOpenDoc}
+          className="max-w-[72ch] px-6 pb-16 pt-2 text-sm"
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/documentation/components/DocViewer.tsx
+++ b/frontend/src/documentation/components/DocViewer.tsx
@@ -1,19 +1,40 @@
 import { useMemo, useState } from 'react'
-import { Clock, Pencil, Plus, RefreshCw, Star, Trash2, X } from 'lucide-react'
+import { Clock, History, Link2, Pencil, Plus, RefreshCw, Star, Trash2, X } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { isOverdue, parseFrontmatter } from '../frontmatter'
 import { Markdown } from '../markdown/Markdown'
 import { extractToc } from '../markdown/toc'
-import type { Doc } from '../types'
+import type { Doc, DocBacklink, DocRevision } from '../types'
 import type { LinkableDevice, LinkableDoc } from '../wikilinks'
+import { DocHistoryRail, RevisionPreview } from './DocHistory'
+
+/** Everything the history rail and the revision preview need, in one prop. */
+export interface HistoryControls {
+  open: boolean
+  loading: boolean
+  revisions: DocRevision[]
+  preview: { revision: DocRevision; body: string } | null
+  onToggle: () => void
+  onSelect: (revisionId: string) => void
+  onClosePreview: () => void
+  onRestore: (revisionId: string) => void
+}
 
 interface Props {
   doc: Doc
   docs: LinkableDoc[]
   devices: LinkableDevice[]
   drifted: boolean
+  /** The documents linking here. Empty until the server answers. */
+  backlinks?: DocBacklink[]
+  backlinksLoading?: boolean
+  /**
+   * Omitted by a host that keeps no history state, and then the viewer offers
+   * none — the button would have nothing to open.
+   */
+  history?: HistoryControls
   onEdit: () => void
   onToggleStar: () => void
   onMarkReviewed: () => void
@@ -24,6 +45,17 @@ interface Props {
   onToggleTask: (body: string) => void
   /** Writes the whole tag list back into the document's frontmatter. */
   onSetTags: (tags: string[]) => void
+}
+
+const NO_HISTORY: HistoryControls = {
+  open: false,
+  loading: false,
+  revisions: [],
+  preview: null,
+  onToggle: () => {},
+  onSelect: () => {},
+  onClosePreview: () => {},
+  onRestore: () => {},
 }
 
 /** The metadata a frontmatter block is worth surfacing as a chip. */
@@ -38,6 +70,9 @@ export function DocViewer({
   docs,
   devices,
   drifted,
+  backlinks = [],
+  backlinksLoading = false,
+  history,
   onEdit,
   onToggleStar,
   onMarkReviewed,
@@ -48,6 +83,7 @@ export function DocViewer({
   onToggleTask,
   onSetTags,
 }: Props) {
+  const controls = history ?? NO_HISTORY
   const { data } = useMemo(() => parseFrontmatter(doc.body), [doc.body])
   const [tagDraft, setTagDraft] = useState<string | null>(null)
   const toc = useMemo(() => extractToc(doc.body), [doc.body])
@@ -68,6 +104,36 @@ export function DocViewer({
     setTagDraft(null)
   }
 
+  // Reading an old version replaces the body, not the page: the title, the
+  // chips and the history rail stay put, so it reads as the same document at a
+  // different moment rather than as somewhere else.
+  const preview = controls.preview
+  if (preview) {
+    return (
+      <div className="flex min-h-0 flex-1">
+        <RevisionPreview
+          revision={preview.revision}
+          body={preview.body}
+          currentBody={doc.body}
+          docs={docs}
+          devices={devices}
+          onOpenDoc={onOpenDoc}
+          onRestore={() => controls.onRestore(preview.revision.id)}
+          onClose={controls.onClosePreview}
+        />
+        {controls.open && (
+          <DocHistoryRail
+            revisions={controls.revisions}
+            activeId={preview.revision.id}
+            loading={controls.loading}
+            onSelect={controls.onSelect}
+            onClose={controls.onToggle}
+          />
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex min-h-0 flex-1">
       <div className="min-w-0 flex-1 overflow-y-auto">
@@ -86,6 +152,19 @@ export function DocViewer({
           <Button size="sm" variant="ghost" onClick={onEdit} className="cursor-pointer gap-1">
             <Pencil size={13} /> Edit
           </Button>
+          {history && (
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              title="Earlier versions of this document"
+              aria-label="Version history"
+              aria-pressed={history.open}
+              onClick={history.onToggle}
+              className={cn('cursor-pointer', history.open && 'bg-muted')}
+            >
+              <History />
+            </Button>
+          )}
           {/* A folder holds children, not a generated body — nothing to rebuild. */}
           {doc.kind !== 'folder' && (
             <Button
@@ -174,11 +253,54 @@ export function DocViewer({
           onOpenDoc={onOpenDoc}
           onCreateFromLink={onCreateFromLink}
           onToggleTask={onToggleTask}
-          className="max-w-[72ch] px-6 pb-16 pt-2 text-sm"
+          className="max-w-[72ch] px-6 pb-6 pt-2 text-sm"
         />
+
+        {/* A wiki-link only says where it goes; this is the other direction,
+            and the reason a device document is worth linking to at all. */}
+        {!backlinksLoading && backlinks.length > 0 && (
+          <section aria-labelledby="backlinks-heading" className="max-w-[72ch] px-6 pb-16">
+            <h2
+              id="backlinks-heading"
+              className="mb-2 flex items-center gap-1.5 border-t border-border pt-4 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70"
+            >
+              <Link2 size={11} /> Linked from ({backlinks.length})
+            </h2>
+            <ul className="space-y-1">
+              {backlinks.map((link) => (
+                <li key={link.doc_id}>
+                  <button
+                    type="button"
+                    onClick={() => onOpenDoc(link.doc_id)}
+                    className="w-full cursor-pointer rounded px-2 py-1.5 text-left hover:bg-muted/60"
+                  >
+                    <span className="flex items-baseline gap-1.5">
+                      <span className="truncate text-xs text-primary">{link.title}</span>
+                      {link.count > 1 && (
+                        <span className="text-[10px] text-muted-foreground">×{link.count}</span>
+                      )}
+                    </span>
+                    <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                      {link.context}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
       </div>
 
-      {toc.length > 1 && (
+      {controls.open ? (
+        <DocHistoryRail
+          revisions={controls.revisions}
+          activeId={null}
+          loading={controls.loading}
+          onSelect={controls.onSelect}
+          onClose={controls.onToggle}
+        />
+      ) : (
+        toc.length > 1 && (
         <nav aria-label="On this page" className="hidden w-52 shrink-0 overflow-y-auto border-l border-border px-3 py-5 xl:block">
           <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
             On this page
@@ -193,7 +315,8 @@ export function DocViewer({
               {entry.text}
             </a>
           ))}
-        </nav>
+          </nav>
+        )
       )}
     </div>
   )

--- a/frontend/src/documentation/components/DocumentationView.tsx
+++ b/frontend/src/documentation/components/DocumentationView.tsx
@@ -9,6 +9,7 @@ import { useCanvasStore } from '@/stores/canvasStore'
 import { useDesignStore } from '@/stores/designStore'
 import type { InventoryEntry } from '@/types'
 import { cn } from '@/lib/utils'
+import { formatRelative } from '@/utils/timeFormat'
 import { isOverdue } from '../frontmatter'
 import { driftedIds, useDocsStore } from '../store'
 import {
@@ -62,6 +63,15 @@ export function DocumentationView() {
     markReviewed,
     setTags,
     regenerate,
+    revisions,
+    revisionsLoading,
+    revisionPreview,
+    loadRevisions,
+    previewRevision,
+    closeRevisionPreview,
+    restore,
+    backlinks,
+    backlinksLoading,
     coverage,
     loadCoverage,
     scaffold,
@@ -84,6 +94,7 @@ export function DocumentationView() {
   const [libraryOpen, setLibraryOpen] = useState(true)
   const [regenerateOpen, setRegenerateOpen] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
+  const [historyOpen, setHistoryOpen] = useState(false)
 
   useEffect(() => {
     void loadDocs()
@@ -235,6 +246,38 @@ export function DocumentationView() {
     setRegenerateOpen(false)
     toast.success('Document regenerated — the old body is in its history')
   }, [openDoc, regenerate])
+
+  // The rail is loaded when it is opened, and again whenever the document it is
+  // showing changes underneath it — a save adds a revision to the list.
+  const openDocId = openDoc?.id
+  const openDocSavedAt = openDoc?.updated_at
+  useEffect(() => {
+    if (!historyOpen || !openDocId) return
+    void loadRevisions(openDocId)
+  }, [historyOpen, openDocId, openDocSavedAt, loadRevisions])
+
+  const handleToggleHistory = useCallback(() => {
+    setHistoryOpen((open) => {
+      // Closing the rail leaves the version being read; there would be no way
+      // back to the current body otherwise.
+      if (open) closeRevisionPreview()
+      return !open
+    })
+  }, [closeRevisionPreview])
+
+  const handleRestore = useCallback(
+    async (revisionId: string) => {
+      if (!openDoc) return
+      const revision = revisions.find((r) => r.id === revisionId)
+      const when = revision ? formatRelative(revision.saved_at) : 'that version'
+      if (!window.confirm(`Restore the version from ${when}? The current body is saved to the history first.`)) {
+        return
+      }
+      await restore(openDoc.id, revisionId)
+      toast.success('Version restored — the body it replaced is in the history')
+    },
+    [openDoc, restore, revisions],
+  )
 
   const handleMigrate = useCallback(async () => {
     const created = await scaffold({ onlyWithNotes: true })
@@ -468,6 +511,18 @@ export function DocumentationView() {
             docs={docs}
             devices={linkableDevices}
             drifted={openDoc.drifted ?? false}
+            backlinks={backlinks}
+            backlinksLoading={backlinksLoading}
+            history={{
+              open: historyOpen,
+              loading: revisionsLoading,
+              revisions,
+              preview: revisionPreview,
+              onToggle: handleToggleHistory,
+              onSelect: (id) => void previewRevision(id),
+              onClosePreview: closeRevisionPreview,
+              onRestore: (id) => void handleRestore(id),
+            }}
             onEdit={startEdit}
             onToggleStar={() => void toggleStar(openDoc.id)}
             onMarkReviewed={() => void markReviewed(openDoc.id)}

--- a/frontend/src/documentation/components/DocumentationView.tsx
+++ b/frontend/src/documentation/components/DocumentationView.tsx
@@ -552,6 +552,7 @@ export function DocumentationView() {
             dirty={dirty}
             saving={saving}
             deviceId={openDoc.device_id}
+            currentDocId={openDoc.id}
             docs={docs}
             devices={linkableDevices}
           />

--- a/frontend/src/documentation/components/EditorMenu.tsx
+++ b/frontend/src/documentation/components/EditorMenu.tsx
@@ -1,0 +1,92 @@
+import { type RefObject } from 'react'
+
+import { cn } from '@/lib/utils'
+import type { Placement } from '@/documentation/caret'
+
+/**
+ * The popover the editor opens at the caret.
+ *
+ * Extracted when the `[[` link picker joined the `/` insert menu: same shape —
+ * a filter field over a labelled list, placed at the caret and measured before
+ * it is shown — and two copies of that would have drifted apart.
+ */
+
+export interface EditorMenuItem {
+  id: string
+  label: string
+  hint: string
+}
+
+interface Props {
+  items: EditorMenuItem[]
+  query: string
+  onQuery: (query: string) => void
+  placeholder: string
+  /** Names the filter field, since the popover has no visible title. */
+  ariaLabel: string
+  emptyText: string
+  /** Null until measured — the menu is rendered hidden to get its height. */
+  at: Placement | null
+  menuRef: RefObject<HTMLDivElement | null>
+  /** Monospace labels suit the `/command` list; document titles are prose. */
+  monoLabels?: boolean
+  onPick: (item: EditorMenuItem) => void
+  onClose: () => void
+}
+
+export function EditorMenu({
+  items,
+  query,
+  onQuery,
+  placeholder,
+  ariaLabel,
+  emptyText,
+  at,
+  menuRef,
+  monoLabels = false,
+  onPick,
+  onClose,
+}: Props) {
+  return (
+    <div
+      ref={menuRef}
+      style={at ? { top: at.top, left: at.left } : undefined}
+      className={cn(
+        'absolute z-20 w-72 overflow-hidden rounded-lg border border-border bg-popover shadow-lg',
+        // Hidden, not unmounted, for the frame it takes to measure it —
+        // placing it needs the height it only has once rendered.
+        !at && 'invisible',
+      )}
+    >
+      <input
+        autoFocus
+        value={query}
+        onChange={(event) => onQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') onClose()
+          if (event.key === 'Enter' && items[0]) {
+            event.preventDefault()
+            onPick(items[0])
+          }
+        }}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="w-full border-b border-border bg-transparent px-3 py-2 text-xs outline-none"
+      />
+      <div className="max-h-56 overflow-y-auto">
+        {items.length === 0 && <p className="px-3 py-2 text-xs text-muted-foreground">{emptyText}</p>}
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onPick(item)}
+            className="flex w-full cursor-pointer flex-col items-start px-3 py-1.5 text-left hover:bg-muted"
+          >
+            <span className={cn('text-xs', monoLabels ? 'font-mono' : 'truncate')}>{item.label}</span>
+            <span className="text-[10px] text-muted-foreground">{item.hint}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/documentation/components/NewDocMenu.tsx
+++ b/frontend/src/documentation/components/NewDocMenu.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 import { cn } from '@/lib/utils'
 
@@ -6,7 +7,7 @@ import { DOC_TEMPLATES } from '../types'
 
 interface Props {
   trigger: ReactNode
-  /** Which way the popover opens. The menu sits at the top of the pane now. */
+  /** Which way the popover opens from the trigger. */
   placement?: 'up' | 'down'
   parentId?: string | null
   onCreate: (input: { title: string; templateId: string; parentId?: string | null }) => void | Promise<void>
@@ -18,55 +19,108 @@ interface Props {
  * A plain popover rather than a shadcn dropdown: the project only ships a
  * handful of primitives and this needs no focus trapping beyond closing on an
  * outside click or Escape.
+ *
+ * It is **portalled to the body and positioned in viewport coordinates**. The
+ * trigger sits at the right edge of the document tree, which is a narrow,
+ * resizable, vertically scrolling column: an absolutely positioned menu wider
+ * than the space to its left escaped that column, where it was both clipped by
+ * the scroll container and painted under the app sidebar. Out of the column
+ * there is nothing to clip it, and the left edge is clamped to the viewport so
+ * a narrow tree cannot push it off screen.
  */
+
+/** Matches `w-64` below; the clamp needs the width before the menu is drawn. */
+const MENU_WIDTH = 256
+const MARGIN = 8
+const GAP = 4
+
 export function NewDocMenu({ trigger, placement = 'up', parentId, onCreate }: Props) {
   const [open, setOpen] = useState(false)
-  const root = useRef<HTMLDivElement>(null)
+  const [at, setAt] = useState<{ left: number; top?: number; bottom?: number } | null>(null)
+  const anchor = useRef<HTMLDivElement>(null)
+  const menu = useRef<HTMLDivElement>(null)
+
+  const place = useCallback(() => {
+    const rect = anchor.current?.getBoundingClientRect()
+    if (!rect) return
+    setAt({
+      // Right-aligned on the trigger, then pulled back inside the viewport.
+      left: Math.min(
+        Math.max(rect.right - MENU_WIDTH, MARGIN),
+        Math.max(window.innerWidth - MENU_WIDTH - MARGIN, MARGIN),
+      ),
+      ...(placement === 'down'
+        ? { top: rect.bottom + GAP }
+        : { bottom: window.innerHeight - rect.top + GAP }),
+    })
+  }, [placement])
 
   useEffect(() => {
     if (!open) return
     const onDown = (event: MouseEvent) => {
-      if (!root.current?.contains(event.target as Node)) setOpen(false)
+      const target = event.target as Node
+      // The menu is no longer a descendant of the trigger, so both are checked.
+      if (!anchor.current?.contains(target) && !menu.current?.contains(target)) setOpen(false)
     }
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setOpen(false)
     }
+    // Fixed coordinates go stale the moment anything moves underneath them;
+    // closing is honest, and cheaper than following the trigger around.
+    const onMove = () => setOpen(false)
     document.addEventListener('mousedown', onDown)
     document.addEventListener('keydown', onKey)
+    window.addEventListener('resize', onMove)
+    window.addEventListener('scroll', onMove, true)
     return () => {
       document.removeEventListener('mousedown', onDown)
       document.removeEventListener('keydown', onKey)
+      window.removeEventListener('resize', onMove)
+      window.removeEventListener('scroll', onMove, true)
     }
   }, [open])
 
   return (
-    <div ref={root} className="relative">
-      <div onClick={() => setOpen((value) => !value)}>{trigger}</div>
-      {open && (
-        <div
-          className={cn(
-            'absolute z-30 w-64 overflow-hidden rounded-lg border border-border bg-popover shadow-lg',
-            placement === 'up' ? 'bottom-full left-0 mb-1' : 'right-0 top-full mt-1',
-          )}
-        >
-          {DOC_TEMPLATES.map((template) => (
-            <button
-              key={template.id}
-              type="button"
-              onClick={async () => {
-                setOpen(false)
-                const title = window.prompt('Document title', template.label)
-                if (!title?.trim()) return
-                await onCreate({ title: title.trim(), templateId: template.id, parentId })
-              }}
-              className="flex w-full cursor-pointer flex-col items-start px-3 py-1.5 text-left hover:bg-muted"
-            >
-              <span className="text-xs">{template.label}</span>
-              <span className="text-[10px] text-muted-foreground">{template.hint}</span>
-            </button>
-          ))}
-        </div>
-      )}
+    <div ref={anchor} className="relative">
+      <div
+        onClick={() => {
+          place()
+          setOpen((value) => !value)
+        }}
+      >
+        {trigger}
+      </div>
+      {open &&
+        at &&
+        createPortal(
+          <div
+            ref={menu}
+            role="menu"
+            style={{ left: at.left, top: at.top, bottom: at.bottom }}
+            className={cn(
+              'fixed z-50 w-64 overflow-hidden rounded-lg border border-border bg-popover shadow-lg',
+            )}
+          >
+            {DOC_TEMPLATES.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                role="menuitem"
+                onClick={async () => {
+                  setOpen(false)
+                  const title = window.prompt('Document title', template.label)
+                  if (!title?.trim()) return
+                  await onCreate({ title: title.trim(), templateId: template.id, parentId })
+                }}
+                className="flex w-full cursor-pointer flex-col items-start px-3 py-1.5 text-left hover:bg-muted"
+              >
+                <span className="text-xs">{template.label}</span>
+                <span className="text-[10px] text-muted-foreground">{template.hint}</span>
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }

--- a/frontend/src/documentation/diff.ts
+++ b/frontend/src/documentation/diff.ts
@@ -1,0 +1,140 @@
+/**
+ * A line diff between two document bodies.
+ *
+ * History is only useful if you can see what a version actually changed, and
+ * "restore and compare afterwards" is not that. This is deliberately small: no
+ * word-level diff, no library — a document is prose in lines, and lines are the
+ * unit a writer thinks in.
+ *
+ * The matching is a plain LCS over the lines that differ, after the common head
+ * and tail are trimmed off. That trim is what keeps it cheap: a typical edit
+ * touches a paragraph in the middle of a long document, so the matrix is built
+ * over a handful of lines rather than the whole file. `MAX_CELLS` catches the
+ * pathological case — two long, wholly different bodies — where the answer is
+ * "all of it changed" anyway.
+ */
+
+export type DiffKind = 'same' | 'add' | 'del'
+
+export interface DiffLine {
+  kind: DiffKind
+  text: string
+}
+
+/** Above this many LCS cells the diff degrades to "replaced wholesale". */
+const MAX_CELLS = 250_000
+
+function split(body: string): string[] {
+  return (body ?? '').split('\n')
+}
+
+function lcs(before: string[], after: string[]): DiffLine[] {
+  // table[i][j] = length of the longest common subsequence of the suffixes.
+  const table: number[][] = Array.from({ length: before.length + 1 }, () =>
+    new Array<number>(after.length + 1).fill(0),
+  )
+  for (let i = before.length - 1; i >= 0; i--) {
+    for (let j = after.length - 1; j >= 0; j--) {
+      table[i][j] =
+        before[i] === after[j]
+          ? table[i + 1][j + 1] + 1
+          : Math.max(table[i + 1][j], table[i][j + 1])
+    }
+  }
+
+  const out: DiffLine[] = []
+  let i = 0
+  let j = 0
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      out.push({ kind: 'same', text: before[i] })
+      i++
+      j++
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      out.push({ kind: 'del', text: before[i] })
+      i++
+    } else {
+      out.push({ kind: 'add', text: after[j] })
+      j++
+    }
+  }
+  while (i < before.length) out.push({ kind: 'del', text: before[i++] })
+  while (j < after.length) out.push({ kind: 'add', text: after[j++] })
+  return out
+}
+
+/** Every line of both bodies, tagged with what happened to it. */
+export function diffLines(before: string, after: string): DiffLine[] {
+  const a = split(before)
+  const b = split(after)
+
+  let head = 0
+  while (head < a.length && head < b.length && a[head] === b[head]) head++
+  let tail = 0
+  while (
+    tail < a.length - head &&
+    tail < b.length - head &&
+    a[a.length - 1 - tail] === b[b.length - 1 - tail]
+  ) {
+    tail++
+  }
+
+  const middleA = a.slice(head, a.length - tail)
+  const middleB = b.slice(head, b.length - tail)
+  const middle =
+    middleA.length * middleB.length > MAX_CELLS
+      ? [
+          ...middleA.map((text): DiffLine => ({ kind: 'del', text })),
+          ...middleB.map((text): DiffLine => ({ kind: 'add', text })),
+        ]
+      : lcs(middleA, middleB)
+
+  return [
+    ...a.slice(0, head).map((text): DiffLine => ({ kind: 'same', text })),
+    ...middle,
+    ...a.slice(a.length - tail).map((text): DiffLine => ({ kind: 'same', text })),
+  ]
+}
+
+/** How many lines the change added and removed, for the one-line summary. */
+export function diffStat(lines: DiffLine[]): { added: number; removed: number } {
+  return {
+    added: lines.filter((line) => line.kind === 'add').length,
+    removed: lines.filter((line) => line.kind === 'del').length,
+  }
+}
+
+/**
+ * The diff with long runs of unchanged lines collapsed to `context` on each
+ * side of a change, so a one-line edit in a long document reads as one hunk.
+ * A collapsed run is reported as a gap rather than dropped silently.
+ */
+export type DiffRow = DiffLine | { kind: 'gap'; text: string; skipped: number }
+
+export function collapseDiff(lines: DiffLine[], context = 3): DiffRow[] {
+  const keep = new Array<boolean>(lines.length).fill(false)
+  lines.forEach((line, index) => {
+    if (line.kind === 'same') return
+    for (let i = Math.max(0, index - context); i <= Math.min(lines.length - 1, index + context); i++) {
+      keep[i] = true
+    }
+  })
+
+  const rows: DiffRow[] = []
+  let skipped = 0
+  lines.forEach((line, index) => {
+    if (keep[index]) {
+      if (skipped) {
+        rows.push({ kind: 'gap', text: `${skipped} unchanged line${skipped > 1 ? 's' : ''}`, skipped })
+        skipped = 0
+      }
+      rows.push(line)
+    } else {
+      skipped++
+    }
+  })
+  if (skipped) {
+    rows.push({ kind: 'gap', text: `${skipped} unchanged line${skipped > 1 ? 's' : ''}`, skipped })
+  }
+  return rows
+}

--- a/frontend/src/documentation/store.ts
+++ b/frontend/src/documentation/store.ts
@@ -5,6 +5,7 @@ import { isOverdue, withTags } from './frontmatter'
 import { isDescendant } from './tree'
 import type {
   Doc,
+  DocBacklink,
   DocCoverage,
   DocRevision,
   DocSearchResult,
@@ -109,6 +110,14 @@ export interface DocsState {
   pendingDraft: string | null
 
   revisions: DocRevision[]
+  revisionsLoading: boolean
+  /** A revision being read, alongside the current body. Null when not reading one. */
+  revisionPreview: { revision: DocRevision; body: string } | null
+
+  /** The documents linking to the open one. Inverted server-side. */
+  backlinks: DocBacklink[]
+  backlinksLoading: boolean
+
   coverage: DocCoverage | null
   search: DocSearchResult | null
   searching: boolean
@@ -149,9 +158,12 @@ export interface DocsState {
   remove: (id: string) => Promise<void>
 
   loadRevisions: (id: string) => Promise<void>
+  previewRevision: (revisionId: string) => Promise<void>
+  closeRevisionPreview: () => void
   restore: (id: string, revisionId: string) => Promise<void>
   regenerate: (id: string) => Promise<boolean>
 
+  loadBacklinks: (id: string) => Promise<void>
   loadCoverage: () => Promise<void>
   scaffold: (input: { deviceIds?: string[]; onlyWithNotes?: boolean }) => Promise<number>
   runSearch: (query: string) => Promise<void>
@@ -186,6 +198,12 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
   pendingDraft: null,
 
   revisions: [],
+  revisionsLoading: false,
+  revisionPreview: null,
+
+  backlinks: [],
+  backlinksLoading: false,
+
   coverage: null,
   search: null,
   searching: false,
@@ -212,7 +230,16 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
   },
 
   open: async (id) => {
-    set({ openLoading: true, draft: null, dirty: false, pendingDraft: null, revisions: [] })
+    set({
+      openLoading: true,
+      draft: null,
+      dirty: false,
+      pendingDraft: null,
+      revisions: [],
+      revisionsLoading: false,
+      revisionPreview: null,
+      backlinks: [],
+    })
     try {
       const { data } = await documentsApi.get(id)
       // A draft newer than the stored document is unsaved work from a previous
@@ -226,6 +253,8 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
       })
       if (draft && stale) clearDraft(id)
       writeUi({ ...readUi(), lastDocId: id })
+      // Not awaited: the document renders now, the "Linked from" block fills in.
+      void get().loadBacklinks(id)
     } catch (error) {
       set({ openLoading: false, loadError: message(error, 'Could not open that document') })
     }
@@ -254,7 +283,17 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
     return true
   },
 
-  close: () => set({ openDoc: null, draft: null, dirty: false, pendingDraft: null, revisions: [] }),
+  close: () =>
+    set({
+      openDoc: null,
+      draft: null,
+      dirty: false,
+      pendingDraft: null,
+      revisions: [],
+      revisionsLoading: false,
+      revisionPreview: null,
+      backlinks: [],
+    }),
 
   startEdit: () => {
     const doc = get().openDoc
@@ -400,9 +439,32 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
   },
 
   loadRevisions: async (id) => {
-    const { data } = await documentsApi.revisions(id)
-    set({ revisions: data })
+    set({ revisionsLoading: true })
+    try {
+      const { data } = await documentsApi.revisions(id)
+      if (get().openDoc?.id !== id) return
+      set({ revisions: data, revisionsLoading: false })
+    } catch (error) {
+      if (get().openDoc?.id !== id) return
+      set({ revisionsLoading: false, loadError: message(error, 'Could not load the history') })
+    }
   },
+
+  // A revision's body is fetched on demand rather than with the list: the list
+  // is what the history panel shows, and fifty bodies to render one of them is
+  // the whole reason `RevisionSummary` carries a size instead of the text.
+  previewRevision: async (revisionId) => {
+    const revision = get().revisions.find((r) => r.id === revisionId)
+    if (!revision) return
+    try {
+      const { data } = await documentsApi.revision(revisionId)
+      set({ revisionPreview: { revision, body: data.body } })
+    } catch (error) {
+      set({ loadError: message(error, 'Could not read that version') })
+    }
+  },
+
+  closeRevisionPreview: () => set({ revisionPreview: null }),
 
   restore: async (id, revisionId) => {
     const { data } = await documentsApi.restore(id, revisionId)
@@ -411,6 +473,9 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
       openDoc: data,
       draft: state.draft === null ? null : data.body,
       dirty: false,
+      // The restored body is now the current one; there is nothing left to
+      // compare it against, so the preview closes rather than showing itself.
+      revisionPreview: null,
       docs: state.docs.map((d) => (d.id === id ? { ...d, ...data } : d)),
     }))
     await get().loadRevisions(id)
@@ -434,6 +499,25 @@ export const useDocsStore = create<DocsState>()((set, get) => ({
     } catch (error) {
       set({ loadError: message(error, 'Could not regenerate that document') })
       return false
+    }
+  },
+
+  // Backlinks are the server's answer because the browser holds no bodies but
+  // its own: `list()` is metadata-only so the tree can badge without a download.
+  loadBacklinks: async (id) => {
+    if (STANDALONE) return
+    set({ backlinksLoading: true })
+    try {
+      const { data } = await documentsApi.backlinks(id)
+      // A slow answer for a document the user has already left is dropped
+      // rather than shown under the new one.
+      if (get().openDoc?.id !== id) return
+      set({ backlinks: data, backlinksLoading: false })
+    } catch {
+      // Backlinks are a bonus panel; a failure must not break reading. A failure
+      // for a document already left must not wipe the one now on screen either.
+      if (get().openDoc?.id !== id) return
+      set({ backlinks: [], backlinksLoading: false })
     }
   },
 

--- a/frontend/src/documentation/types.ts
+++ b/frontend/src/documentation/types.ts
@@ -51,6 +51,18 @@ export interface DocRevision {
   size: number
 }
 
+/** A document pointing at the open one. Inverted server-side — see the route. */
+export interface DocBacklink {
+  doc_id: string
+  title: string
+  kind: DocKind
+  device_id?: string | null
+  /** The link as it was written, which may differ from the target's title. */
+  label: string
+  context: string
+  count: number
+}
+
 export interface DocSearchHit {
   doc_id: string
   title: string

--- a/frontend/src/documentation/wikilinks.ts
+++ b/frontend/src/documentation/wikilinks.ts
@@ -4,6 +4,11 @@
  * Parsed as a plain text pass rather than a remark plugin: the syntax is one
  * token with no nesting, and keeping it out of the AST pipeline means the
  * markdown stays ordinary markdown for anything that reads the file elsewhere.
+ *
+ * This is the forward direction only — where a link goes. The reverse ("what
+ * links here") lives in `backend/app/services/doc_backlinks.py`, which mirrors
+ * the rules below, because it needs every body and the browser holds none but
+ * the open one. Change a rule here and change it there.
  */
 
 export type WikiTarget = 'device' | 'doc' | 'node'
@@ -55,7 +60,7 @@ export function splitWikiLinks(text: string): Segment[] {
   return segments
 }
 
-/** Every wiki-link in a body, for the backlinks index. */
+/** Every wiki-link in a body. */
 export function collectWikiLinks(body: string): WikiLink[] {
   const found: WikiLink[] = []
   LINK.lastIndex = 0
@@ -103,21 +108,4 @@ export function resolveWikiLink(
     docs.find((doc) => doc.title.toLowerCase() === key)?.id ??
     null
   )
-}
-
-/** doc id → the documents that link to it. */
-export function backlinkIndex(
-  docs: (LinkableDoc & { body: string })[],
-  devices: LinkableDevice[] = [],
-): Record<string, string[]> {
-  const index: Record<string, string[]> = {}
-  for (const doc of docs) {
-    for (const link of collectWikiLinks(doc.body)) {
-      const targetId = resolveWikiLink(link, docs, devices)
-      if (!targetId || targetId === doc.id) continue
-      const current = index[targetId] ?? []
-      if (!current.includes(doc.id)) index[targetId] = [...current, doc.id]
-    }
-  }
-  return index
 }

--- a/frontend/src/hooks/__tests__/useDocsUrlSync.test.ts
+++ b/frontend/src/hooks/__tests__/useDocsUrlSync.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useDocsUrlSync } from '@/hooks/useDocsUrlSync'
+import type { AppView } from '@/stores/uiStore'
+
+const search = () => window.location.search
+
+interface Props {
+  view: AppView
+  openDocId: string | null
+  ready: boolean
+  enabled: boolean
+  onRestore: (docId: string | null) => void | Promise<void>
+}
+
+const setup = (props: Partial<Props> = {}) => {
+  const onRestore = props.onRestore ?? vi.fn()
+  return renderHook((p: Props) => useDocsUrlSync(p), {
+    initialProps: {
+      view: 'canvas' as AppView,
+      openDocId: null,
+      ready: true,
+      enabled: true,
+      ...props,
+      onRestore,
+    },
+  })
+}
+
+describe('useDocsUrlSync', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('writes the section and the document into the URL', async () => {
+    const { rerender } = setup()
+    await waitFor(() => expect(search()).toBe(''))
+
+    rerender({ view: 'documentation', openDocId: 'doc-1', ready: true, enabled: true, onRestore: vi.fn() })
+    await waitFor(() => {
+      const params = new URLSearchParams(search())
+      expect(params.get('view')).toBe('docs')
+      expect(params.get('doc')).toBe('doc-1')
+    })
+  })
+
+  it('drops both params when leaving the section', async () => {
+    const { rerender } = setup({ view: 'documentation', openDocId: 'doc-1' })
+    await waitFor(() => expect(new URLSearchParams(search()).get('doc')).toBe('doc-1'))
+
+    rerender({ view: 'canvas', openDocId: null, ready: true, enabled: true, onRestore: vi.fn() })
+    await waitFor(() => {
+      const params = new URLSearchParams(search())
+      expect(params.get('view')).toBeNull()
+      expect(params.get('doc')).toBeNull()
+    })
+  })
+
+  it('preserves the design param', async () => {
+    window.history.replaceState(null, '', '/?design=abc')
+    setup({ view: 'documentation', openDocId: 'doc-1' })
+    await waitFor(() => expect(new URLSearchParams(search()).get('design')).toBe('abc'))
+  })
+
+  // The regression: the writer used to run before the reader and overwrite
+  // `?view=docs&doc=` with the default view, so a refresh lost the document.
+  it('restores the document the URL asks for instead of wiping it', async () => {
+    window.history.replaceState(null, '', '/?design=abc&view=docs&doc=doc-9')
+    const onRestore = vi.fn()
+    setup({ onRestore })
+
+    await waitFor(() => expect(onRestore).toHaveBeenCalledWith('doc-9'))
+    const params = new URLSearchParams(search())
+    expect(params.get('view')).toBe('docs')
+    expect(params.get('doc')).toBe('doc-9')
+  })
+
+  it('restores the section when the URL names no document', async () => {
+    window.history.replaceState(null, '', '/?view=docs')
+    const onRestore = vi.fn()
+    setup({ onRestore })
+
+    await waitFor(() => expect(onRestore).toHaveBeenCalledWith(null))
+  })
+
+  it('keeps the URL across the auth bootstrap and restores once ready', async () => {
+    window.history.replaceState(null, '', '/?view=docs&doc=doc-9')
+    const onRestore = vi.fn()
+    const { rerender } = setup({ ready: false, onRestore })
+
+    // Still signed out: nothing fetched, and the request survives in the URL.
+    await waitFor(() => expect(new URLSearchParams(search()).get('doc')).toBe('doc-9'))
+    expect(onRestore).not.toHaveBeenCalled()
+
+    rerender({ view: 'canvas', openDocId: null, ready: true, enabled: true, onRestore })
+    await waitFor(() => expect(onRestore).toHaveBeenCalledWith('doc-9'))
+  })
+
+  it('holds the URL until an awaited restore settles', async () => {
+    window.history.replaceState(null, '', '/?view=docs&doc=doc-9')
+    let release: () => void = () => {}
+    const onRestore = vi.fn(() => new Promise<void>((resolve) => (release = resolve)))
+    const { rerender } = setup({ onRestore })
+
+    await waitFor(() => expect(onRestore).toHaveBeenCalled())
+    // The section has switched but the document has not landed yet: the writer
+    // must not publish `view=docs` with no `doc` in the meantime.
+    rerender({ view: 'documentation', openDocId: null, ready: true, enabled: true, onRestore })
+    expect(new URLSearchParams(search()).get('doc')).toBe('doc-9')
+
+    release()
+    rerender({ view: 'documentation', openDocId: 'doc-9', ready: true, enabled: true, onRestore })
+    await waitFor(() => expect(new URLSearchParams(search()).get('doc')).toBe('doc-9'))
+  })
+
+  it('releases the URL when the restore fails, so the section can be left', async () => {
+    window.history.replaceState(null, '', '/?view=docs&doc=gone')
+    const onRestore = vi.fn(() => Promise.reject(new Error('no such document')))
+    const { rerender } = setup({ onRestore })
+
+    await waitFor(() => expect(onRestore).toHaveBeenCalled())
+    rerender({ view: 'canvas', openDocId: null, ready: true, enabled: true, onRestore })
+    await waitFor(() => expect(new URLSearchParams(search()).get('doc')).toBeNull())
+  })
+
+  it('ignores the URL in standalone, where documents need a backend', async () => {
+    window.history.replaceState(null, '', '/?view=docs&doc=doc-9')
+    const onRestore = vi.fn()
+    setup({ enabled: false, onRestore })
+
+    await waitFor(() => expect(search()).toBe(''))
+    expect(onRestore).not.toHaveBeenCalled()
+  })
+
+  it('restores only once', async () => {
+    window.history.replaceState(null, '', '/?view=docs&doc=doc-9')
+    const onRestore = vi.fn()
+    const { rerender } = setup({ onRestore })
+
+    await waitFor(() => expect(onRestore).toHaveBeenCalledTimes(1))
+    rerender({ view: 'documentation', openDocId: 'doc-9', ready: true, enabled: true, onRestore })
+    rerender({ view: 'documentation', openDocId: 'doc-2', ready: true, enabled: true, onRestore })
+    await waitFor(() => expect(new URLSearchParams(search()).get('doc')).toBe('doc-2'))
+    expect(onRestore).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not add history entries', async () => {
+    const before = window.history.length
+    const { rerender } = setup()
+    rerender({ view: 'documentation', openDocId: 'doc-1', ready: true, enabled: true, onRestore: vi.fn() })
+    await waitFor(() => expect(new URLSearchParams(search()).get('doc')).toBe('doc-1'))
+    expect(window.history.length).toBe(before)
+  })
+})

--- a/frontend/src/hooks/useDocsUrlSync.ts
+++ b/frontend/src/hooks/useDocsUrlSync.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react'
+import { getDocIdFromUrl, isDocsViewInUrl, setDocsViewInUrl } from '@/utils/designUrl'
+import type { AppView } from '@/stores/uiStore'
+
+interface DocsUrlSyncOptions {
+  /** The section the app is showing. */
+  view: AppView
+  /** The open document's id, or null when the section shows no document. */
+  openDocId: string | null
+  /**
+   * True once the app may talk to the backend — the session is bootstrapped.
+   * Restoring earlier would fetch the document without a session and land on
+   * an error the user never sees, because the login page is still up.
+   */
+  ready: boolean
+  /** False in standalone: documents need the backend, so the URL means nothing. */
+  enabled: boolean
+  /**
+   * Honour the URL: switch to Documentation and open `docId` when there is one.
+   * Awaited — the URL stays untouched until it settles.
+   */
+  onRestore: (docId: string | null) => void | Promise<void>
+}
+
+/**
+ * Two-way sync between the Documentation section and `?view=docs&doc=<id>`,
+ * so a document survives a refresh and its URL can be shared.
+ *
+ * The order matters, and used not to: reflecting the view into the address bar
+ * and reading the address bar were two effects, and the writer ran first. On
+ * boot it wrote the *default* view — canvas, no document — over the very params
+ * the reader was about to consume, so a refresh always came back to the canvas.
+ * Here the URL's request is captured at the first render and the writer stays
+ * quiet until that request has been honoured (or there was none to honour).
+ */
+export function useDocsUrlSync({ view, openDocId, ready, enabled, onRestore }: DocsUrlSyncOptions): void {
+  // Read once, at the first render, before any effect can rewrite the address
+  // bar — a lazy initializer, not a ref, which must not be read during render.
+  const [boot] = useState(() => {
+    const docs = enabled && isDocsViewInUrl()
+    return { docs, docId: docs ? getDocIdFromUrl() : null }
+  })
+
+  // Nothing to restore means the writer owns the URL from the first render.
+  const [restored, setRestored] = useState(!boot.docs)
+
+  // Kept in a ref so a caller that passes a fresh closure each render doesn't
+  // re-run the restore.
+  const restore = useRef(onRestore)
+  useEffect(() => {
+    restore.current = onRestore
+  })
+
+  useEffect(() => {
+    if (restored || !ready) return
+    let cancelled = false
+    // Settled either way — a document that no longer exists must not keep the
+    // URL frozen, or the section could never be left. `then(f, f)` rather than
+    // `finally`, which would rethrow the rejection as an unhandled one.
+    const settle = () => {
+      if (!cancelled) setRestored(true)
+    }
+    void Promise.resolve(restore.current(boot.docId)).then(settle, settle)
+    return () => {
+      cancelled = true
+    }
+  }, [restored, ready, boot])
+
+  useEffect(() => {
+    if (!restored) return
+    setDocsViewInUrl(view === 'documentation', openDocId)
+  }, [restored, view, openDocId])
+}


### PR DESCRIPTION
## What

The documentation section (#418) stored two things it never showed: up to 50 revisions per document, and the reverse of every wiki-link. This PR gives both a way in, and adds the section to the README and FEATURES.md, where it was missing entirely.

## Changes

**Frontend — history**
- A history button in the document header opens a rail listing every revision by what caused it (Saved, Regenerated, Restored, Migrated from notes, Generated), with relative time and size.
- Selecting a revision replaces the body in place — same title, chips and rail — so it reads as the same document at another moment. `Changes` turns it into a line diff against the current body; `Restore` confirms, then restores, snapshotting the body it replaces first.
- `RegenerateDocModal` told the user the old body "is in its history"; that statement is now reachable.
- A revision's body is fetched only when opened. The list carries a size, not the text.
- New `documentation/diff.ts`: LCS over lines after the common head and tail are trimmed, unchanged runs collapsed to gaps. No diff library. Two long unrelated bodies degrade to a wholesale replacement instead of building a 250k-cell matrix.
- Store: `revisionsLoading`, `revisionPreview`, `previewRevision`, `closeRevisionPreview`; `restore` closes the preview and re-reads the list; a response for a document the user has already left is dropped rather than shown under the new one.

**Backend + frontend — backlinks**
- New `GET /api/v1/documents/{id}/backlinks` and `services/doc_backlinks.py`. Each document now lists "Linked from" under its body, with the line the link was written on and the label as written; repeated links from one document collapse into a count, and a document never backlinks itself.
- Inverted server-side because the browser holds no body but the open one — `GET /documents` is metadata-only so the tree can badge without downloading the whole space. The service mirrors the resolution rules in `wikilinks.ts` (prefixes, id then slug then title, case-insensitive), as `doc_template.service_url` mirrors `utils/serviceUrl.ts`; both sides say so and `test_doc_backlinks.py` pins them.
- The inventory is loaded only when some body actually carries a `[[device:…]]`.
- Removed the client-side `backlinkIndex`: written, tested, never rendered, and a second copy of the resolution rules on the side that cannot see every body is only drift.

**Docs**
- README: a Documentation section beside the Rack Canvas one, plus a mention in About and in the Features blurb.
- FEATURES.md: new section 13 after Device Inventory; 13-19 shift to 14-20 and the table of contents follows. The `#12-device-inventory-` anchor `docs/rack-canvas.md` links to does not move.
- `docs/documentation.md`: a Backlinks section, a History section, a backlinks row in the API table, and a "Not built yet" list that now names what is actually left (export/import, print view, open-tasks view, images, documents in the canvas search modal, `[[` autocompletion, MCP tools).

No migration, no schema change: both features read tables that already existed.

## Testing

- Backend: 1229 passed, 8 skipped (`pytest`), including 23 new in `tests/test_doc_backlinks.py` covering link parsing, resolution against documents, devices and nodes, the inversion rules, and the route (auth, 404, a target carrying no links of its own, a device document reached through `[[device:…]]`, an unresolved link).
- Frontend: 2573 passed across 175 files (`npm test`), including 42 new — `diff.test.ts` (insertions, deletions, changed lines, empty bodies, the degradation guard, gap collapsing), `storeHistory.test.ts` (revision loading and staleness, preview, restore, backlinks) and `DocHistory.test.tsx` (the rail, the preview, the diff toggle, the backlinks block).
- `npm run lint` and `npm run typecheck` clean; `ruff` and `mypy` clean.

ha-relevant: no
