### PR TITLE
fix: keep the canvas pan and zoom when coming back from Documentation

### DIFF
--- a/frontend/src/components/canvas/CanvasContainer.tsx
+++ b/frontend/src/components/canvas/CanvasContainer.tsx
@@ -11,6 +11,7 @@ import {
   type Node,
   type Edge,
   type Connection,
+  type Viewport,
 } from '@xyflow/react'
 import { MousePointer2, Hand } from 'lucide-react'
 import '@xyflow/react/dist/style.css'
@@ -45,10 +46,16 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
     onNodesChange, onEdgesChange,
     setSelectedNode, snapshotHistory,
     fitViewPending, clearFitViewPending,
+    savedViewport, setSavedViewport,
     copySelectedNodes, pasteNodes,
     removeNodesFromGroup,
   } = useCanvasStore()
-  const { fitView, screenToFlowPosition, getIntersectingNodes } = useReactFlow<Node<NodeData>>()
+  const { fitView, getViewport, screenToFlowPosition, getIntersectingNodes } = useReactFlow<Node<NodeData>>()
+
+  // React Flow reads defaultViewport once, on mount. Leaving the canvas
+  // (Documentation) unmounts it, so hold the stored pan/zoom as it was at first
+  // render: later saves must not feed back into the prop.
+  const [initialViewport] = useState(savedViewport)
 
   // Track the last cursor position over the canvas so paste lands under it.
   const cursorRef = useRef<{ x: number; y: number } | null>(null)
@@ -93,11 +100,14 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
   useEffect(() => {
     if (!fitViewPending || nodes.length === 0) return
     const id = setTimeout(() => {
-      fitView({ padding: 0.12, duration: 350 })
+      void fitView({ padding: 0.12, duration: 350 }).then(() => {
+        // Where the fit landed is the viewport to come back to.
+        setSavedViewport(getViewport())
+      })
       clearFitViewPending()
     }, 50)
     return () => clearTimeout(id)
-  }, [fitViewPending, nodes.length, fitView, clearFitViewPending])
+  }, [fitViewPending, nodes.length, fitView, getViewport, setSavedViewport, clearFitViewPending])
 
   const activeTheme = useThemeStore((s) => s.activeTheme)
   const theme = THEMES[activeTheme]
@@ -124,6 +134,12 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
   const onPaneClick = useCallback(() => {
     setSelectedNode(null)
   }, [setSelectedNode])
+
+  // Every pan / zoom the user ends is remembered, so leaving the canvas and
+  // coming back does not reset the view to 1:1 at the origin.
+  const handleMoveEnd = useCallback((_: unknown, viewport: Viewport) => {
+    setSavedViewport(viewport)
+  }, [setSavedViewport])
 
   const handleEdgeDoubleClick = useCallback((_: React.MouseEvent, edge: Edge<EdgeData>) => {
     onEdgeDoubleClick?.(edge)
@@ -216,6 +232,8 @@ export function CanvasContainer({ onConnect: onConnectProp, onEdgeDoubleClick, o
         onNodeDragStart={onNodeDragStart}
         onNodeDrag={onNodeDrag}
         onNodeDragStop={handleNodeDragStop}
+        onMoveEnd={handleMoveEnd}
+        defaultViewport={initialViewport ?? undefined}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         deleteKeyCode={['Backspace', 'Delete']}

--- a/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
+++ b/frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { CanvasContainer } from '../CanvasContainer'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { useThemeStore } from '@/stores/themeStore'
@@ -10,7 +10,11 @@ import type { NodeData, EdgeData } from '@/types'
 let rfProps: Record<string, unknown> = {}
 
 // Hoisted holder so the mock factory can read the configurable intersection set.
-const rf = vi.hoisted(() => ({ intersecting: [] as unknown[] }))
+const rf = vi.hoisted(() => ({
+  intersecting: [] as unknown[],
+  viewport: { x: 0, y: 0, zoom: 1 },
+  fitView: vi.fn(() => Promise.resolve(true)),
+}))
 
 vi.mock('@xyflow/react', () => ({
   ReactFlow: (props: Record<string, unknown>) => {
@@ -25,7 +29,8 @@ vi.mock('@xyflow/react', () => ({
   SelectionMode: { Partial: 'partial' },
   Position: { Top: 'top', Right: 'right', Bottom: 'bottom', Left: 'left' },
   useReactFlow: () => ({
-    fitView: vi.fn(),
+    fitView: rf.fitView,
+    getViewport: () => rf.viewport,
     screenToFlowPosition: vi.fn(),
     getIntersectingNodes: () => rf.intersecting,
     setNodes: vi.fn(),
@@ -52,7 +57,12 @@ describe('CanvasContainer', () => {
   beforeEach(() => {
     rfProps = {}
     rf.intersecting = []
-    useCanvasStore.setState({ nodes: [], edges: [], selectedNodeId: null })
+    rf.viewport = { x: 0, y: 0, zoom: 1 }
+    rf.fitView.mockClear()
+    useCanvasStore.setState({
+      nodes: [], edges: [], selectedNodeId: null,
+      savedViewport: null, fitViewPending: false,
+    })
     useThemeStore.setState({ activeTheme: 'default' })
   })
 
@@ -443,5 +453,61 @@ describe('CanvasContainer', () => {
     const result = await (rfProps.onBeforeDelete as () => Promise<boolean>)()
     expect(snapshotHistory).toHaveBeenCalledOnce()
     expect(result).toBe(true)
+  })
+
+  // ── Viewport persistence across unmount (#docs round-trip) ────────────────
+
+  it('onMoveEnd stores the viewport the user ended on', () => {
+    render(<CanvasContainer />)
+    act(() => {
+      ;(rfProps.onMoveEnd as (...args: unknown[]) => unknown)({}, { x: -300, y: 120, zoom: 0.5 })
+    })
+    expect(useCanvasStore.getState().savedViewport).toEqual({ x: -300, y: 120, zoom: 0.5 })
+  })
+
+  it('mounts at the stored viewport — leaving for Documentation must not reset to 1:1', () => {
+    useCanvasStore.setState({ savedViewport: { x: -300, y: 120, zoom: 0.5 } })
+    render(<CanvasContainer />)
+    expect(rfProps.defaultViewport).toEqual({ x: -300, y: 120, zoom: 0.5 })
+  })
+
+  it('keeps the stored viewport across an unmount / remount round-trip', () => {
+    const first = render(<CanvasContainer />)
+    act(() => {
+      ;(rfProps.onMoveEnd as (...args: unknown[]) => unknown)({}, { x: -80, y: 15, zoom: 0.75 })
+    })
+    first.unmount()
+    render(<CanvasContainer />)
+    expect(rfProps.defaultViewport).toEqual({ x: -80, y: 15, zoom: 0.75 })
+  })
+
+  it('leaves defaultViewport undefined on a first load, so React Flow fits', () => {
+    render(<CanvasContainer />)
+    expect(rfProps.defaultViewport).toBeUndefined()
+  })
+
+  it('does not feed a later pan back into defaultViewport (read once, on mount)', () => {
+    render(<CanvasContainer />)
+    act(() => {
+      ;(rfProps.onMoveEnd as (...args: unknown[]) => unknown)({}, { x: -80, y: 15, zoom: 0.75 })
+    })
+    expect(rfProps.defaultViewport).toBeUndefined()
+  })
+
+  it('stores where fitView landed, so the fitted view survives the round-trip', async () => {
+    vi.useFakeTimers()
+    try {
+      rf.viewport = { x: -42, y: 7, zoom: 0.6 }
+      useCanvasStore.setState({ nodes: [makeNode('n1')], fitViewPending: true })
+      render(<CanvasContainer />)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+      })
+      expect(rf.fitView).toHaveBeenCalledOnce()
+      expect(useCanvasStore.getState().savedViewport).toEqual({ x: -42, y: 7, zoom: 0.6 })
+      expect(useCanvasStore.getState().fitViewPending).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/stores/__tests__/canvasStore/viewport.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/viewport.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '@/stores/canvasStore'
+
+describe('savedViewport', () => {
+  beforeEach(() =>
+    useCanvasStore.setState({ savedViewport: null, nodes: [], edges: [], fitViewPending: false }),
+  )
+
+  it('setSavedViewport stores the pan/zoom', () => {
+    useCanvasStore.getState().setSavedViewport({ x: -120, y: 40, zoom: 0.55 })
+    expect(useCanvasStore.getState().savedViewport).toEqual({ x: -120, y: 40, zoom: 0.55 })
+  })
+
+  it('setSavedViewport does not dirty the canvas — panning is not an edit', () => {
+    useCanvasStore.setState({ hasUnsavedChanges: false })
+    useCanvasStore.getState().setSavedViewport({ x: 1, y: 2, zoom: 1.5 })
+    expect(useCanvasStore.getState().hasUnsavedChanges).toBe(false)
+  })
+
+  it('loadCanvas clears it so a new design fits instead of inheriting a pan/zoom', () => {
+    useCanvasStore.setState({ savedViewport: { x: -120, y: 40, zoom: 0.55 } })
+    useCanvasStore.getState().loadCanvas([], [])
+    expect(useCanvasStore.getState().savedViewport).toBeNull()
+    expect(useCanvasStore.getState().fitViewPending).toBe(true)
+  })
+})

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -6,6 +6,7 @@ import {
   type NodePositionChange,
   type EdgeChange,
   type Connection,
+  type Viewport,
   applyNodeChanges,
   applyEdgeChanges,
 } from '@xyflow/react'
@@ -348,6 +349,11 @@ interface CanvasState {
   applyLayout: (nodes: Node<NodeData>[], edges: Edge<EdgeData>[]) => void
   fitViewPending: boolean
   clearFitViewPending: () => void
+  /** Last pan/zoom the user was looking at. React Flow unmounts whenever the app
+   *  leaves the canvas (Documentation, a rack design…), and remounts at the
+   *  default 1:1 viewport; this is what the canvas restores from on the way back. */
+  savedViewport: Viewport | null
+  setSavedViewport: (viewport: Viewport) => void
   notifyScanDeviceFound: () => void
   setServiceStatuses: (nodeId: string, statuses: { port?: number; protocol?: string; host?: string | null; status: ServiceStatus }[]) => void
   hideIp: boolean
@@ -396,6 +402,7 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
   floorMap: null,
   floorMapEditNonce: 0,
   fitViewPending: false,
+  savedViewport: null,
 
   past: [],
   future: [],
@@ -1245,6 +1252,9 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
       past: [],
       future: [],
       fitViewPending: true,
+      // A new design's viewport is whatever fitView lands on, never the pan/zoom
+      // the previous one was left at.
+      savedViewport: null,
       // What the server just gave us: the reference a save diffs against.
       factsBaseline: factsBaselines(nodes),
     })
@@ -1265,6 +1275,8 @@ export const useCanvasStore = create<CanvasState>((rawSet, get) => {
     }),
 
   clearFitViewPending: () => set({ fitViewPending: false }),
+
+  setSavedViewport: (viewport) => set({ savedViewport: viewport }),
 
   applyTypeNodeStyle: (nodeType, style) =>
     set((state) => ({


### PR DESCRIPTION
## What

Coming back to the canvas after visiting Documentation left the graph zoomed in at the origin, with nodes running off screen and under the panels. The canvas now returns to the pan and zoom the user left it at.

Root cause: `App` unmounts `CanvasContainer` while `appView === 'documentation'`, and React Flow remounts at its default viewport (`x: 0, y: 0, zoom: 1`). The only corrective `fitView` runs on `fitViewPending`, which `loadCanvas` sets on a fresh load and the canvas clears right after — so nothing reset the view on the way back.

## Changes

Frontend
- `canvasStore`: new `savedViewport` state plus a `setSavedViewport` action. `loadCanvas` clears it, so switching design still fits to the new graph instead of inheriting the previous one's pan and zoom. Saving a viewport does not mark the canvas unsaved — panning is not an edit.
- `CanvasContainer`: `onMoveEnd` records every pan/zoom the user ends; the `fitView` effect records where the fit landed; `defaultViewport` mounts from the stored value, read once at first render (React Flow only reads that prop on mount, and later saves must not feed back into it).

No API, schema or persistence change — the viewport is remembered in memory for the session, not saved with the canvas.

## Testing

- `frontend/src/stores/__tests__/canvasStore/viewport.test.ts` (new): the store action, the no-dirty guarantee, and the `loadCanvas` reset.
- `frontend/src/components/canvas/__tests__/CanvasContainer.test.tsx`: six cases covering `onMoveEnd` capture, mounting at the stored viewport, an unmount/remount round-trip, the untouched first load, the read-once `defaultViewport`, and storing where `fitView` landed.
- `npm run lint`, `npm run typecheck`, `npm test` — 180 files, 2623 tests pass.

ha-relevant: yes
