### PR TITLE
test: stop the pre-split backup test tracking the app version

### DIFF
--- a/backend/tests/migrations/test_legacy_node_columns.py
+++ b/backend/tests/migrations/test_legacy_node_columns.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 import app.db.database as database
 import app.services.inventory_sync as inventory_sync
+from app.core.config import APP_VERSION
 
 # `create_all` under v3.2.0. NOT NULL is reproduced exactly where it was.
 _NODES_320 = (
@@ -412,8 +413,10 @@ async def test_the_newest_backup_that_still_has_the_columns_is_the_one_read(db_3
     shutil.copy2(db_path, pre_split)
 
     await database.init_db()  # drops the columns, and backs up under this version
-    # Post-split backups: newer, and unable to say who drew what.
-    for name in ("back-3.3.1", "back-3.3.2"):
+    # Post-split backups: newer, and unable to say who drew what. On a real
+    # install the current version's own backup is one of them — the columns went
+    # in an earlier boot, not this one — so overwrite the one `init_db` took.
+    for name in ("back-3.3.1", "back-3.3.2", f"back-{APP_VERSION}"):
         shutil.copy2(db_path, db_path.parent / f"{db_path.name}.{name}")
 
     assert database._pre_split_backup() == pre_split


### PR DESCRIPTION
## What

Fixes the only failing job on `main` (Quality, run 34136720191, commit 574b84d "chore: bump version to 3.4.1"). The failure is a version-coupled test fixture, not a product bug.

`_backup_db` names its copy `homelab.db.back-<APP_VERSION>`, so bumping to 3.4.1 renamed the backup `init_db` takes from `back-3.3.2` to `back-3.4.1`. `test_the_newest_backup_that_still_has_the_columns_is_the_one_read` hardcoded its post-split copies as `back-3.3.1` / `back-3.3.2`, which happened to overwrite that backup while the version was 3.3.2. At 3.4.1 nothing overwrites it, so it survives still carrying the legacy `services` / `properties` columns this very boot is about to drop, and wins the newest-first scan in `_pre_split_backup`:

```
AssertionError: assert PosixPath('.../v320.db.back-3.4.1') == PosixPath('.../v320.db.back-3.3.0')
```

The fixture was also unlike a real install, where the current version's backup is taken *after* the columns are gone — they went in the 3.3.0 boot, not the one under test.

`_pre_split_backup` is deliberately unchanged: preferring the newest backup that still holds the columns is correct, the drop boot's own backup included.

## Changes

- backend/tests: the post-split loop now also copies a column-less database over `back-<APP_VERSION>`, so the test matches a real upgrade path and stops breaking on every version bump.

## Testing

- `pytest tests/migrations/test_legacy_node_columns.py` — 9 passed.
- Full backend suite via the pre-commit hook: ruff, mypy and 1248 tests green.

ha-relevant: no