### PR TITLE
feat: make canvas connection points editable over MCP

### DIFF
--- a/backend/app/api/routes/edges.py
+++ b/backend/app/api/routes/edges.py
@@ -6,6 +6,7 @@ from app.api.deps import get_current_user
 from app.db.database import get_db
 from app.db.models import Design, Edge, Node
 from app.schemas.edges import EdgeCreate, EdgeResponse, EdgeUpdate
+from app.schemas.utils import SIDES, clamp_handles, handle_count_field, parse_side_handle
 
 router = APIRouter()
 
@@ -55,6 +56,74 @@ async def _auto_handles(
     return "top", "bottom-t"
 
 
+# ---------------------------------------------------------------------------
+# Connection-point guards
+# ---------------------------------------------------------------------------
+
+
+def _side_count(node: Node, side: str) -> int:
+    """A node's clamped connection-point count for one side."""
+    return clamp_handles(side, getattr(node, handle_count_field(side), None))
+
+
+async def _reject_missing_handle(db: AsyncSession, node_id: str, handle: str | None, role: str) -> None:
+    """422 when an endpoint names a connection point its node does not have.
+
+    React Flow draws nothing for an edge whose handle ID resolves to no element,
+    so such an edge would persist and be invisible on the canvas with no error
+    anywhere — the same failure `_remap_shrunk_handles` prevents when a count is
+    lowered. Callers that supply no handle are auto-assigned one instead and
+    never reach this.
+    """
+    if handle is None:
+        return
+    parsed = parse_side_handle(handle)
+    if parsed is None:
+        # Not a per-side handle ('cluster-right' and friends): its own renderer
+        # owns it, and no count here describes it.
+        return
+    side, idx = parsed
+    node = await db.get(Node, node_id)
+    if node is None:
+        # An unknown node is not this guard's error to report; the edge routes
+        # have never checked that either endpoint exists.
+        return
+    count = _side_count(node, side)
+    if 0 <= idx < count:
+        return
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"{role}_handle '{handle}' does not exist: node {node_id} has {count} "
+            f"connection point(s) on its {side} side."
+        ),
+    )
+
+
+async def _existing_handle(db: AsyncSession, node_id: str, handle: str) -> str:
+    """Keep an auto-assigned handle, or swap it for one the node actually has.
+
+    The auto-assignment below always names a top/bottom slot 0, which a node that
+    opted out of those sides no longer draws. The server picked it, not the
+    caller, so this corrects it silently rather than raising. A node with no
+    connection point at all keeps the original: there is nothing better to use,
+    and refusing to create the edge would lose more than it saves.
+    """
+    node = await db.get(Node, node_id)
+    if node is None:
+        return handle
+    parsed = parse_side_handle(handle)
+    if parsed is not None:
+        side, idx = parsed
+        if 0 <= idx < _side_count(node, side):
+            return handle
+    suffix = "-t" if handle.endswith("-t") else ""
+    for side in SIDES:
+        if _side_count(node, side) > 0:
+            return f"{side}{suffix}"
+    return handle
+
+
 @router.get("", response_model=list[EdgeResponse])
 async def list_edges(db: AsyncSession = Depends(get_db), _: str = Depends(get_current_user)) -> list[Edge]:
     result = await db.execute(select(Edge))
@@ -75,12 +144,15 @@ async def create_edge(body: EdgeCreate, db: AsyncSession = Depends(get_db), _: s
     # Compares the canvas Y positions of both nodes so that the edge always exits
     # the upstream node's bottom and enters the downstream node's top (or vice versa
     # for reverse flows), matching the UI convention for top-to-bottom topologies.
+    await _reject_missing_handle(db, data["source"], data.get("source_handle"), "source")
+    await _reject_missing_handle(db, data["target"], data.get("target_handle"), "target")
+
     if data.get("source_handle") is None or data.get("target_handle") is None:
         auto_src, auto_tgt = await _auto_handles(db, data["source"], data["target"])
         if data.get("source_handle") is None:
-            data["source_handle"] = auto_src
+            data["source_handle"] = await _existing_handle(db, data["source"], auto_src)
         if data.get("target_handle") is None:
-            data["target_handle"] = auto_tgt
+            data["target_handle"] = await _existing_handle(db, data["target"], auto_tgt)
 
     edge = Edge(**data)
     db.add(edge)
@@ -105,7 +177,10 @@ async def update_edge(
     edge = await db.get(Edge, edge_id)
     if not edge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Edge not found")
-    for field, value in body.model_dump(exclude_unset=True).items():
+    sent = body.model_dump(exclude_unset=True)
+    await _reject_missing_handle(db, edge.source, sent.get("source_handle"), "source")
+    await _reject_missing_handle(db, edge.target, sent.get("target_handle"), "target")
+    for field, value in sent.items():
         setattr(edge, field, value)
     await db.commit()
     await db.refresh(edge)

--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -1,13 +1,20 @@
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.db.database import get_db
-from app.db.models import Design, InventoryDevice, Node
+from app.db.models import Design, Edge, InventoryDevice, Node
 from app.schemas.nodes import NodeCreate, NodeResponse, NodeUpdate
+from app.schemas.utils import (
+    SIDES,
+    handle_count_field,
+    handle_id,
+    removed_handle_ids,
+    side_default,
+)
 from app.services.doc_links import unlink_documents
 from app.services.inventory_sync import (
     facts_from_payload,
@@ -20,6 +27,47 @@ from app.services.inventory_sync import (
 from app.services.node_dedupe import find_duplicate_node
 
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Connection-point helpers
+# ---------------------------------------------------------------------------
+
+
+async def _remap_shrunk_handles(db: AsyncSession, node: Node, sent: dict[str, Any]) -> None:
+    """Move this node's edges off the connection points a shrink just deleted.
+
+    The canvas store does the same remap client-side (canvasStore.updateNode), so
+    the UI never hits this; an API client — the MCP write tools — lowers a handle
+    count without it, and React Flow silently drops an edge whose handle no longer
+    exists. Removed handles fall back to the side's slot-0 ID, or to 'bottom' when
+    the side went to zero and has no slot 0 left.
+
+    Call before the new counts are written to the node.
+    """
+    fallbacks: dict[str, str] = {}
+    for side in SIDES:
+        field = handle_count_field(side)
+        new_count = sent.get(field)
+        if new_count is None:
+            continue
+        raw_old = getattr(node, field, None)
+        old_count = raw_old if isinstance(raw_old, int) else side_default(side)
+        if new_count >= old_count:
+            continue
+        fallback = 'bottom' if new_count == 0 else handle_id(side, 0)
+        for hid in removed_handle_ids(side, old_count, new_count):
+            fallbacks[hid] = fallback
+
+    if not fallbacks:
+        return
+
+    result = await db.execute(select(Edge).where(or_(Edge.source == node.id, Edge.target == node.id)))
+    for edge in result.scalars().all():
+        if edge.source == node.id and edge.source_handle in fallbacks:
+            edge.source_handle = fallbacks[edge.source_handle]
+        if edge.target == node.id and edge.target_handle in fallbacks:
+            edge.target_handle = fallbacks[edge.target_handle]
+
 
 # ---------------------------------------------------------------------------
 # Auto-positioning helpers
@@ -156,6 +204,8 @@ async def update_node(
     # Dropped rather than rejected so the rest of the edit still lands.
     if sent.get("parent_id") == node_id:
         sent.pop("parent_id")
+    # Before the new counts land: the old ones are what says which handles go away.
+    await _remap_shrunk_handles(db, node, sent)
     for field, value in node_columns(sent).items():
         setattr(node, field, value)
     # The user edited the device, not just its drawing: push the facts down.

--- a/backend/app/schemas/canvas.py
+++ b/backend/app/schemas/canvas.py
@@ -1,10 +1,10 @@
 from typing import Any
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 
 from app.schemas.edges import EdgeResponse
 from app.schemas.nodes import NodeResponse
-from app.schemas.utils import normalize_animated, normalize_marker
+from app.schemas.utils import clamp_handles, normalize_animated, normalize_marker
 
 
 class NodeSave(BaseModel):
@@ -53,6 +53,16 @@ class NodeSave(BaseModel):
     right_handles: int = 0
     pos_x: float = 0
     pos_y: float = 0
+
+    # Same 0..64 clamp the create/update schemas apply, so a full-canvas save
+    # cannot store a count the renderer would silently narrow.
+    @field_validator('bottom_handles', 'top_handles', 'left_handles', 'right_handles', mode='before')
+    @classmethod
+    def clamp_handle_count(cls, v: object, info: ValidationInfo) -> object:
+        if v is None:
+            return None
+        side = (info.field_name or '').removesuffix('_handles')
+        return clamp_handles(side, v)
 
     @model_validator(mode="after")
     def drop_self_parent(self) -> "NodeSave":

--- a/backend/app/schemas/nodes.py
+++ b/backend/app/schemas/nodes.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationInfo, field_validator
+
+from app.schemas.utils import clamp_handles
 
 
 class NodeBase(BaseModel):
@@ -38,6 +40,18 @@ class NodeBase(BaseModel):
     top_handles: int = 1
     left_handles: int = 0
     right_handles: int = 0
+
+    # Connection-point counts are clamped to 0..64 here rather than in the route:
+    # the frontend clamps them again at render (handleUtils.clampHandles), so an
+    # unclamped row would draw a different node than it stores. See #435 — the MCP
+    # write tools reach these fields without the canvas UI's own bounds.
+    @field_validator('bottom_handles', 'top_handles', 'left_handles', 'right_handles', mode='before')
+    @classmethod
+    def clamp_handle_count(cls, v: object, info: ValidationInfo) -> object:
+        if v is None:
+            return None
+        side = (info.field_name or '').removesuffix('_handles')
+        return clamp_handles(side, v)
 
 
 class NodeCreate(NodeBase):
@@ -84,6 +98,18 @@ class NodeUpdate(BaseModel):
     top_handles: int | None = None
     left_handles: int | None = None
     right_handles: int | None = None
+
+    # Connection-point counts are clamped to 0..64 here rather than in the route:
+    # the frontend clamps them again at render (handleUtils.clampHandles), so an
+    # unclamped row would draw a different node than it stores. See #435 — the MCP
+    # write tools reach these fields without the canvas UI's own bounds.
+    @field_validator('bottom_handles', 'top_handles', 'left_handles', 'right_handles', mode='before')
+    @classmethod
+    def clamp_handle_count(cls, v: object, info: ValidationInfo) -> object:
+        if v is None:
+            return None
+        side = (info.field_name or '').removesuffix('_handles')
+        return clamp_handles(side, v)
 
 
 class NodeResponse(NodeBase):

--- a/backend/app/schemas/utils.py
+++ b/backend/app/schemas/utils.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 
 def normalize_animated(v: object) -> str:
@@ -83,3 +84,29 @@ def handle_id(side: str, idx: int) -> str:
 def removed_handle_ids(side: str, old_count: int, new_count: int) -> set[str]:
     """The source handle IDs dropped when a side shrinks from old to new count."""
     return {handle_id(side, i) for i in range(new_count, old_count)}
+
+
+# A side handle ID, in either the source form ('left', 'left-3') or the
+# invisible target form the frontend renders alongside it ('left-t', 'left-3-t').
+_SIDE_HANDLE_RE = re.compile(r'^(top|bottom|left|right)(?:-(\d+))?(?:-t)?$')
+
+
+def parse_side_handle(handle: str) -> tuple[str, int] | None:
+    """Split a side handle ID into (side, slot index), or None when it isn't one.
+
+    A handle outside this vocabulary is left for its owner to interpret — the
+    'cluster-*' IDs a specialized node renderer draws are not per-side handles
+    and must not be validated against a side's count.
+
+    The numbered form is 2-based, because slot 0 keeps the bare side name: an
+    ID ending in '-0' or '-1' is therefore one the canvas never emits, and is
+    reported as slot -1 so that no count can satisfy it.
+    """
+    m = _SIDE_HANDLE_RE.match(handle)
+    if m is None:
+        return None
+    side, slot = m.group(1), m.group(2)
+    if slot is None:
+        return side, 0
+    idx = int(slot) - 1
+    return side, (idx if idx >= 1 else -1)

--- a/backend/app/schemas/utils.py
+++ b/backend/app/schemas/utils.py
@@ -1,3 +1,6 @@
+import math
+
+
 def normalize_animated(v: object) -> str:
     """Normalize legacy bool/int animated values to string mode ('none'/'snake'/'flow')."""
     if v is True or v == 1 or v == '1':
@@ -25,3 +28,58 @@ def normalize_marker(v: object) -> str:
     if isinstance(v, str) and v in MARKER_SHAPES:
         return v
     return 'none'
+
+
+# ---------------------------------------------------------------------------
+# Connection points (React Flow handles)
+# ---------------------------------------------------------------------------
+# Mirrors frontend/src/utils/handleUtils.ts — keep the two in step.
+#
+# Handle IDs:  slot 0      = the bare side name ('top' | 'bottom' | 'left' | 'right')
+#              slot N >= 1 = '{side}-{N + 1}'  (e.g. 'bottom-2', 'left-3')
+#
+# Slot 0 keeps the bare name so edges saved before the multi-handle expansion
+# stay valid. Invisible target handles carry a '-t' suffix on the frontend only;
+# what is stored on an edge is always the source form.
+
+SIDES = ('top', 'bottom', 'left', 'right')
+
+MIN_HANDLES = 0
+MAX_HANDLES = 64
+
+
+def side_default(side: str) -> int:
+    """Count a side falls back to when the node carries no explicit value.
+
+    Top/bottom default to their historical single handle; left/right to none, so
+    an existing diagram gains no side handles unless the user opts in.
+    """
+    return 1 if side in ('top', 'bottom') else 0
+
+
+def handle_count_field(side: str) -> str:
+    """The `nodes` column storing a side's handle count."""
+    return f"{side}_handles"
+
+
+def clamp_handles(side: str, n: object) -> int:
+    """Clamp a raw count into 0..64.
+
+    A non-numeric or non-finite value falls back to the side default, so a
+    corrupt field still yields the historical count; an explicit 0 is honoured.
+    """
+    if isinstance(n, bool) or not isinstance(n, int | float):
+        return side_default(side)
+    if isinstance(n, float) and not math.isfinite(n):
+        return side_default(side)
+    return max(MIN_HANDLES, min(MAX_HANDLES, math.floor(n)))
+
+
+def handle_id(side: str, idx: int) -> str:
+    """The source handle ID at a given slot index for a side."""
+    return side if idx == 0 else f"{side}-{idx + 1}"
+
+
+def removed_handle_ids(side: str, old_count: int, new_count: int) -> set[str]:
+    """The source handle IDs dropped when a side shrinks from old to new count."""
+    return {handle_id(side, i) for i in range(new_count, old_count)}

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -119,6 +119,18 @@ async def test_save_canvas_round_trips_per_side_handles(client: AsyncClient, hea
     assert node["right_handles"] == 4
 
 
+async def test_save_canvas_clamps_per_side_handles(client: AsyncClient, headers: dict):
+    # Same 0..64 bound the create/update routes apply (#435): the renderer clamps
+    # at draw time, so a saved count above it would draw a node the row doesn't
+    # describe.
+    n1 = node_payload(label="Sw", type="switch", bottom_handles=5000, left_handles=-2)
+    await client.post("/api/v1/canvas/save", json={"nodes": [n1], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 1}}, headers=headers)
+
+    node = (await client.get("/api/v1/canvas", headers=headers)).json()["nodes"][0]
+    assert node["bottom_handles"] == 64
+    assert node["left_handles"] == 0
+
+
 async def test_save_canvas_defaults_per_side_handles(client: AsyncClient, headers: dict):
     # Nodes saved without the new fields fall back to top/bottom=1, left/right=0.
     n1 = node_payload(label="Srv", type="server")

--- a/backend/tests/test_edges.py
+++ b/backend/tests/test_edges.py
@@ -330,3 +330,154 @@ async def test_create_edge_child_node_abs_y_resolved_through_parent(client: Asyn
     data = res.json()
     assert data["source_handle"] == "bottom"
     assert data["target_handle"] == "top-t"
+
+
+# ---------------------------------------------------------------------------
+# Connection-point guards (#435)
+# ---------------------------------------------------------------------------
+# An edge whose handle ID resolves to no element is dropped by React Flow: it
+# persists in the DB and is simply invisible. Handles became settable over the
+# MCP, so the endpoints now check them.
+
+
+async def test_create_edge_rejects_a_handle_the_node_does_not_have(client: AsyncClient, headers: dict, two_nodes):
+    src, tgt = two_nodes
+    res = await client.post(
+        "/api/v1/edges",
+        json={"source": src, "target": tgt, "source_handle": "right-3", "target_handle": "top"},
+        headers=headers,
+    )
+    assert res.status_code == 422
+    assert "right-3" in res.json()["detail"]
+    assert (await client.get("/api/v1/edges", headers=headers)).json() == []
+
+
+async def test_create_edge_rejects_a_side_the_node_opted_out_of(client: AsyncClient, headers: dict):
+    # left/right default to zero connection points, so even slot 0 is absent.
+    src = (await client.post("/api/v1/nodes", json={"type": "router", "label": "R1"}, headers=headers)).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "N1"}, headers=headers)).json()["id"]
+
+    res = await client.post(
+        "/api/v1/edges", json={"source": src, "target": tgt, "source_handle": "left"}, headers=headers
+    )
+
+    assert res.status_code == 422
+
+
+async def test_create_edge_accepts_a_handle_the_node_opted_into(client: AsyncClient, headers: dict):
+    src = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "proxmox", "label": "pve1", "right_handles": 1}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "proxmox", "label": "pve2", "left_handles": 1}, headers=headers
+        )
+    ).json()["id"]
+
+    res = await client.post(
+        "/api/v1/edges",
+        json={"source": src, "target": tgt, "type": "cluster", "source_handle": "right", "target_handle": "left"},
+        headers=headers,
+    )
+
+    assert res.status_code == 201
+    assert res.json()["source_handle"] == "right"
+
+
+async def test_create_edge_accepts_the_target_form_of_a_handle(client: AsyncClient, headers: dict):
+    # '<side>-t' is the invisible target twin the canvas renders beside slot 0;
+    # the auto-assignment stores exactly that, so it must validate.
+    src = (await client.post("/api/v1/nodes", json={"type": "router", "label": "R1"}, headers=headers)).json()["id"]
+    tgt = (
+        await client.post("/api/v1/nodes", json={"type": "nas", "label": "N1", "top_handles": 2}, headers=headers)
+    ).json()["id"]
+
+    res = await client.post(
+        "/api/v1/edges",
+        json={"source": src, "target": tgt, "source_handle": "bottom", "target_handle": "top-2-t"},
+        headers=headers,
+    )
+
+    assert res.status_code == 201
+    assert res.json()["target_handle"] == "top-2-t"
+
+
+async def test_create_edge_leaves_a_foreign_handle_namespace_alone(client: AsyncClient, headers: dict, two_nodes):
+    # 'cluster-right' is not a per-side handle; no count here describes it, so
+    # the guard must not judge it.
+    src, tgt = two_nodes
+    res = await client.post(
+        "/api/v1/edges",
+        json={"source": src, "target": tgt, "type": "cluster", "source_handle": "cluster-right"},
+        headers=headers,
+    )
+    assert res.status_code == 201
+
+
+async def test_update_edge_rejects_a_handle_the_node_does_not_have(client: AsyncClient, headers: dict, two_nodes):
+    src, tgt = two_nodes
+    edge_id = (
+        await client.post("/api/v1/edges", json={"source": src, "target": tgt}, headers=headers)
+    ).json()["id"]
+
+    res = await client.patch(f"/api/v1/edges/{edge_id}", json={"source_handle": "bottom-9"}, headers=headers)
+
+    assert res.status_code == 422
+    edge = (await client.get("/api/v1/edges", headers=headers)).json()[0]
+    assert edge["source_handle"] == "bottom"
+
+
+async def test_update_edge_accepts_a_handle_the_node_has(client: AsyncClient, headers: dict):
+    src = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "bottom_handles": 4}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "N1"}, headers=headers)).json()["id"]
+    edge_id = (
+        await client.post("/api/v1/edges", json={"source": src, "target": tgt}, headers=headers)
+    ).json()["id"]
+
+    res = await client.patch(f"/api/v1/edges/{edge_id}", json={"source_handle": "bottom-4"}, headers=headers)
+
+    assert res.status_code == 200
+    assert res.json()["source_handle"] == "bottom-4"
+
+
+async def test_auto_assignment_avoids_a_side_with_no_connection_point(client: AsyncClient, headers: dict):
+    # The caller supplied no handle, so the server corrects its own pick rather
+    # than raising: bottom is gone, and the node's remaining side is used.
+    src = (
+        await client.post(
+            "/api/v1/nodes",
+            json={"type": "switch", "label": "sw1", "bottom_handles": 0, "top_handles": 0, "right_handles": 2},
+            headers=headers,
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "N1"}, headers=headers)).json()["id"]
+
+    res = await client.post("/api/v1/edges", json={"source": src, "target": tgt}, headers=headers)
+
+    assert res.status_code == 201
+    assert res.json()["source_handle"] == "right"
+    assert res.json()["target_handle"] == "top-t"
+
+
+async def test_auto_assignment_keeps_its_pick_when_the_node_has_nothing(client: AsyncClient, headers: dict):
+    # Every side is empty: there is no better handle to reach for, and refusing
+    # the edge would lose more than it saves.
+    src = (
+        await client.post(
+            "/api/v1/nodes",
+            json={"type": "switch", "label": "sw1", "top_handles": 0, "bottom_handles": 0},
+            headers=headers,
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "N1"}, headers=headers)).json()["id"]
+
+    res = await client.post("/api/v1/edges", json={"source": src, "target": tgt}, headers=headers)
+
+    assert res.status_code == 201
+    assert res.json()["source_handle"] == "bottom"

--- a/backend/tests/test_handle_utils.py
+++ b/backend/tests/test_handle_utils.py
@@ -1,0 +1,84 @@
+"""Unit tests for the per-side connection-point vocabulary.
+
+Mirrors frontend/src/utils/handleUtils.ts — the two must agree, or the server
+stores handles the canvas cannot draw.
+"""
+
+import pytest
+
+from app.schemas.utils import (
+    MAX_HANDLES,
+    clamp_handles,
+    handle_count_field,
+    handle_id,
+    parse_side_handle,
+    removed_handle_ids,
+    side_default,
+)
+
+
+@pytest.mark.parametrize(("side", "expected"), [("top", 1), ("bottom", 1), ("left", 0), ("right", 0)])
+def test_side_default(side: str, expected: int) -> None:
+    assert side_default(side) == expected
+
+
+def test_handle_count_field() -> None:
+    assert handle_count_field("left") == "left_handles"
+
+
+@pytest.mark.parametrize(("raw", "expected"), [(0, 0), (3, 3), (64, 64), (65, 64), (5000, MAX_HANDLES), (-1, 0)])
+def test_clamp_handles_bounds(raw: int, expected: int) -> None:
+    assert clamp_handles("bottom", raw) == expected
+
+
+@pytest.mark.parametrize("raw", [None, "4", float("nan"), float("inf"), True])
+def test_clamp_handles_falls_back_to_the_side_default(raw: object) -> None:
+    # A missing or corrupt count still yields the historical number, per side.
+    assert clamp_handles("bottom", raw) == 1
+    assert clamp_handles("left", raw) == 0
+
+
+def test_clamp_handles_truncates_a_fraction() -> None:
+    assert clamp_handles("bottom", 3.9) == 3
+
+
+def test_handle_id_keeps_the_bare_side_name_for_slot_zero() -> None:
+    # Slot 0 stays 'bottom' so edges saved before the multi-handle expansion
+    # keep resolving.
+    assert handle_id("bottom", 0) == "bottom"
+    assert handle_id("bottom", 1) == "bottom-2"
+    assert handle_id("left", 3) == "left-4"
+
+
+def test_removed_handle_ids() -> None:
+    assert removed_handle_ids("bottom", 4, 2) == {"bottom-3", "bottom-4"}
+    assert removed_handle_ids("bottom", 2, 2) == set()
+    assert removed_handle_ids("bottom", 1, 4) == set()
+
+
+@pytest.mark.parametrize(
+    ("handle", "expected"),
+    [
+        ("top", ("top", 0)),
+        ("bottom-2", ("bottom", 1)),
+        ("left-4", ("left", 3)),
+        # The invisible target twin resolves to the same slot as its source.
+        ("right-t", ("right", 0)),
+        ("bottom-3-t", ("bottom", 2)),
+    ],
+)
+def test_parse_side_handle(handle: str, expected: tuple[str, int]) -> None:
+    assert parse_side_handle(handle) == expected
+
+
+@pytest.mark.parametrize("handle", ["cluster-right", "", "middle", "top-left", "bottom-x"])
+def test_parse_side_handle_ignores_a_foreign_namespace(handle: str) -> None:
+    # Not a per-side handle: whoever owns it interprets it, not the side counts.
+    assert parse_side_handle(handle) is None
+
+
+@pytest.mark.parametrize("handle", ["bottom-0", "bottom-1"])
+def test_parse_side_handle_reports_an_impossible_slot(handle: str) -> None:
+    # The numbered form is 2-based, so these are IDs the canvas never emits;
+    # slot -1 means no count can satisfy them.
+    assert parse_side_handle(handle) == ("bottom", -1)

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -487,3 +487,184 @@ async def test_a_device_node_never_keeps_a_description(client: AsyncClient, head
     )
     assert res.json()["description"] is None
     assert res.json()["notes"] == "Backs up nightly."
+
+
+# ---------------------------------------------------------------------------
+# Connection points (#435)
+# ---------------------------------------------------------------------------
+# Handle counts became writable over the MCP, which reaches these fields without
+# the canvas UI's own bounds and edge bookkeeping. Both now live server-side.
+
+
+async def test_handle_count_is_clamped_on_create(client: AsyncClient, headers: dict):
+    # The renderer clamps to 0..64 anyway (handleUtils.clampHandles), so an
+    # unclamped row would draw a different node than it stores.
+    res = await client.post(
+        "/api/v1/nodes",
+        json={"type": "switch", "label": "sw1", "bottom_handles": 5000, "left_handles": -3},
+        headers=headers,
+    )
+    assert res.status_code == 201
+    assert res.json()["bottom_handles"] == 64
+    assert res.json()["left_handles"] == 0
+
+
+async def test_handle_count_is_clamped_on_update(client: AsyncClient, headers: dict):
+    node_id = (
+        await client.post("/api/v1/nodes", json={"type": "switch", "label": "sw1"}, headers=headers)
+    ).json()["id"]
+
+    res = await client.patch(f"/api/v1/nodes/{node_id}", json={"right_handles": 999}, headers=headers)
+
+    assert res.status_code == 200
+    assert res.json()["right_handles"] == 64
+
+
+async def test_a_handle_count_of_zero_is_honoured(client: AsyncClient, headers: dict):
+    # 0 is a real value, not a missing one: a side can have no connection point.
+    node_id = (
+        await client.post("/api/v1/nodes", json={"type": "switch", "label": "sw1"}, headers=headers)
+    ).json()["id"]
+
+    res = await client.patch(f"/api/v1/nodes/{node_id}", json={"top_handles": 0}, headers=headers)
+
+    assert res.json()["top_handles"] == 0
+
+
+async def _edge_by_id(client: AsyncClient, headers: dict, edge_id: str) -> dict:
+    edges = (await client.get("/api/v1/edges", headers=headers)).json()
+    return next(e for e in edges if e["id"] == edge_id)
+
+
+async def test_shrinking_a_side_moves_its_edges_to_slot_zero(client: AsyncClient, headers: dict):
+    # Regression: React Flow silently drops an edge whose handle no longer
+    # exists, so the link vanishes from the canvas with no error.
+    src = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "bottom_handles": 4}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)).json()["id"]
+    edge_id = (
+        await client.post(
+            "/api/v1/edges",
+            json={"source": src, "target": tgt, "source_handle": "bottom-4", "target_handle": "top"},
+            headers=headers,
+        )
+    ).json()["id"]
+
+    await client.patch(f"/api/v1/nodes/{src}", json={"bottom_handles": 2}, headers=headers)
+
+    edge = await _edge_by_id(client, headers, edge_id)
+    assert edge["source_handle"] == "bottom"
+    assert edge["target_handle"] == "top"
+
+
+async def test_shrinking_a_side_leaves_the_surviving_handles_alone(client: AsyncClient, headers: dict):
+    src = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "bottom_handles": 4}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)).json()["id"]
+    edge_id = (
+        await client.post(
+            "/api/v1/edges",
+            json={"source": src, "target": tgt, "source_handle": "bottom-2", "target_handle": "top"},
+            headers=headers,
+        )
+    ).json()["id"]
+
+    await client.patch(f"/api/v1/nodes/{src}", json={"bottom_handles": 2}, headers=headers)
+
+    assert (await _edge_by_id(client, headers, edge_id))["source_handle"] == "bottom-2"
+
+
+async def test_a_side_dropped_to_zero_falls_back_to_bottom(client: AsyncClient, headers: dict):
+    # Slot 0 goes away with the side, so there is nothing on it to fall back to.
+    src = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "right_handles": 2}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)).json()["id"]
+    edge_id = (
+        await client.post(
+            "/api/v1/edges",
+            json={"source": src, "target": tgt, "source_handle": "right-2", "target_handle": "top"},
+            headers=headers,
+        )
+    ).json()["id"]
+
+    await client.patch(f"/api/v1/nodes/{src}", json={"right_handles": 0}, headers=headers)
+
+    assert (await _edge_by_id(client, headers, edge_id))["source_handle"] == "bottom"
+
+
+async def test_the_target_end_is_remapped_too(client: AsyncClient, headers: dict):
+    src = (await client.post("/api/v1/nodes", json={"type": "router", "label": "r1"}, headers=headers)).json()["id"]
+    tgt = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "top_handles": 3}, headers=headers
+        )
+    ).json()["id"]
+    edge_id = (
+        await client.post(
+            "/api/v1/edges",
+            json={"source": src, "target": tgt, "source_handle": "bottom", "target_handle": "top-3"},
+            headers=headers,
+        )
+    ).json()["id"]
+
+    await client.patch(f"/api/v1/nodes/{tgt}", json={"top_handles": 1}, headers=headers)
+
+    edge = await _edge_by_id(client, headers, edge_id)
+    assert edge["target_handle"] == "top"
+    assert edge["source_handle"] == "bottom"
+
+
+async def test_growing_a_side_touches_no_edge(client: AsyncClient, headers: dict):
+    src = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "bottom_handles": 2}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)).json()["id"]
+    edge_id = (
+        await client.post(
+            "/api/v1/edges",
+            json={"source": src, "target": tgt, "source_handle": "bottom-2", "target_handle": "top"},
+            headers=headers,
+        )
+    ).json()["id"]
+
+    await client.patch(f"/api/v1/nodes/{src}", json={"bottom_handles": 8}, headers=headers)
+
+    assert (await _edge_by_id(client, headers, edge_id))["source_handle"] == "bottom-2"
+
+
+async def test_another_nodes_edges_are_not_remapped(client: AsyncClient, headers: dict):
+    # The shrink is scoped to the node being edited; an unrelated link that
+    # happens to sit on the same handle ID must survive untouched.
+    shrunk = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw1", "bottom_handles": 4}, headers=headers
+        )
+    ).json()["id"]
+    other = (
+        await client.post(
+            "/api/v1/nodes", json={"type": "switch", "label": "sw2", "bottom_handles": 4}, headers=headers
+        )
+    ).json()["id"]
+    tgt = (await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)).json()["id"]
+    edge_id = (
+        await client.post(
+            "/api/v1/edges",
+            json={"source": other, "target": tgt, "source_handle": "bottom-4", "target_handle": "top"},
+            headers=headers,
+        )
+    ).json()["id"]
+
+    await client.patch(f"/api/v1/nodes/{shrunk}", json={"bottom_handles": 1}, headers=headers)
+
+    assert (await _edge_by_id(client, headers, edge_id))["source_handle"] == "bottom-4"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7194,9 +7194,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/mcp/app/backend_client.py
+++ b/mcp/app/backend_client.py
@@ -1,5 +1,48 @@
+import json
+
 import httpx
+
 from .config import settings
+
+
+class BackendError(RuntimeError):
+    """A non-2xx answer from the backend, carrying the reason it gave.
+
+    httpx's own error text stops at the status line and the URL, so FastAPI's
+    `{"detail": ...}` — the half that says what to do about it — never reached
+    the calling client. A rejected connection point, a duplicate device, a
+    missing design: all of them arrived as a bare '422 Unprocessable Content'.
+    """
+
+    def __init__(self, method: str, path: str, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"{method} {path} failed with {status_code}{suffix}")
+
+
+# Enough for a FastAPI detail — a structured one included — without pasting a
+# whole HTML error page into the client's context.
+_MAX_DETAIL = 500
+
+
+def _detail_of(resp: httpx.Response) -> str:
+    """The backend's explanation for a failed response, as a single string.
+
+    `detail` is a string for most errors and an object for the structured ones
+    (the approve-duplicate prompt); anything else falls back to the raw body.
+    """
+    try:
+        payload = resp.json()
+    except ValueError:
+        text = resp.text.strip()
+    else:
+        detail = payload.get("detail") if isinstance(payload, dict) else None
+        if detail is None:
+            text = json.dumps(payload)
+        else:
+            text = detail if isinstance(detail, str) else json.dumps(detail)
+    return text[:_MAX_DETAIL]
 
 
 class BackendClient:
@@ -19,7 +62,8 @@ class BackendClient:
 
     async def request(self, method: str, path: str, **kwargs) -> dict:
         resp = await self._client.request(method, path, **kwargs)
-        resp.raise_for_status()
+        if resp.is_error:
+            raise BackendError(method, path, resp.status_code, _detail_of(resp))
         if resp.status_code == 204:
             return {}
         return resp.json()

--- a/mcp/app/tools.py
+++ b/mcp/app/tools.py
@@ -106,6 +106,21 @@ _ZONE_COLOR_FIELDS = {
 #
 # The node must already have the connection point — left/right default to none —
 # or the backend answers 422 rather than storing an edge the canvas cannot draw.
+# Presentation, mirroring the backend EdgeBase (backend/app/schemas/edges.py) and
+# the EdgeData types the canvas draws from (frontend/src/types/index.ts). Every one
+# is optional: an omitted field keeps the edge type's own preset.
+_EDGE_STYLE_FIELDS = {
+    "animated":     {"type": "string", "enum": ["none", "basic", "snake", "flow"], "description": "Line animation. 'basic' is the dashed march, 'snake' a travelling segment, 'flow' a continuous drift."},
+    "custom_color": {"type": "string", "description": "Line colour override, e.g. '#00d4ff'. Omit to use the edge type's colour."},
+    "path_style":   {"type": "string", "enum": ["bezier", "smooth"], "description": "How the line is routed between the two connection points."},
+    "line_style":   {"type": "string", "enum": ["solid", "dashed", "dotted"], "description": "How the line itself is stroked."},
+    "width_mult":   {"type": "number", "minimum": 1, "maximum": 4, "description": "Stroke-width multiplier (1-4x) on the edge type's base width."},
+    "marker_start": {"type": "string", "enum": ["none", "arrow", "arrow-open", "circle", "diamond", "square"], "description": "Marker drawn at the source end."},
+    "marker_end":   {"type": "string", "enum": ["none", "arrow", "arrow-open", "circle", "diamond", "square"], "description": "Marker drawn at the target end."},
+    "vlan_id":      {"type": "integer", "description": "VLAN tag carried by the link. Shown on the edge for a 'vlan' type."},
+    "speed":        {"type": "string", "description": "Link speed as it should read on the canvas, e.g. '10G' or '2.5 Gbps'."},
+}
+
 _EDGE_HANDLE_FIELDS = {
     "source_handle": {"type": "string", "description": "Connection point on the source node, e.g. 'bottom' or 'right-2'. The node must have it already — raise that side's *_handles first, or the call is rejected. Omit to let the server pick."},
     "target_handle": {"type": "string", "description": "Connection point on the target node, e.g. 'top' or 'left-3'. The node must have it already — raise that side's *_handles first, or the call is rejected. Omit to let the server pick."},
@@ -158,17 +173,19 @@ def _build_tools() -> list[Tool]:
                 "target": {"type": "string"},
                 "type":   {"type": "string", "enum": EDGE_TYPES, "default": "ethernet"},
                 "label":  {"type": "string"},
+                **_EDGE_STYLE_FIELDS,
                 **_EDGE_HANDLE_FIELDS,
                 **_DESIGN_ID_FIELD,
             },
         }),
-        Tool(name="update_edge", description="Update an existing link: its type, label, or which connection points it attaches to. Call get_canvas to discover edge ids.", inputSchema={
+        Tool(name="update_edge", description="Update an existing link: its type, label, styling (animation, colour, line/path style, width, endpoint markers), or which connection points it attaches to. Call get_canvas to discover edge ids.", inputSchema={
             "type": "object",
             "required": ["id"],
             "properties": {
                 "id":    {"type": "string", "description": "Edge id."},
                 "type":  {"type": "string", "enum": EDGE_TYPES},
                 "label": {"type": "string"},
+                **_EDGE_STYLE_FIELDS,
                 **_EDGE_HANDLE_FIELDS,
             },
         }),

--- a/mcp/app/tools.py
+++ b/mcp/app/tools.py
@@ -62,6 +62,15 @@ _NODE_FIELDS = {
     # (`merge_properties` / `apply_view` in backend/app/services/inventory_sync.py).
     # A property with no `key` collapses with every other keyless one — send two
     # and the node draws one.
+    # Connection points. The count is per side; the IDs an edge references are
+    # derived from it — slot 0 is the bare side name, slot N >= 1 is
+    # '{side}-{N + 1}' (frontend/src/utils/handleUtils.ts). Lowering a count
+    # moves the edges that used the dropped handles back to the side's slot 0.
+    "top_handles":    {"type": "integer", "minimum": 0, "maximum": 64, "description": "Connection points on the top side (default 1). Their IDs are 'top', 'top-2', 'top-3', ..."},
+    "bottom_handles": {"type": "integer", "minimum": 0, "maximum": 64, "description": "Connection points on the bottom side (default 1). Their IDs are 'bottom', 'bottom-2', 'bottom-3', ..."},
+    "left_handles":   {"type": "integer", "minimum": 0, "maximum": 64, "description": "Connection points on the left side (default 0). Their IDs are 'left', 'left-2', 'left-3', ..."},
+    "right_handles":  {"type": "integer", "minimum": 0, "maximum": 64, "description": "Connection points on the right side (default 0). Their IDs are 'right', 'right-2', 'right-3', ..."},
+    "show_port_numbers": {"type": "boolean", "description": "Number each connection point on the node card."},
     "properties":    {
         "type": "array",
         "description": "Key/value metadata shown on the node. `key` is the identity: two properties sharing one are the same property.",
@@ -88,6 +97,15 @@ _ZONE_COLOR_FIELDS = {
     "border_style": {"type": "string", "enum": ["solid", "dashed", "dotted"]},
     "border_width": {"type": "number"},
     "text_color":   {"type": "string", "description": "Label colour, e.g. '#e6edf3'."},
+}
+
+# Which connection point each end of an edge attaches to. The IDs are the node's
+# per-side handle IDs (see the *_handles fields above): 'bottom', 'bottom-2',
+# 'left-3', ... Omit both on create and the backend picks them from the two nodes'
+# relative positions (_auto_handles in backend/app/api/routes/edges.py).
+_EDGE_HANDLE_FIELDS = {
+    "source_handle": {"type": "string", "description": "Connection point on the source node, e.g. 'bottom' or 'right-2'. Omit to let the server pick."},
+    "target_handle": {"type": "string", "description": "Connection point on the target node, e.g. 'top' or 'left-3'. Omit to let the server pick."},
 }
 
 # Optional design/canvas selector. The backend attaches nodes/edges to the first
@@ -129,7 +147,7 @@ def _build_tools() -> list[Tool]:
             "required": ["id"],
             "properties": {"id": {"type": "string"}},
         }),
-        Tool(name="create_edge", description="Create a network link between two nodes", inputSchema={
+        Tool(name="create_edge", description="Create a network link between two nodes. Pass source_handle/target_handle to choose which connection points it attaches to; omit them and the server picks from the nodes' relative positions.", inputSchema={
             "type": "object",
             "required": ["source", "target"],
             "properties": {
@@ -137,8 +155,23 @@ def _build_tools() -> list[Tool]:
                 "target": {"type": "string"},
                 "type":   {"type": "string", "enum": EDGE_TYPES, "default": "ethernet"},
                 "label":  {"type": "string"},
+                **_EDGE_HANDLE_FIELDS,
                 **_DESIGN_ID_FIELD,
             },
+        }),
+        Tool(name="update_edge", description="Update an existing link: its type, label, or which connection points it attaches to. Call get_canvas to discover edge ids.", inputSchema={
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id":    {"type": "string", "description": "Edge id."},
+                "type":  {"type": "string", "enum": EDGE_TYPES},
+                "label": {"type": "string"},
+                **_EDGE_HANDLE_FIELDS,
+            },
+        }),
+        Tool(name="list_edges", description="List every link with its full detail — type, label, waypoints, and the source_handle/target_handle each end attaches to. get_canvas slims edges down to id/source/target/type/label; use this when the connection points or styling matter.", inputSchema={
+            "type": "object",
+            "properties": {},
         }),
         Tool(name="delete_edge", description="Delete a network link", inputSchema={
             "type": "object",
@@ -370,6 +403,13 @@ async def _dispatch(name: str, args: dict) -> dict:
 
     if name == "create_edge":
         return await backend.post("/api/v1/edges", args)
+
+    if name == "update_edge":
+        edge_id = args.pop("id")
+        return await backend.patch(f"/api/v1/edges/{edge_id}", args)
+
+    if name == "list_edges":
+        return await backend.get("/api/v1/edges")
 
     if name == "delete_edge":
         return await backend.delete(f"/api/v1/edges/{args['id']}")

--- a/mcp/app/tools.py
+++ b/mcp/app/tools.py
@@ -103,9 +103,12 @@ _ZONE_COLOR_FIELDS = {
 # per-side handle IDs (see the *_handles fields above): 'bottom', 'bottom-2',
 # 'left-3', ... Omit both on create and the backend picks them from the two nodes'
 # relative positions (_auto_handles in backend/app/api/routes/edges.py).
+#
+# The node must already have the connection point — left/right default to none —
+# or the backend answers 422 rather than storing an edge the canvas cannot draw.
 _EDGE_HANDLE_FIELDS = {
-    "source_handle": {"type": "string", "description": "Connection point on the source node, e.g. 'bottom' or 'right-2'. Omit to let the server pick."},
-    "target_handle": {"type": "string", "description": "Connection point on the target node, e.g. 'top' or 'left-3'. Omit to let the server pick."},
+    "source_handle": {"type": "string", "description": "Connection point on the source node, e.g. 'bottom' or 'right-2'. The node must have it already — raise that side's *_handles first, or the call is rejected. Omit to let the server pick."},
+    "target_handle": {"type": "string", "description": "Connection point on the target node, e.g. 'top' or 'left-3'. The node must have it already — raise that side's *_handles first, or the call is rejected. Omit to let the server pick."},
 }
 
 # Optional design/canvas selector. The backend attaches nodes/edges to the first

--- a/mcp/tests/test_backend_client.py
+++ b/mcp/tests/test_backend_client.py
@@ -1,0 +1,92 @@
+"""The backend's own explanation must survive the trip to the MCP client.
+
+httpx's error text stops at the status line, so a rejected call used to reach the
+caller as a bare "Client error '422 Unprocessable Content'" — the reason, which is
+the only part that says what to do next, was dropped.
+"""
+
+import httpx
+import pytest
+
+from app.backend_client import BackendClient, BackendError
+
+
+def _client_answering(response: httpx.Response) -> BackendClient:
+    backend = BackendClient()
+    backend._client = httpx.AsyncClient(
+        base_url="http://backend",
+        transport=httpx.MockTransport(lambda _request: response),
+    )
+    return backend
+
+
+@pytest.mark.anyio
+async def test_a_string_detail_reaches_the_caller():
+    detail = "source_handle 'right-2' does not exist: node n1 has 0 connection point(s) on its right side."
+    backend = _client_answering(httpx.Response(422, json={"detail": detail}))
+
+    with pytest.raises(BackendError) as exc:
+        await backend.post("/api/v1/edges", {})
+
+    assert detail in str(exc.value)
+    assert "422" in str(exc.value)
+    assert exc.value.status_code == 422
+    assert exc.value.detail == detail
+
+
+@pytest.mark.anyio
+async def test_a_structured_detail_is_serialized():
+    # The approve-duplicate prompt answers with an object, not a string.
+    backend = _client_answering(httpx.Response(409, json={"detail": {"code": "duplicate", "node_id": "n1"}}))
+
+    with pytest.raises(BackendError) as exc:
+        await backend.post("/api/v1/scan/pending/d1/approve", {})
+
+    assert "duplicate" in str(exc.value)
+    assert "n1" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_a_non_json_body_falls_back_to_its_text():
+    backend = _client_answering(httpx.Response(500, text="Internal Server Error"))
+
+    with pytest.raises(BackendError) as exc:
+        await backend.get("/api/v1/nodes")
+
+    assert "Internal Server Error" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_the_method_and_path_are_named():
+    backend = _client_answering(httpx.Response(404, json={"detail": "Edge not found"}))
+
+    with pytest.raises(BackendError) as exc:
+        await backend.patch("/api/v1/edges/e1", {})
+
+    assert "PATCH" in str(exc.value)
+    assert "/api/v1/edges/e1" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_a_long_detail_is_truncated():
+    # An HTML error page must not land whole in the client's context.
+    backend = _client_answering(httpx.Response(500, text="x" * 5000))
+
+    with pytest.raises(BackendError) as exc:
+        await backend.get("/api/v1/nodes")
+
+    assert len(exc.value.detail) == 500
+
+
+@pytest.mark.anyio
+async def test_a_204_still_returns_an_empty_dict():
+    backend = _client_answering(httpx.Response(204))
+
+    assert await backend.delete("/api/v1/edges/e1") == {}
+
+
+@pytest.mark.anyio
+async def test_a_success_is_returned_unchanged():
+    backend = _client_answering(httpx.Response(200, json={"id": "e1"}))
+
+    assert await backend.get("/api/v1/edges/e1") == {"id": "e1"}

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -763,3 +763,45 @@ async def test_list_edges_returns_the_unslimmed_edges(mock_backend):
 
     mock_backend.get.assert_called_once_with("/api/v1/edges")
     assert result == [edge]
+
+
+def test_edge_schemas_expose_the_styling_fields():
+    # The backend has always accepted these; only the canvas UI could set them.
+    for tool_name in ("create_edge", "update_edge"):
+        props = _tool_schema(tool_name)
+        for field in ("animated", "custom_color", "path_style", "line_style",
+                      "width_mult", "marker_start", "marker_end", "vlan_id", "speed"):
+            assert field in props, f"{tool_name} schema missing {field}"
+
+
+def test_edge_style_enums_match_what_the_backend_normalizes():
+    # normalize_animated / normalize_marker (backend/app/schemas/utils.py) coerce
+    # anything outside these sets to 'none', so an advertised value that isn't
+    # there would silently do nothing.
+    props = _tool_schema("create_edge")
+    assert set(props["animated"]["enum"]) == {"none", "basic", "snake", "flow"}
+    markers = {"none", "arrow", "arrow-open", "circle", "diamond", "square"}
+    assert set(props["marker_start"]["enum"]) == markers
+    assert set(props["marker_end"]["enum"]) == markers
+    assert set(props["path_style"]["enum"]) == {"bezier", "smooth"}
+    assert set(props["line_style"]["enum"]) == {"solid", "dashed", "dotted"}
+    assert (props["width_mult"]["minimum"], props["width_mult"]["maximum"]) == (1, 4)
+
+
+@pytest.mark.anyio
+async def test_create_edge_forwards_the_styling_fields(mock_backend):
+    args = {
+        "source": "1", "target": "2", "type": "wifi",
+        "animated": "basic", "custom_color": "#00d4ff", "line_style": "dashed",
+        "width_mult": 2, "marker_end": "arrow", "vlan_id": 20, "speed": "10G",
+    }
+    await _dispatch("create_edge", dict(args))
+    mock_backend.post.assert_called_once_with("/api/v1/edges", args)
+
+
+@pytest.mark.anyio
+async def test_update_edge_forwards_the_styling_fields(mock_backend):
+    await _dispatch("update_edge", {"id": "e7", "animated": "flow", "path_style": "smooth"})
+    mock_backend.patch.assert_called_once_with(
+        "/api/v1/edges/e7", {"animated": "flow", "path_style": "smooth"}
+    )

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -688,3 +688,78 @@ def test_update_node_documents_that_status_is_observed_not_set():
     tool = next(t for t in TOOLS if t.name == "update_node")
     description = tool.inputSchema["properties"]["status"]["description"]
     assert "status checker" in description and "unknown" in description
+
+
+# ---------------------------------------------------------------------------
+# Connection points (#435)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", ["create_node", "update_node"])
+def test_node_schemas_expose_the_handle_counts(tool_name):
+    # They were readable through get_node but not settable — the whole of #435.
+    props = _tool_schema(tool_name)
+    for side in ("top", "bottom", "left", "right"):
+        field = f"{side}_handles"
+        assert field in props, f"{tool_name} schema missing {field}"
+        assert props[field]["minimum"] == 0
+        assert props[field]["maximum"] == 64
+    assert "show_port_numbers" in props
+
+
+def test_edge_schemas_expose_the_connection_points():
+    for tool_name in ("create_edge", "update_edge"):
+        props = _tool_schema(tool_name)
+        assert "source_handle" in props, f"{tool_name} schema missing source_handle"
+        assert "target_handle" in props, f"{tool_name} schema missing target_handle"
+
+
+def test_update_edge_schema_cannot_repoint_or_move_an_edge():
+    # EdgeUpdate carries neither source/target nor design_id: an edge is deleted
+    # and recreated to change what it connects, never patched.
+    props = _tool_schema("update_edge")
+    assert props.keys() >= {"id"}
+    for absent in ("source", "target", "design_id"):
+        assert absent not in props
+
+
+@pytest.mark.anyio
+async def test_update_node_forwards_handle_counts(mock_backend):
+    await _dispatch("update_node", {"id": "42", "left_handles": 3, "right_handles": 0})
+    mock_backend.patch.assert_called_once_with(
+        "/api/v1/nodes/42", {"left_handles": 3, "right_handles": 0}
+    )
+
+
+@pytest.mark.anyio
+async def test_create_node_forwards_handle_counts(mock_backend):
+    args = {"type": "switch", "label": "sw1", "bottom_handles": 8, "show_port_numbers": True}
+    await _dispatch("create_node", dict(args))
+    mock_backend.post.assert_called_once_with("/api/v1/nodes", args)
+
+
+@pytest.mark.anyio
+async def test_create_edge_forwards_explicit_handles(mock_backend):
+    args = {"source": "1", "target": "2", "source_handle": "bottom-3", "target_handle": "left"}
+    await _dispatch("create_edge", dict(args))
+    mock_backend.post.assert_called_once_with("/api/v1/edges", args)
+
+
+@pytest.mark.anyio
+async def test_update_edge_patches_by_id(mock_backend):
+    await _dispatch("update_edge", {"id": "e7", "source_handle": "right-2", "label": "uplink"})
+    mock_backend.patch.assert_called_once_with(
+        "/api/v1/edges/e7", {"source_handle": "right-2", "label": "uplink"}
+    )
+
+
+@pytest.mark.anyio
+async def test_list_edges_returns_the_unslimmed_edges(mock_backend):
+    # get_canvas slims source_handle/target_handle away; this is how they're read.
+    edge = {"id": "e1", "source": "1", "target": "2", "source_handle": "bottom-2", "target_handle": "top"}
+    mock_backend.get = AsyncMock(return_value=[edge])
+
+    result = await _dispatch("list_edges", {})
+
+    mock_backend.get.assert_called_once_with("/api/v1/edges")
+    assert result == [edge]


### PR DESCRIPTION
## What

Connection points were readable over MCP but not editable: `top/bottom/left/right_handles`
came back from `get_node` yet were absent from the `update_node` schema, and `create_edge`
took no handle arguments, so the server always picked which points an edge attached to.
This exposes both, and closes the two backend gaps that opening them up would otherwise
turn into silent link loss.

Closes #435.

## Changes

**MCP (`mcp/app/tools.py`)**
- `create_node` and `update_node` now take `top_handles`, `bottom_handles`, `left_handles`,
  `right_handles` and `show_port_numbers`. The field descriptions carry the handle-ID
  convention (slot 0 is the bare side name, slot N >= 1 is `bottom-2`, `left-3`, ...) so a
  client can build a valid handle ID without reading the frontend source.
- `create_edge` takes `source_handle` / `target_handle`. Omitting them keeps the existing
  behaviour, where the backend infers the pair from the two nodes' relative positions.
- New `update_edge` tool (`PATCH /api/v1/edges/{id}`): type, label and both handles. It
  deliberately advertises no `source` / `target` / `design_id`, because `EdgeUpdate` cannot
  repoint or move an edge.
- New `list_edges` tool. `get_canvas` slims edges down to id/source/target/type/label, so
  the handles an edge sits on were unreadable through any tool; this returns them in full.

**Backend** — both of these were previously unreachable, since only the canvas UI wrote
handle counts. The MCP write tools reach them without the UI's own bounds and bookkeeping.
- Handle counts are clamped to 0..64 on every write path: `NodeBase`, `NodeUpdate` and the
  canvas-save `NodeSave` schema. The renderer clamps again at draw time, so an unclamped row
  drew a different node than it stored.
- `_remap_shrunk_handles` in the node PATCH route ports the canvas store's remap
  (`canvasStore.updateNode`) to the server: when a side's count drops, edges left on a
  deleted handle move to that side's slot 0, or to `bottom` when the side went to zero.
  Without it React Flow silently stops drawing the edge, with no error anywhere.
- Shared handle vocabulary in `app/schemas/utils.py` (`SIDES`, `clamp_handles`, `handle_id`,
  `removed_handle_ids`), mirroring `frontend/src/utils/handleUtils.ts`.

No migration, no breaking change: every new field is optional, and the clamp only narrows
values the renderer already refused to draw.

## Testing

- `backend/tests/test_nodes.py` — clamp on create and update, an explicit count of 0 honoured,
  the shrink remap on the source and target ends, a side dropped to zero, growing a side as a
  no-op, and another node's edges left untouched.
- `backend/tests/test_canvas.py` — the same clamp on the full-canvas save path.
- `mcp/tests/test_tools.py` — the new schema fields on all four tools, `update_edge` refusing
  to advertise source/target/design_id, and dispatch/forwarding for each new tool.
- Verified the remap tests fail with the remap call removed, so they are not vacuous.
- `cd backend && ruff check . && mypy app/ && pytest` — clean, 1258 passed / 8 skipped.
  `cd mcp && pytest` — 306 passed. Frontend untouched.

ha-relevant: no
