### PR TITLE
fix(device-merge): guard nullable discovered_at sort; dedupe once per reconcile batch

### DIFF
--- a/backend/app/services/device_merge.py
+++ b/backend/app/services/device_merge.py
@@ -262,6 +262,8 @@ async def merge_devices(
     db: AsyncSession,
     winner: InventoryDevice,
     losers: list[InventoryDevice],
+    *,
+    dedupe_nodes: bool = True,
 ) -> dict[str, Any]:
     """Fold ``losers`` into ``winner``. Does not commit — the caller owns that.
 
@@ -286,7 +288,7 @@ async def merge_devices(
     loser_ids = [row.id for row in losers]
     # Oldest first: where two losers both fill the same gap, the older sighting
     # is the one that has survived longest without being contradicted.
-    for loser in sorted(losers, key=lambda d: (d.discovered_at, d.id)):
+    for loser in sorted(losers, key=lambda d: (d.discovered_at or datetime.min, d.id)):
         for field in _FILL_SCALARS:
             if _blank(getattr(winner, field, None)):
                 value = getattr(loser, field, None)
@@ -335,9 +337,11 @@ async def merge_devices(
         await _rewrite_links(db, winner.ieee_address, loser_ieees)
 
     # Two nodes on one canvas may now draw the survivor — that is exactly the
-    # same-design duplicate the node repair collapses.
-    await dedupe_nodes_by_device(db)
-    await db.flush()
+    # same-design duplicate the node repair collapses. Batch callers set
+    # dedupe_nodes=False and run dedupe_nodes_by_device once after all merges.
+    if dedupe_nodes:
+        await dedupe_nodes_by_device(db)
+        await db.flush()
 
     logger.info(
         "Inventory merge: %d row(s) folded into %s (%s)",
@@ -378,7 +382,7 @@ def _pick_winner(group: list[InventoryDevice]) -> InventoryDevice:
         key=lambda d: (
             0 if d.ieee_address else 1,
             0 if d.status == "approved" else 1,
-            d.discovered_at,
+            d.discovered_at or datetime.min,
             d.id,
         ),
     )[0]
@@ -442,6 +446,11 @@ async def reconcile_duplicates(db: AsyncSession) -> int:
     merged = 0
     for group in _auto_groups(list(rows)):
         winner = _pick_winner(group)
-        result = await merge_devices(db, winner, [row for row in group if row is not winner])
+        result = await merge_devices(
+            db, winner, [row for row in group if row is not winner], dedupe_nodes=False
+        )
         merged += int(result["merged"])
+    if merged:
+        await dedupe_nodes_by_device(db)
+        await db.flush()
     return merged

--- a/backend/app/services/device_merge.py
+++ b/backend/app/services/device_merge.py
@@ -24,7 +24,7 @@ here, so the declared ``ON DELETE SET NULL`` never fires.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import or_, select, update
@@ -77,10 +77,30 @@ def _blank(value: Any) -> bool:
     return value is None or value == ""
 
 
+def _naive(value: datetime | None) -> datetime:
+    """A stored timestamp in a form two rows can be compared in.
+
+    SQLite keeps no offset, so a row read back from the database carries a naive
+    datetime while a row created in this session still holds the tz-aware value
+    ``_now`` gave it — and ``expire_on_commit=False`` means no commit ever
+    reconciles the two. A reconcile pass sorts exactly those two together (a
+    scan is where a row first learns the MAC that proves it a duplicate), so
+    comparing them raw raises ``TypeError: can't compare offset-naive and
+    offset-aware datetimes`` and aborts the merge. Normalise to naive UTC before
+    every comparison. ``datetime.min`` stands in for no timestamp at all, which
+    the column forbids but a hand-edited database could still hold.
+    """
+    if value is None:
+        return datetime.min
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 def _newest(left: datetime | None, right: datetime | None) -> datetime | None:
     if left is None or right is None:
         return left or right
-    return max(left, right)
+    return max(left, right, key=_naive)
 
 
 def _merged_ip(winner: str | None, loser: str | None) -> str | None:
@@ -288,7 +308,7 @@ async def merge_devices(
     loser_ids = [row.id for row in losers]
     # Oldest first: where two losers both fill the same gap, the older sighting
     # is the one that has survived longest without being contradicted.
-    for loser in sorted(losers, key=lambda d: (d.discovered_at or datetime.min, d.id)):
+    for loser in sorted(losers, key=lambda d: (_naive(d.discovered_at), d.id)):
         for field in _FILL_SCALARS:
             if _blank(getattr(winner, field, None)):
                 value = getattr(loser, field, None)
@@ -307,7 +327,7 @@ async def merge_devices(
         winner.last_scan = _newest(winner.last_scan, loser.last_scan)
         # The device has been known since the earliest of the rows saw it.
         if loser.discovered_at and winner.discovered_at:
-            winner.discovered_at = min(winner.discovered_at, loser.discovered_at)
+            winner.discovered_at = min(winner.discovered_at, loser.discovered_at, key=_naive)
 
     winner.status = _merged_status(winner.status, losers)
 
@@ -382,7 +402,7 @@ def _pick_winner(group: list[InventoryDevice]) -> InventoryDevice:
         key=lambda d: (
             0 if d.ieee_address else 1,
             0 if d.status == "approved" else 1,
-            d.discovered_at or datetime.min,
+            _naive(d.discovered_at),
             d.id,
         ),
     )[0]

--- a/backend/tests/test_device_merge.py
+++ b/backend/tests/test_device_merge.py
@@ -22,7 +22,7 @@ from app.db.models import (
     Rack,
     RackDevice,
 )
-from app.services.device_merge import merge_devices, reconcile_duplicates
+from app.services.device_merge import _naive, _newest, merge_devices, reconcile_duplicates
 
 
 def _at(day: int) -> datetime:
@@ -348,34 +348,63 @@ async def test_reconcile_is_idempotent(db_session):
     assert await reconcile_duplicates(db_session) == 0
 
 
-# --- Regression: nullable discovered_at (#439) ---------------------------
+# --- Regression: mixed tz-awareness on discovered_at (#440) --------------
+#
+# Every other test in this file builds both rows in one session, so both carry
+# the tz-aware value the column default gave them and every comparison is
+# naive-vs-naive or aware-vs-aware. Production is not like that: SQLite stores
+# no offset, so a row read back is naive, while a row this session just created
+# is aware — and `expire_on_commit=False` means no commit reconciles them.
+# `expire_all` reproduces that split, which is the state a scan reconcile runs
+# in: it is where a row first learns the MAC that proves it a duplicate.
+
+
+async def _stored(db, **kwargs):
+    """A row as it comes back from the database — naive, offset dropped."""
+    device = await _device(db, **kwargs)
+    await db.flush()
+    db.expire_all()
+    await db.refresh(device)
+    return device
 
 
 @pytest.mark.asyncio
-async def test_merge_devices_tolerates_null_discovered_at(db_session):
-    """A loser with discovered_at=None must not raise TypeError in the sort key."""
-    winner = await _device(db_session, id="w", ip="10.0.0.1", mac="aa:bb:cc:dd:ee:01")
-    loser = InventoryDevice(id="l", ip="10.0.0.2", mac="aa:bb:cc:dd:ee:02", discovered_at=None)
-    db_session.add(loser)
+async def test_merge_devices_compares_stored_and_session_timestamps(db_session):
+    """A loser read from the database must sort against a winner created here."""
+    stored = await _stored(db_session, id="l", ip="10.0.0.2", mac="aa:bb:cc:dd:ee:02")
+    assert stored.discovered_at.tzinfo is None, "row from the database should be naive"
+    winner = InventoryDevice(id="w", ip="10.0.0.1", mac="aa:bb:cc:dd:ee:01")
+    db_session.add(winner)
     await db_session.flush()
+    assert winner.discovered_at.tzinfo is not None, "row made here should be tz-aware"
 
-    result = await merge_devices(db_session, winner, [loser])
+    result = await merge_devices(db_session, winner, [stored])
     assert result["merged"] == 1
+    # The survivor keeps the earlier sighting, whichever form it was stored in.
+    assert _naive(winner.discovered_at) == _naive(stored.discovered_at)
 
 
 @pytest.mark.asyncio
-async def test_reconcile_tolerates_null_discovered_at(db_session):
-    """reconcile_duplicates must not abort when a row has discovered_at=None."""
-    await _device(db_session, id="a", mac="aa:bb:cc:dd:ee:ff", discovered_at=_at(1))
-    loser = InventoryDevice(id="b", mac="aa:bb:cc:dd:ee:ff", discovered_at=None)
-    db_session.add(loser)
+async def test_reconcile_compares_stored_and_session_timestamps(db_session):
+    """A scan reconcile folds a row it just made into one already on disk."""
+    await _stored(db_session, id="a", mac="aa:bb:cc:dd:ee:ff")
+    fresh = InventoryDevice(id="b", mac="aa:bb:cc:dd:ee:ff")
+    db_session.add(fresh)
     await db_session.flush()
 
-    merged = await reconcile_duplicates(db_session)
-    assert merged == 1
+    assert await reconcile_duplicates(db_session) == 1
 
 
-# --- Regression: dedupe called once per reconcile batch (#450) -----------
+@pytest.mark.asyncio
+async def test_newest_compares_stored_and_session_timestamps():
+    """`last_seen`/`last_scan` carry the same split — scanner writes them aware."""
+    stored = datetime(2026, 1, 2)
+    fresh = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert _newest(stored, fresh) is stored
+    assert _newest(fresh, stored) is stored
+
+
+# --- Regression: dedupe called once per reconcile batch ------------------
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_device_merge.py
+++ b/backend/tests/test_device_merge.py
@@ -8,6 +8,7 @@ that never saw them.
 """
 
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import select
@@ -345,6 +346,55 @@ async def test_reconcile_is_idempotent(db_session):
     assert await reconcile_duplicates(db_session) == 1
     await db_session.flush()
     assert await reconcile_duplicates(db_session) == 0
+
+
+# --- Regression: nullable discovered_at (#439) ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_devices_tolerates_null_discovered_at(db_session):
+    """A loser with discovered_at=None must not raise TypeError in the sort key."""
+    winner = await _device(db_session, id="w", ip="10.0.0.1", mac="aa:bb:cc:dd:ee:01")
+    loser = InventoryDevice(id="l", ip="10.0.0.2", mac="aa:bb:cc:dd:ee:02", discovered_at=None)
+    db_session.add(loser)
+    await db_session.flush()
+
+    result = await merge_devices(db_session, winner, [loser])
+    assert result["merged"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_tolerates_null_discovered_at(db_session):
+    """reconcile_duplicates must not abort when a row has discovered_at=None."""
+    await _device(db_session, id="a", mac="aa:bb:cc:dd:ee:ff", discovered_at=_at(1))
+    loser = InventoryDevice(id="b", mac="aa:bb:cc:dd:ee:ff", discovered_at=None)
+    db_session.add(loser)
+    await db_session.flush()
+
+    merged = await reconcile_duplicates(db_session)
+    assert merged == 1
+
+
+# --- Regression: dedupe called once per reconcile batch (#450) -----------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_calls_dedupe_nodes_once_regardless_of_group_count(db_session):
+    """dedupe_nodes_by_device must be called exactly once even with N merge groups."""
+    for i in range(3):
+        mac = f"aa:bb:cc:dd:ee:{i:02x}"
+        await _device(db_session, id=f"a{i}", mac=mac, discovered_at=_at(1))
+        await _device(db_session, id=f"b{i}", mac=mac, discovered_at=_at(2))
+
+    with patch(
+        "app.services.device_merge.dedupe_nodes_by_device", new_callable=AsyncMock
+    ) as mock_dedupe:
+        merged = await reconcile_duplicates(db_session)
+
+    assert merged == 3
+    assert mock_dedupe.call_count == 1, (
+        f"dedupe_nodes_by_device called {mock_dedupe.call_count} times; expected 1"
+    )
 
 
 # --- The route -----------------------------------------------------------


### PR DESCRIPTION
## Summary

Two unrelated bugs in `backend/app/services/device_merge.py`, both found during automated review of the SNMP/UniFi PR series.

### Fix 1 — `discovered_at` comparison raises TypeError (#440)

`reconcile_duplicates` aborts with `TypeError` and leaves duplicates in place. Original diagnosis was a nullable `discovered_at`; that turned out to be wrong, and the fix has been amended in place — see the review comment below for the full working.

The column is not nullable in practice: `Mapped[datetime]` with `default=_now`, never `Optional` in any commit, no `ADD COLUMN` backfill, no non-ORM writer. SQLAlchemy also substitutes the column default over an explicitly assigned `None`, so the original regression tests passed on unpatched `main`.

The real cause is mixed tz-awareness. SQLite stores no offset, so a row read back from the database is naive while a row the current session created still holds the tz-aware value `_now` gave it — and `expire_on_commit=False` (`database.py:97`) means no commit reconciles the two:

```
new tz: UTC   old tz: None
TypeError: can't compare offset-naive and offset-aware datetimes
```

A reconcile pass sorts exactly those two together. Per `scanner.py:870`, "a scan is where a row first learns its MAC", so the group is one fresh row plus one stored row and `_pick_winner` raises before the loser sort is reached. The scanner's `except Exception` swallows it into `status="error"` on the run; `proxmox.py:329` has no guard and 500s.

**Fix**: a `_naive()` normaliser to naive UTC, applied at all four comparison sites — both sort keys, the `discovered_at` fold, and `_newest`, which carries the same split for `last_seen`/`last_scan` (the scanner writes those tz-aware at `scanner.py:756,769`).

### Fix 2 — `dedupe_nodes_by_device` called per merge group, O(N x nodes)

`merge_devices` called `dedupe_nodes_by_device(db)` unconditionally at the end, which performs a full `SELECT * FROM nodes WHERE device_id IS NOT NULL` scan. `reconcile_duplicates` calls `merge_devices` once per duplicate group, so N groups produce N unbounded node scans inside one transaction.

**Fix**: add a `dedupe_nodes: bool = True` kwarg to `merge_devices` (the default preserves existing behaviour for manual user-triggered merges). `reconcile_duplicates` passes `dedupe_nodes=False` and calls `dedupe_nodes_by_device` once after all groups are processed — O(node_count) instead of O(N x node_count).

## Test plan

- [x] A merge where one row comes from the database and one was created in-session — succeeds without TypeError
- [x] `reconcile_duplicates` across that same split — folds the pair
- [x] `_newest` compares a stored naive timestamp against a session-fresh tz-aware one
- [x] `reconcile_duplicates` with multiple duplicate groups — one `dedupe_nodes_by_device` call
- [x] Manual merge via UI/API still dedupes nodes (default `dedupe_nodes=True` path)
- [x] ruff + mypy clean, full backend suite green

The three tz tests reproduce the split with `expire_all()` rather than building both rows in one session, and fail on the `or datetime.min` key they replace. That in-session uniformity is why the existing suite never caught this.

Closes #440
