### PR TITLE
fix(docs): remove text node from zone resolution; don't cache FTS5 probe failure

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -62,7 +62,7 @@ router = APIRouter()
 
 # Node.type values that are canvas furniture. A zone or a group is documented
 # through its node; everything else is documented through its device.
-_FURNITURE_TYPES = {"group", "groupRect", "text"}
+_FURNITURE_TYPES = {"group", "groupRect"}
 
 _INTERVAL = re.compile(r"^\s*(\d+)\s*([dwmy])\s*$", re.IGNORECASE)
 _INTERVAL_DAYS = {"d": 1, "w": 7, "m": 30, "y": 365}

--- a/backend/app/services/doc_search.py
+++ b/backend/app/services/doc_search.py
@@ -40,8 +40,12 @@ async def fts_available(db: AsyncSession) -> bool:
             await db.execute(text("SELECT doc_id FROM documents_fts LIMIT 1"))
             _available = True
         except OperationalError:
-            _available = False
+            # Don't cache False: a transient startup error (container ordering
+            # race, brief DB unavailability) would permanently disable FTS5 for
+            # the process lifetime. Re-probe each call until the index confirms
+            # it exists; the probe is a single cheap SELECT.
             logger.info("FTS5 unavailable — document search falls back to LIKE")
+            return False
     return _available
 
 

--- a/backend/tests/test_doc_search.py
+++ b/backend/tests/test_doc_search.py
@@ -170,3 +170,38 @@ def test_excerpt_centres_on_the_match():
 
 def test_excerpt_falls_back_to_the_head_when_there_is_no_match():
     assert doc_search._excerpt("short body", "absent") == "short body"
+
+
+# ── Regression: FTS5 probe failure must not cache False (#448) ──────────────
+
+
+async def test_fts_probe_failure_does_not_permanently_disable_search(db_session: AsyncSession):
+    """A transient OperationalError must not set _available=False for the session.
+
+    After the probe fails (FTS table dropped), reset_availability_cache() clears
+    the flag and the next call re-probes. Before the fix the second call would
+    return False because the failure was cached.
+    """
+    docs = await _seed(db_session)
+
+    # Simulate a transient unavailability: drop the table, probe (returns False),
+    # then restore it.
+    await db_session.execute(text("DROP TABLE documents_fts"))
+    doc_search.reset_availability_cache()
+    result = await doc_search.fts_available(db_session)
+    assert result is False
+
+    # After the fix, _available must still be None (not cached False), so the
+    # next probe after FTS5 comes back wins.
+    assert doc_search._available is None
+
+    # Restore the table and re-index — probe should now succeed.
+    await db_session.execute(text(
+        "CREATE VIRTUAL TABLE documents_fts USING fts5(doc_id, title, tags, body)"
+    ))
+    for doc in docs:
+        await doc_search.index_document(db_session, doc)
+    await db_session.flush()
+
+    result = await doc_search.fts_available(db_session)
+    assert result is True

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -211,6 +211,40 @@ async def test_a_device_document_records_its_zone_and_neighbours(client: AsyncCl
     assert "`switch-core`" in doc["body"]
 
 
+async def test_text_annotation_node_is_not_used_as_zone_label(client: AsyncClient, headers: dict):
+    """A device parented in a text annotation must not inherit the annotation as its zone.
+
+    Regression for #446: _FURNITURE_TYPES included 'text', causing arbitrary
+    annotation content to appear as zone_label in the generated device document.
+    """
+    design_id = await _design(client, headers)
+    device = await _device(client, headers)
+    text_node = await client.post(
+        "/api/v1/nodes",
+        json={"type": "text", "label": "⚠ maintenance zone", "design_id": design_id, "pos_x": 0, "pos_y": 0},
+        headers=headers,
+    )
+    text_id = text_node.json()["id"]
+    await client.post(
+        "/api/v1/nodes",
+        json={
+            "type": "nas",
+            "label": "nas-01",
+            "design_id": design_id,
+            "ip": "192.168.1.20",
+            "hostname": "nas-01.lan",
+            "parent_id": text_id,
+            "pos_x": 0,
+            "pos_y": 0,
+        },
+        headers=headers,
+    )
+
+    doc = await _create(client, headers, title="nas-01", kind="device", device_id=device["id"])
+    assert "maintenance zone" not in doc["body"]
+    assert "Zone" not in doc["body"]
+
+
 # ── blocks ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Two independent bugs found during automated review of the SNMP/UniFi PR series.

### Fix 1 — text annotation node used as zone label (#446)

`_FURNITURE_TYPES` in `backend/app/api/routes/documents.py` included `'text'`. The `_device_context` function walks up the parent chain to find the zone a device belongs to, and stops at the first node whose type is in `_FURNITURE_TYPES`. If a device node is parented inside a canvas text annotation (e.g. a caption `"⚠ maintenance zone"`), that annotation's content becomes `zone_label` in the generated device document — producing a Physical Location entry that looks valid but reflects arbitrary annotation text.

Text nodes are not zones. Only `group` and `groupRect` nodes represent named zones.

**Fix**: remove `'text'` from `_FURNITURE_TYPES`.

### Fix 2 — transient startup error permanently disables FTS5 (#448)

`fts_available()` in `backend/app/services/doc_search.py` cached `_available = False` on `OperationalError`. A transient DB unreachability at startup (container ordering race, brief connection failure) permanently disabled full-text search for the entire process lifetime — all searches fell back to `LIKE` with no ranking, even after the DB recovered.

**Fix**: only cache `True`. On `OperationalError`, log and return `False` without writing to `_available`, so the next request retries the cheap `SELECT` probe.

## Test plan

- [ ] Device node parented inside a text annotation → generated doc shows no zone, not the annotation text
- [ ] Device node parented inside a `group` → generated doc shows the group label as zone
- [ ] Restart with DB temporarily unreachable; after DB comes up, FTS5 search works (not permanently degraded to LIKE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1RFEtMaB6wcHC9ck6fgjb