### PR TITLE
fix(mcp): guard None client in BackendClient.request; avoid redundant inventory fetch

### DIFF
--- a/mcp/app/backend_client.py
+++ b/mcp/app/backend_client.py
@@ -61,6 +61,8 @@ class BackendClient:
             await self._client.aclose()
 
     async def request(self, method: str, path: str, **kwargs) -> dict:
+        if self._client is None:
+            raise BackendError(method, path, 0, "Backend client not initialized — startup failed")
         resp = await self._client.request(method, path, **kwargs)
         if resp.is_error:
             raise BackendError(method, path, resp.status_code, _detail_of(resp))

--- a/mcp/app/racks.py
+++ b/mcp/app/racks.py
@@ -668,13 +668,16 @@ def _relocate_after_shrink(state: dict[str, Any], rack: dict[str, Any]) -> None:
         settled.append(device)
 
 
-async def _mount_device(design_id: str, args: dict[str, Any]) -> dict[str, Any]:
+async def _mount_device(
+    design_id: str, args: dict[str, Any], inventory: dict[str, Any] | None = None
+) -> dict[str, Any]:
     state = await _load_state(design_id)
     rack = _rack_or_raise(state, args["rack_id"])
 
-    inventory = cast(
-        dict[str, Any], await backend.get(f"/api/v1/racks/inventory?design_id={quote(design_id)}")
-    )
+    if inventory is None:
+        inventory = cast(
+            dict[str, Any], await backend.get(f"/api/v1/racks/inventory?design_id={quote(design_id)}")
+        )
     item = next(
         (i for i in inventory.get("items", []) if i["id"] == args["inventory_device_id"]), None
     )

--- a/mcp/tests/test_backend_client.py
+++ b/mcp/tests/test_backend_client.py
@@ -90,3 +90,19 @@ async def test_a_success_is_returned_unchanged():
     backend = _client_answering(httpx.Response(200, json={"id": "e1"}))
 
     assert await backend.get("/api/v1/edges/e1") == {"id": "e1"}
+
+
+@pytest.mark.anyio
+async def test_request_before_start_raises_backend_error_not_attribute_error():
+    """A BackendClient that was never started must raise BackendError, not AttributeError.
+
+    Regression for #444: _client is None until start() is called; a degraded
+    startup left it None and every tool call crashed with an opaque AttributeError.
+    """
+    backend = BackendClient()
+
+    with pytest.raises(BackendError) as exc:
+        await backend.get("/api/v1/nodes")
+
+    assert exc.value.status_code == 0
+    assert "not initialized" in exc.value.detail.lower()


### PR DESCRIPTION
## Summary

Two related robustness fixes in the MCP layer, found during automated review of the SNMP/UniFi PR series.

### Fix 1 — BackendClient.request dereferences None on degraded startup (#444)

`BackendClient._client` is typed `httpx.AsyncClient | None` and initialized to `None` in `__init__`. If `start()` fails (network error, bad config), `_client` stays `None` and the server can start in a degraded state. Any subsequent MCP tool call reached `self._client.request(...)` and raised `AttributeError: 'NoneType' object has no attribute 'request'` — an opaque crash with no diagnostic for the MCP client.

**Fix**: add a guard at the top of `request()` that raises `BackendError` with a clear message before touching `_client`.

### Fix 2 — `_mount_device` always fetches inventory — redundant in batch callers (#453)

`_mount_device` always issued a `GET /api/v1/racks/inventory` to verify the target device and check racked status. Callers that already hold the inventory (e.g. a batch loop over `list_rack_inventory` results) paid an extra round-trip per mount.

**Fix**: add `inventory: dict | None = None` kwarg to `_mount_device`. The caller can pass pre-fetched data; `None` (default) preserves the existing fetch behaviour.

## Test plan

- [ ] With `BACKEND_URL` unreachable at MCP startup: any tool call returns a `BackendError` message, not `AttributeError`
- [ ] `mount_device` with `inventory=None` (default): fetches as before, mounts correctly
- [ ] Batch mount scenario with pre-fetched inventory: no extra GET issued per mount

Closes #444, #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1RFEtMaB6wcHC9ck6fgjb