### PR TITLE
fix(documents): validate design_id on creation — reject nonexistent designs with 404

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.db.database import get_db
-from app.db.models import Document, DocumentRevision, Edge, InventoryDevice, Node, Rack, RackDevice
+from app.db.models import Design, Document, DocumentRevision, Edge, InventoryDevice, Node, Rack, RackDevice
 from app.schemas.documents import (
     BacklinkHit,
     CoverageResponse,
@@ -520,6 +520,7 @@ async def create_document(
     for link, model, what in (
         (body.device_id, InventoryDevice, "Device"),
         (body.node_id, Node, "Node"),
+        (body.design_id, Design, "Design"),
     ):
         if link and not await db.get(model, link):
             raise HTTPException(404, f"{what} not found")

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -131,6 +131,15 @@ async def test_create_rejects_a_device_that_does_not_exist(client: AsyncClient, 
     assert res.status_code == 404
 
 
+async def test_create_rejects_a_design_that_does_not_exist(client: AsyncClient, headers: dict):
+    res = await client.post(
+        "/api/v1/documents",
+        json={"title": "X", "kind": "design", "design_id": str(uuid.uuid4())},
+        headers=headers,
+    )
+    assert res.status_code == 404
+
+
 async def test_a_device_gets_at_most_one_document(client: AsyncClient, headers: dict):
     device = await _device(client, headers)
     body = {"title": "nas", "kind": "device", "device_id": device["id"]}


### PR DESCRIPTION
## Summary

`POST /documents` with `kind='design'` and a nonexistent `design_id` returned 201 and stored a permanently orphaned `Document` row. `device_id` and `node_id` were validated via `db.get()` in the existing validation loop; `design_id` was absent from that loop.

## Fix

Add `(body.design_id, Design, "Design")` to the existing three-tuple validation loop and import `Design` from `app.db.models`.

```python
for link, model, what in (
    (body.device_id, InventoryDevice, "Device"),
    (body.node_id, Node, "Node"),
    (body.design_id, Design, "Design"),   # ← added
):
    if link and not await db.get(model, link):
        raise HTTPException(404, f"{what} not found")
```

## Test plan

- [ ] `POST /documents` with a nonexistent `design_id` → 404
- [ ] `POST /documents` with a valid `design_id` → 201 as before
- [ ] `pytest tests/test_documents.py::test_create_rejects_a_design_that_does_not_exist` passes

Closes #439

