### PR TITLE
fix(device-merge): warn when multiple loser IEEE addresses collapse into one

### DIFF
--- a/backend/app/services/device_merge.py
+++ b/backend/app/services/device_merge.py
@@ -323,6 +323,12 @@ async def merge_devices(
         # `ieee_address` is UNIQUE, so the address can only move once the row
         # holding it is gone — assigned after the delete below.
         adopted = loser_ieees[0]
+        if len(loser_ieees) > 1:
+            logger.warning(
+                "Inventory merge: winner %s has no IEEE address; adopting %s "
+                "and discarding %d other IEEE address(es): %s",
+                winner.id, adopted, len(loser_ieees) - 1, loser_ieees[1:],
+            )
 
     for loser in losers:
         await db.delete(loser)

--- a/backend/tests/test_device_merge.py
+++ b/backend/tests/test_device_merge.py
@@ -7,6 +7,7 @@ document, and not the *visibility* of the facts that just arrived on a canvas
 that never saw them.
 """
 
+import logging
 from datetime import datetime, timezone
 
 import pytest
@@ -403,3 +404,28 @@ async def test_merge_route_requires_auth(client, db_session):
         "/api/v1/scan/pending/merge", json={"winner_id": "w", "loser_ids": ["l"]}
     )
     assert res.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_merge_warns_when_multiple_loser_ieees_collapse(db_session, caplog):
+    # Winner has no IEEE; two losers each have a distinct IEEE address.
+    # Only the first can be adopted (ieee_address is UNIQUE). Verify a
+    # WARNING is emitted so operators can see the discarded address.
+    winner = await _device(db_session, id="w", ip="10.0.0.1")
+    loser1 = await _device(db_session, id="l1", ip="10.0.0.2",
+                            ieee_address="aa:bb:cc:dd:ee:01")
+    loser2 = await _device(db_session, id="l2", ip="10.0.0.3",
+                            ieee_address="aa:bb:cc:dd:ee:02")
+    await db_session.commit()
+
+    with caplog.at_level(logging.WARNING, logger="app.services.device_merge"):
+        await merge_devices(db_session, winner, [loser1, loser2])
+        await db_session.commit()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING
+                and "discarding" in r.message]
+    assert warnings, "expected a WARNING about discarded IEEE address(es)"
+    assert "aa:bb:cc:dd:ee:02" in warnings[0].message
+    # Winner adopts the first loser's address
+    await db_session.refresh(winner)
+    assert winner.ieee_address == "aa:bb:cc:dd:ee:01"


### PR DESCRIPTION
## Summary

When `merge_devices` is called with a winner that has no `ieee_address` and multiple losers each carry a distinct `ieee_address`, only the first loser's address can be adopted — `ieee_address` has a UNIQUE constraint, so once the surviving row exists only one value is legal.

Before this change the extra addresses were silently discarded. Operators had no way to know that topology data (LLDP link endpoints, MAC-table entries) was lost.

**Fix**: emit a `WARNING` log immediately after choosing the adopted address when `len(loser_ieees) > 1`, listing the discarded addresses. No schema change, no data change — this is observability only.

```
WARNING app.services.device_merge — Inventory merge: winner <id> has no IEEE address;
    adopting aa:bb:cc:dd:ee:01 and discarding 1 other IEEE address(es): ['aa:bb:cc:dd:ee:02']
```

## Test plan

- [ ] `pytest backend/tests/test_device_merge.py::test_merge_warns_when_multiple_loser_ieees_collapse` passes
- [ ] Single-loser merge (the common path) produces no extra WARNING

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1RFEtMaB6wcHC9ck6fgjb