### PR TITLE
fix: stop a text annotation being read as a device's zone

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -60,9 +60,12 @@ from app.services.doc_tree import (
 
 router = APIRouter()
 
-# Node.type values that are canvas furniture. A zone or a group is documented
-# through its node; everything else is documented through its device.
-_FURNITURE_TYPES = {"group", "groupRect", "text"}
+# The furniture a device can sit *in*, and so be located by. Deliberately not
+# `inventory_sync.FURNITURE_TYPES`, which answers a different question: a `text`
+# annotation is furniture — it draws no device — but it is a caption, not a
+# place, and its content is nobody's zone name (#446). A device parented in one
+# keeps walking up to the zone that really holds it, if there is one.
+_ZONE_TYPES = {"group", "groupRect"}
 
 _INTERVAL = re.compile(r"^\s*(\d+)\s*([dwmy])\s*$", re.IGNORECASE)
 _INTERVAL_DAYS = {"d": 1, "w": 7, "m": 30, "y": 365}
@@ -150,7 +153,7 @@ async def _device_context(db: AsyncSession, device_id: str) -> dict[str, Any]:
             parent = await db.get(Node, parent_id)
             if parent is None:
                 break
-            if parent.type in _FURNITURE_TYPES:
+            if parent.type in _ZONE_TYPES:
                 context["zone_label"] = parent.label
                 break
             parent_id = parent.parent_id

--- a/backend/app/api/routes/nodes.py
+++ b/backend/app/api/routes/nodes.py
@@ -204,6 +204,19 @@ async def update_node(
     # Dropped rather than rejected so the rest of the edit still lands.
     if sent.get("parent_id") == node_id:
         sent.pop("parent_id")
+    # A `text` annotation is a caption, not a container. The canvas never nests
+    # anything under one, but the API is reachable without it (MCP write tools,
+    # scripts), and a device that lands there is read back as being *in* the
+    # annotation — its content is printed as the device's zone in the generated
+    # document (#446). Rejected rather than dropped: unlike a self-parent this is
+    # a wrong argument, not a slip, and the caller should hear about it.
+    if sent.get("parent_id"):
+        parent = await db.get(Node, sent["parent_id"])
+        if parent is not None and parent.type == "text":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A text annotation cannot be a parent node",
+            )
     # Before the new counts land: the old ones are what says which handles go away.
     await _remap_shrunk_handles(db, node, sent)
     for field, value in node_columns(sent).items():

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -211,6 +211,83 @@ async def test_a_device_document_records_its_zone_and_neighbours(client: AsyncCl
     assert "`switch-core`" in doc["body"]
 
 
+async def test_a_text_annotation_is_never_read_as_a_zone(client: AsyncClient, headers: dict):
+    """A device parented in a text annotation has no zone, not the caption (#446).
+
+    The annotation's content is arbitrary user text; printed as `zone_label` it
+    is indistinguishable from a real zone in the Physical Location section.
+    """
+    design_id = await _design(client, headers)
+    device = await _device(client, headers)
+    annotation = await client.post(
+        "/api/v1/nodes",
+        json={"type": "text", "label": "\u26a0 maintenance zone", "design_id": design_id, "pos_x": 0, "pos_y": 0},
+        headers=headers,
+    )
+    node = await client.post(
+        "/api/v1/nodes",
+        json={
+            "type": "nas",
+            "label": "nas-01",
+            "design_id": design_id,
+            "ip": "192.168.1.20",
+            "hostname": "nas-01.lan",
+            "parent_id": annotation.json()["id"],
+            "pos_x": 0,
+            "pos_y": 0,
+        },
+        headers=headers,
+    )
+    # Without the link there is no node to walk up from and the test would pass
+    # on nothing at all.
+    assert node.json()["device_id"] == device["id"], node.text
+
+    doc = await _create(client, headers, title="nas-01", kind="device", device_id=device["id"])
+    assert "maintenance zone" not in doc["body"]
+    assert "Zone **" not in doc["body"]
+
+
+async def test_a_zone_above_a_text_annotation_still_names_the_device(client: AsyncClient, headers: dict):
+    """Skipping the annotation means walking past it, not giving up (#446)."""
+    design_id = await _design(client, headers)
+    device = await _device(client, headers)
+    zone = await client.post(
+        "/api/v1/nodes",
+        json={"type": "groupRect", "label": "Garage", "design_id": design_id, "pos_x": 0, "pos_y": 0},
+        headers=headers,
+    )
+    annotation = await client.post(
+        "/api/v1/nodes",
+        json={
+            "type": "text",
+            "label": "\u26a0 maintenance",
+            "design_id": design_id,
+            "parent_id": zone.json()["id"],
+            "pos_x": 0,
+            "pos_y": 0,
+        },
+        headers=headers,
+    )
+    node = await client.post(
+        "/api/v1/nodes",
+        json={
+            "type": "nas",
+            "label": "nas-01",
+            "design_id": design_id,
+            "ip": "192.168.1.20",
+            "hostname": "nas-01.lan",
+            "parent_id": annotation.json()["id"],
+            "pos_x": 0,
+            "pos_y": 0,
+        },
+        headers=headers,
+    )
+    assert node.json()["device_id"] == device["id"], node.text
+
+    doc = await _create(client, headers, title="nas-01", kind="device", device_id=device["id"])
+    assert "Zone **Garage**." in doc["body"]
+
+
 # ── blocks ──────────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -443,6 +443,40 @@ async def test_update_node_self_parent_leaves_a_real_parent_alone(client: AsyncC
     assert res.json()["parent_id"] == host_id
 
 
+# ── text-parent guard (#446) ─────────────────────────────────────────────────
+
+async def test_update_node_refuses_a_text_annotation_as_parent(client: AsyncClient, headers: dict):
+    annotation = await client.post(
+        "/api/v1/nodes", json={"type": "text", "label": "\u26a0 maintenance zone"}, headers=headers
+    )
+    node = await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)
+
+    res = await client.patch(
+        f"/api/v1/nodes/{node.json()['id']}",
+        json={"parent_id": annotation.json()["id"], "label": "renamed"},
+        headers=headers,
+    )
+
+    assert res.status_code == 400
+    assert "text annotation" in res.json()["detail"]
+    # Rejected whole: unlike the self-parent slip, the rest of the edit does not land.
+    read = await client.get(f"/api/v1/nodes/{node.json()['id']}", headers=headers)
+    assert read.json()["parent_id"] is None
+    assert read.json()["label"] == "nas1"
+
+
+async def test_update_node_still_accepts_a_group_as_parent(client: AsyncClient, headers: dict):
+    group = await client.post("/api/v1/nodes", json={"type": "groupRect", "label": "Garage"}, headers=headers)
+    node = await client.post("/api/v1/nodes", json={"type": "nas", "label": "nas1"}, headers=headers)
+
+    res = await client.patch(
+        f"/api/v1/nodes/{node.json()['id']}", json={"parent_id": group.json()["id"]}, headers=headers
+    )
+
+    assert res.status_code == 200
+    assert res.json()["parent_id"] == group.json()["id"]
+
+
 # ── furniture descriptions ───────────────────────────────────────────────────
 
 async def test_create_and_update_a_group_description(client: AsyncClient, headers: dict):


### PR DESCRIPTION
## What

A device node parented inside a canvas text annotation had that annotation's content written as its `zone_label`, so the generated device document printed it in the Physical Location section as if it were a real zone. This fixes the zone resolution and closes the API path that allowed the bad row to be written in the first place.

## Changes

**Backend — document generation**
- `_device_context` walked a device node's parent chain and stopped at the first node whose type was in `_FURNITURE_TYPES`, a set that included `text`. That set was a fork of `inventory_sync.FURNITURE_TYPES`, reused for a question it does not answer: `text` genuinely is furniture (it draws no device), but it is a caption, not a place.
- Replaced it with `_ZONE_TYPES` (`group`, `groupRect`) — the question the walk is actually asking. A device under an annotation now keeps walking up and resolves to the zone that really holds it, if there is one, instead of stopping at the caption.
- No stored document changes: generation is create-time only, nothing rewrites an existing body.

**Backend — node API**
- `PATCH /api/v1/nodes/{id}` now returns 400 for a `parent_id` naming a `text` node. The canvas store never nests anything under an annotation, but the API is reachable without it (MCP write tools, scripts, direct calls), which is how such a row gets written.
- Rejected rather than dropped, unlike the adjacent self-parent guard (#370): that one is a slip and the rest of the edit should still land, this is a wrong argument the caller should hear about.

No breaking changes, no migration.

## Testing

`cd backend && .venv/bin/python -m pytest` — 1354 passed, 8 skipped. `ruff` and `mypy` clean.

New tests, each confirmed to fail with the source fix reverted:
- `test_a_text_annotation_is_never_read_as_a_zone` — device parented in an annotation gets no zone. Asserts the node actually linked to the inventory row first, so the test cannot silently pass on nothing.
- `test_a_zone_above_a_text_annotation_still_names_the_device` — `groupRect > text > device` resolves to the `groupRect`, proving the walk skips past the annotation rather than giving up.
- `test_update_node_refuses_a_text_annotation_as_parent` — 400, and the rest of the edit does not land.
- `test_update_node_still_accepts_a_group_as_parent` — the guard does not catch legitimate parents.

Closes #446

ha-relevant: no
