### PR TITLE
fix(db): device_inventory rebuild silently drops every row's properties

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -283,14 +283,23 @@ async def init_db() -> None:
                     "discovered_at DATETIME"
                     ")"
                 )
+                # Carry every column the old table actually has, the way the
+                # nodes rebuild does. A hand-written list silently drops
+                # whatever it forgets — this one forgot `properties`, which
+                # wiped the Zigbee/Z-Wave attributes off every device it
+                # migrated. Intersecting with the old shape also keeps the
+                # rebuild working on a DB predating any of these columns.
+                new_cols = [
+                    "id", "ip", "mac", "hostname", "os", "services",
+                    "suggested_type", "status", "discovery_source",
+                    "ieee_address", "friendly_name", "device_subtype",
+                    "model", "vendor", "lqi", "properties", "discovered_at",
+                ]
+                old_cols = {c[1] for c in cols}
+                carried = ", ".join(c for c in new_cols if c in old_cols)
                 await conn.exec_driver_sql(
-                    "INSERT INTO device_inventory_new "
-                    "(id, ip, mac, hostname, os, services, suggested_type, status, "
-                    "discovery_source, ieee_address, friendly_name, device_subtype, "
-                    "model, vendor, lqi, discovered_at) "
-                    "SELECT id, ip, mac, hostname, os, services, suggested_type, status, "
-                    "discovery_source, ieee_address, friendly_name, device_subtype, "
-                    "model, vendor, lqi, discovered_at FROM device_inventory"
+                    f"INSERT INTO device_inventory_new ({carried}) "
+                    f"SELECT {carried} FROM device_inventory"
                 )
                 await conn.exec_driver_sql("DROP TABLE device_inventory")
                 await conn.exec_driver_sql(


### PR DESCRIPTION
The `device_inventory` ip-nullable rebuild in `init_db` creates the new table **with** a `properties` column, but the `INSERT ... SELECT` that repopulates it omits that column from both sides — so every device's `properties` is dropped on that migration path.

```python
"CREATE TABLE device_inventory_new ("
...
"lqi INTEGER,"
"properties JSON,"          # <- declared
"discovered_at DATETIME"
")"
...
"INSERT INTO device_inventory_new "
"(id, ip, ..., lqi, discovered_at) "   # <- and then not carried
```

That's where the Zigbee/Z-Wave per-device attributes live, so a user upgrading from a build whose `device_inventory.ip` was still `NOT NULL` loses them with no error.

The `nodes` rebuild next door already does this correctly — it computes the carried column list rather than hand-writing one. This change does the same for `device_inventory`, intersecting the declared columns with what the old table actually has, which also keeps the rebuild working on a database predating any of these columns.

Found while running 3.4.1 against a live install; the fix is in use there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)