### PR TITLE
ci: publish under the repository owner so forks can build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,19 +15,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: ghcr.io/pouzor/homelable-backend
+          - image: ghcr.io/${{ github.repository_owner }}/homelable-backend
             context: .
             dockerfile: Dockerfile.backend
             build_args: ""
-          - image: ghcr.io/pouzor/homelable-frontend
+          - image: ghcr.io/${{ github.repository_owner }}/homelable-frontend
             context: .
             dockerfile: Dockerfile.frontend
             build_args: ""
-          - image: ghcr.io/pouzor/homelable-frontend-standalone
+          - image: ghcr.io/${{ github.repository_owner }}/homelable-frontend-standalone
             context: .
             dockerfile: Dockerfile.frontend
             build_args: "VITE_STANDALONE=true"
-          - image: ghcr.io/pouzor/homelable-mcp
+          - image: ghcr.io/${{ github.repository_owner }}/homelable-mcp
             context: ./mcp
             dockerfile: Dockerfile.mcp
             build_args: ""


### PR DESCRIPTION
`docker-publish.yml` hardcodes the image names to `ghcr.io/pouzor/...`. On a fork the workflow authenticates with that fork's `GITHUB_TOKEN` and then tries to push into **this** repo's registry, so every build fails:

```
ERROR: failed to push ghcr.io/pouzor/homelable-backend:...: denied: permission_denied: write_package
```

`${{ github.repository_owner }}` resolves to `pouzor` here — the published names and tags are identical — and to the fork's owner anywhere else, so a fork can build and test its own images.

Verified on a fork: all four images (backend, frontend, frontend-standalone, mcp) build and publish multi-arch with this change, and fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)