### PR TITLE
feat(kubernetes): read-only Kubernetes topology (revives #385)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,12 +47,28 @@ SCANNER_HTTP_VERIFY_TLS=false
 # Status checker interval in seconds
 STATUS_CHECKER_INTERVAL=60
 
+# Kubernetes topology — disabled by default. Homelable reads a small,
+# read-only Kubernetes inventory and exposes a sanitized observed graph; it
+# never applies or edits Kubernetes resources. In production, deploy the
+# backend in-cluster with a least-privilege ServiceAccount.
+# KUBERNETES_ENABLED=false
+# KUBERNETES_SOURCE=auto               # auto | in_cluster | kubeconfig
+# KUBERNETES_CLUSTER_NAME=kubernetes
+# KUBERNETES_SYNC_INTERVAL=300         # seconds
+# Advanced external-install mode only: mount this kubeconfig read-only. Do not
+# put its contents, a bearer token, or any Kubernetes credential in this file.
+# KUBERNETES_KUBECONFIG_PATH=/run/secrets/homelable-topology.kubeconfig
+# KUBERNETES_KUBECONFIG_CONTEXT=homelable-topology
+
 # MCP server — used by the mcp service (port 8001)
 # MCP_API_KEY: authenticates AI clients (Claude Code, etc.) → MCP server
 # MCP_SERVICE_KEY: authenticates MCP server → backend (never exposed externally)
 # Generate keys: python3 -c "import secrets; print(secrets.token_hex(32))"
 MCP_API_KEY=mcp_sk_changeme
 MCP_SERVICE_KEY=svc_changeme
+# Run a separate MCP listener with this true and a different MCP_API_KEY for
+# read-only agents. Resources remain available, but no tools are registered.
+# MCP_READ_ONLY=false
 
 # Live view — read-only public canvas at /view?key=<value>
 # Off by default. Set to a random secret to enable.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,6 +31,7 @@ Here's what Homelable can do. One line on what each feature is, then how to swit
 17. [MCP Server (AI integration)](#17-mcp-server-)
 18. [Settings & Shortcuts](#18-settings--shortcuts)
 19. [Authentication (Local / OpenID Connect)](#19-authentication-local--openid-connect-)
+20. [Kubernetes Topology](#20-kubernetes-topology-)
 
 ---
 
@@ -287,6 +288,19 @@ The AI can list nodes/edges/canvas/pending/scans, add/update/delete nodes and ed
 **How it protects you:** provider tokens are exchanged server-side and never touch the browser — Homelable issues its own short-lived, `__Host-`, HttpOnly, `SameSite=Lax` session cookie. Discovery metadata, issuer, audience, signature, expiry, nonce, state and PKCE are all validated; cookie-authenticated writes require a CSRF token and an allowed `Origin`; the status WebSocket authenticates from the cookie and validates `Origin`. Local Bearer auth and the MCP service key keep working unchanged. Full config, provider examples and troubleshooting: [docs/oidc-auth.md](./docs/oidc-auth.md).
 
 > OIDC is Full-mode only — the no-backend standalone build has no login.
+
+---
+
+## 20. Kubernetes Topology 🔒
+
+**What:** A separate, read-only map of one Kubernetes cluster: **Ingress → Service → workload → Pod → Node**. It is observed state, not an editable canvas, and includes external endpoints for selectorless Services.
+
+**Use:**
+1. Deploy the backend in the cluster with the least-privilege reader ServiceAccount from [docs/kubernetes-topology.md](./docs/kubernetes-topology.md).
+2. Set `KUBERNETES_ENABLED=true` and `KUBERNETES_SOURCE=in_cluster`, then restart the backend.
+3. Select **Kubernetes** in the sidebar. Pods and nodes stay collapsed until you expand the workload you are investigating.
+
+The collector only lists the resources required to explain topology; it cannot change the cluster and never returns Secrets, ConfigMaps, labels, annotations, container environment, logs, or credentials. Agents can read the same sanitized snapshot through `homelable://kubernetes/topology`. For an agent that must not receive canvas or scan tools, run a separate MCP listener with `MCP_READ_ONLY=true`. Full RBAC, data boundaries, sync state, and advanced read-only-kubeconfig setup: [docs/kubernetes-topology.md](./docs/kubernetes-topology.md).
 
 ---
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -106,7 +106,26 @@ SCANNER_RANGES=["192.168.1.0/24"]
 
 # How often to check node status (seconds)
 STATUS_CHECKER_INTERVAL=60
+
+# Kubernetes topology — disabled by default. See docs/kubernetes-topology.md
+# for the least-privilege RBAC manifest and security boundaries.
+# KUBERNETES_ENABLED=true
+# KUBERNETES_SOURCE=in_cluster       # auto | in_cluster | kubeconfig
+# KUBERNETES_CLUSTER_NAME=kubernetes
+# KUBERNETES_SYNC_INTERVAL=300
 ```
+
+### Kubernetes topology (optional)
+
+Kubernetes topology is an observed, read-only graph separate from the editable
+canvas. It is disabled by default. For a production deployment, run the
+backend in the target cluster with a projected, least-privilege ServiceAccount
+and set `KUBERNETES_SOURCE=in_cluster`.
+
+Do not grant Secrets, ConfigMaps, `pods/log`, `pods/exec`, or any mutating
+Kubernetes verb. The full RBAC manifest, an external Docker/kubeconfig example,
+data-redaction rules, and sync-state behaviour are in
+[docs/kubernetes-topology.md](./docs/kubernetes-topology.md).
 
 ### OpenID Connect (optional)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   <a href="#network-scanner">Network Scanner</a> ·
   <a href="#zigbee2mqtt-import">Zigbee / Z-Wave</a> ·
   <a href="#proxmox-ve-import">Proxmox</a> ·
+  <a href="#kubernetes-topology">Kubernetes</a> ·
   <a href="#live-view-read-only-public-canvas">Live View</a> ·
   <a href="#mcp-server-ai-integration-optional">MCP Server</a>
 </p>
@@ -57,7 +58,7 @@ If you are running  <img width="22" height="22" align="top" alt="New_Home_Assist
 
 ## Features
 
-From one-click **network scans** and **Proxmox / Zigbee / Z-Wave** imports to **live status monitoring**, floor plans, **rack canvases** with port-to-port patching, multi-canvas layouts and an **MCP server** for AI assistants — Homelable maps and watches your whole homelab.
+From one-click **network scans**, **Kubernetes topology**, and **Proxmox / Zigbee / Z-Wave** imports to **live status monitoring**, floor plans, **rack canvases** with port-to-port patching, multi-canvas layouts and an **MCP server** for AI assistants — Homelable maps and watches your whole homelab.
 
 Every feature, with how to turn it on and use it, is described in **[FEATURES.md](./FEATURES.md)**.
 
@@ -241,6 +242,24 @@ Each host is linked to its guests with a `virtual` edge. vCPU / RAM / disk are i
 
 ---
 
+## Kubernetes Topology
+
+Homelable can observe one Kubernetes cluster as a separate, read-only
+topology: **Ingress → Service → workload → Pod → Node**. It resolves
+EndpointSlices, so selectorless Services that target an address outside the
+cluster are represented accurately as external endpoints.
+
+Kubernetes observation is disabled by default and never modifies the cluster.
+The recommended deployment is in-cluster with a projected ServiceAccount
+limited to `list` for the topology resources. The graph is sanitized
+before it is stored or returned: it excludes Secrets, ConfigMaps, labels,
+annotations, container environment, logs, and credentials.
+
+> **Full setup, RBAC manifest, data boundaries, sync states, and advanced
+> read-only kubeconfig mode:** [docs/kubernetes-topology.md](./docs/kubernetes-topology.md)
+
+---
+
 ## Live View (read-only public canvas)
 
 Live View lets you share a read-only snapshot of your canvas with anyone on your network — no login required. It is disabled by default.
@@ -328,7 +347,7 @@ Homelable can exposes a [Model Context Protocol](https://modelcontextprotocol.io
 
 | | Action |
 |---|---|
-| **Read** | List all nodes, edges, full canvas, pending devices, scan history |
+| **Read** | List all nodes, edges, full canvas, pending devices, scan history, and the sanitized Kubernetes topology snapshot |
 | **Write** | Add / update / delete nodes and edges, trigger a network scan, approve or hide discovered devices |
 
 ### Setup
@@ -405,11 +424,14 @@ Or add it manually to `~/.claude.json`:
 - *"Add a new LXC container named `pihole` at 192.168.1.5, connected to my switch."*
 - *"Trigger a network scan on 192.168.1.0/24 and show me the pending devices."*
 - *"Show me the full canvas topology."*
+- *"Show the Kubernetes ingress-to-service routes and their current endpoint relationships."*
 
 ### Security
 
 - The MCP server is **not** intended to be exposed to the internet — keep port 8001 firewalled to your LAN.
 - Rotate the key any time by updating `MCP_API_KEY` in `.env` and restarting: `docker compose restart mcp`.
 - The MCP server communicates with the backend over the internal Docker network — the backend API is never directly exposed to MCP clients.
+- `homelable://kubernetes/topology` is a read-only resource backed by the last complete Kubernetes sync. It does not add Kubernetes write tools; see [Kubernetes topology](./docs/kubernetes-topology.md) for its data and access boundaries.
+- For agents that must not receive canvas or scan tools, run a **separate** MCP listener with its own `MCP_API_KEY` and `MCP_READ_ONLY=true`. That listener exposes resources but registers no tools. Do not share its key with a full-access MCP listener.
 
 ---

--- a/backend/app/api/routes/kubernetes.py
+++ b/backend/app/api/routes/kubernetes.py
@@ -1,0 +1,39 @@
+"""Read-only API for reconciled Kubernetes topology snapshots."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.db.database import get_db
+from app.schemas.kubernetes import KubernetesSyncOut, KubernetesTopologyOut
+from app.services.kubernetes_sync import stored_topology, sync_kubernetes_topology, sync_status
+
+router = APIRouter()
+
+
+@router.get("/status", response_model=KubernetesSyncOut)
+async def get_kubernetes_status(
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(get_current_user),
+) -> KubernetesSyncOut:
+    """Return sync freshness without contacting the Kubernetes API."""
+    return await sync_status(db)
+
+
+@router.get("/topology", response_model=KubernetesTopologyOut)
+async def get_kubernetes_topology(
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(get_current_user),
+) -> dict[str, object]:
+    """Return the last known-good, sanitized graph without contacting Kubernetes."""
+    return await stored_topology(db)
+
+
+@router.post("/sync", response_model=KubernetesSyncOut)
+async def sync_kubernetes(
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(get_current_user),
+) -> KubernetesSyncOut:
+    """Request a serialized refresh using configured server-side credentials only."""
+    return await sync_kubernetes_topology(db)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -107,6 +107,8 @@ class Settings(BaseSettings):
                     app_origin,
                     app_origin,
                 )
+        if self.kubernetes_enabled and self.kubernetes_source == "kubeconfig" and not self.kubernetes_kubeconfig_path:
+            raise ValueError("KUBERNETES_SOURCE=kubeconfig requires KUBERNETES_KUBECONFIG_PATH")
         return self
 
     # Scanner
@@ -191,6 +193,19 @@ class Settings(BaseSettings):
     zwave_mqtt_tls_insecure: bool = False
     zwave_sync_enabled: bool = False
     zwave_sync_interval: int = 3600  # seconds (floor 300 enforced on write)
+
+    # Kubernetes topology is intentionally opt-in.  Credentials are never
+    # accepted by the API: when enabled the backend uses a projected in-cluster
+    # ServiceAccount or an operator-mounted read-only kubeconfig. This keeps
+    # the feature read-only and avoids persisting credentials.
+    kubernetes_enabled: bool = False
+    kubernetes_source: Literal["auto", "in_cluster", "kubeconfig"] = "auto"
+    kubernetes_cluster_name: str = "kubernetes"
+    kubernetes_sync_interval: int = Field(default=300, ge=300)
+    # Advanced remote/development mode only. The file must be mounted read-only;
+    # credentials are never accepted via, persisted by, or returned from the API.
+    kubernetes_kubeconfig_path: str = ""
+    kubernetes_kubeconfig_context: str = ""
 
     def _override_path(self) -> Path:
         return Path(self.sqlite_path).parent / "scan_config.json"

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.db.database import AsyncSessionLocal
 from app.db.models import InventoryDevice, Node
+from app.services.kubernetes_sync import sync_kubernetes_topology
 from app.services.status_checker import check_node, check_services
 
 if TYPE_CHECKING:
@@ -244,6 +245,16 @@ async def _run_zwave_sync() -> None:
     await _run_mesh_sync("zwave")
 
 
+async def _run_kubernetes_sync() -> None:
+    """Refresh the observed graph; failures retain the last successful snapshot."""
+    # Strict opt-in avoids a MagicMock (or another non-boolean config adapter)
+    # unexpectedly scheduling API traffic in test and embedded deployments.
+    if settings.kubernetes_enabled is not True:
+        return
+    async with AsyncSessionLocal() as db:
+        await sync_kubernetes_topology(db)
+
+
 def _add_service_check_job() -> None:
     scheduler.add_job(
         _run_service_checks,
@@ -288,6 +299,17 @@ def _add_zwave_sync_job() -> None:
     )
 
 
+def _add_kubernetes_sync_job() -> None:
+    scheduler.add_job(
+        _run_kubernetes_sync,
+        "interval",
+        seconds=settings.kubernetes_sync_interval,
+        id="kubernetes_sync",
+        max_instances=1,
+        coalesce=True,
+    )
+
+
 def start_scheduler() -> None:
     global scheduler
     if scheduler.running:
@@ -312,6 +334,8 @@ def start_scheduler() -> None:
         _add_zigbee_sync_job()
     if settings.zwave_sync_enabled:
         _add_zwave_sync_job()
+    if settings.kubernetes_enabled is True:
+        _add_kubernetes_sync_job()
     scheduler.start()
     logger.info("Scheduler started — status checks every %ds", settings.status_checker_interval)
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -308,3 +308,68 @@ class ScanRun(Base):
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     error: Mapped[str | None] = mapped_column(Text)
+
+
+class KubernetesCluster(Base):
+    """A configured, observed Kubernetes cluster.
+
+    This is deliberately independent of the editable canvas and physical
+    inventory.  Kubernetes resource UIDs have a very different lifecycle from
+    devices, and sync must never create or delete user-owned canvas objects.
+    """
+
+    __tablename__ = "kubernetes_clusters"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, onupdate=_now)
+
+
+class KubernetesResource(Base):
+    """Sanitized observed resource from a successful topology reconciliation."""
+
+    __tablename__ = "kubernetes_resources"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    cluster_id: Mapped[str] = mapped_column(
+        String, ForeignKey("kubernetes_clusters.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    kind: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    namespace: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    status: Mapped[str | None] = mapped_column(String, nullable=True)
+    properties: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    observed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, nullable=False)
+
+
+class KubernetesRelationship(Base):
+    """Sanitized relationship from a successful topology reconciliation."""
+
+    __tablename__ = "kubernetes_relationships"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    cluster_id: Mapped[str] = mapped_column(
+        String, ForeignKey("kubernetes_clusters.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    source: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    target: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    properties: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+
+class KubernetesSyncState(Base):
+    """Sync freshness and safe diagnostics for the last attempted collection."""
+
+    __tablename__ = "kubernetes_sync_state"
+
+    cluster_id: Mapped[str] = mapped_column(
+        String, ForeignKey("kubernetes_clusters.id", ondelete="CASCADE"), primary_key=True
+    )
+    status: Mapped[str] = mapped_column(String, nullable=False, default="never")
+    last_attempted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_successful_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    object_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    relationship_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.routes import (
     canvas,
     designs,
     edges,
+    kubernetes,
     liveview,
     media,
     nodes,
@@ -91,6 +92,7 @@ app.include_router(liveview.router, prefix="/api/v1/liveview", tags=["liveview"]
 app.include_router(zigbee.router, prefix="/api/v1/zigbee", tags=["zigbee"])
 app.include_router(zwave.router, prefix="/api/v1/zwave", tags=["zwave"])
 app.include_router(proxmox.router, prefix="/api/v1/proxmox", tags=["proxmox"])
+app.include_router(kubernetes.router, prefix="/api/v1/kubernetes", tags=["kubernetes"])
 app.include_router(stats.router, prefix="/api/v1/stats", tags=["stats"])
 app.include_router(media.router, prefix="/api/v1/media", tags=["media"])
 

--- a/backend/app/schemas/kubernetes.py
+++ b/backend/app/schemas/kubernetes.py
@@ -1,0 +1,49 @@
+"""Public, sanitized Kubernetes topology response schemas."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+KubernetesTopologyState = Literal["disabled", "never_synced", "syncing", "fresh", "stale", "error"]
+
+
+class KubernetesSyncOut(BaseModel):
+    enabled: bool
+    configured: bool
+    state: KubernetesTopologyState
+    last_success_at: datetime | None = None
+    last_attempt_at: datetime | None = None
+    last_error: str | None = None
+    object_count: int = 0
+    relationship_count: int = 0
+
+
+class KubernetesClusterOut(BaseModel):
+    id: str
+    name: str
+
+
+class KubernetesObjectOut(BaseModel):
+    id: str
+    kind: str
+    name: str
+    namespace: str | None = None
+    status: str | None = None
+    properties: dict[str, Any] | None = None
+
+
+class KubernetesRelationshipOut(BaseModel):
+    source: str
+    target: str
+    kind: str
+    properties: dict[str, Any] | None = None
+
+
+class KubernetesTopologyOut(BaseModel):
+    schema_version: int = Field(1, serialization_alias="schemaVersion")
+    cluster: KubernetesClusterOut
+    sync: KubernetesSyncOut
+    objects: list[KubernetesObjectOut]
+    relationships: list[KubernetesRelationshipOut]

--- a/backend/app/services/kubernetes_client.py
+++ b/backend/app/services/kubernetes_client.py
@@ -1,0 +1,157 @@
+"""Read-only asynchronous Kubernetes API client used by topology sync.
+
+The client uses a projected in-cluster ServiceAccount by default, or an
+operator-mounted read-only kubeconfig in explicitly configured external mode.
+A Homelable browser can never submit a kubeconfig or bearer token.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Mapping
+from contextlib import suppress
+from typing import Any, Protocol
+
+TopologyLists = dict[str, list[dict[str, Any]]]
+
+
+class KubernetesClientError(RuntimeError):
+    """A safe, operator-facing Kubernetes collection error."""
+
+
+class KubernetesTopologyClient(Protocol):
+    """Boundary that lets sync tests use a deterministic, credential-free fake."""
+
+    async def collect(self) -> TopologyLists: ...
+
+
+class _KubernetesTopologyClientBase:
+    """Shared API collection for the two server-side credential sources."""
+
+    def __init__(self, *, request_timeout_seconds: float = 20.0) -> None:
+        self.request_timeout_seconds = request_timeout_seconds
+
+    async def collect(self) -> TopologyLists:
+        try:
+            from kubernetes_asyncio import client, config
+        except ImportError as exc:  # pragma: no cover - exercised in deployed image
+            raise KubernetesClientError("Kubernetes support is not installed") from exc
+
+        try:
+            await self._load_config(config)
+            api_client = client.ApiClient()
+            core = client.CoreV1Api(api_client)
+            apps = client.AppsV1Api(api_client)
+            batch = client.BatchV1Api(api_client)
+            networking = client.NetworkingV1Api(api_client)
+            calls = {
+                "nodes": core.list_node,
+                "namespaces": core.list_namespace,
+                "pods": core.list_pod_for_all_namespaces,
+                "services": core.list_service_for_all_namespaces,
+                "endpoint_slices": core.list_endpoint_slice_for_all_namespaces,
+                "endpoints": core.list_endpoints_for_all_namespaces,
+                "replicasets": apps.list_replica_set_for_all_namespaces,
+                "deployments": apps.list_deployment_for_all_namespaces,
+                "statefulsets": apps.list_stateful_set_for_all_namespaces,
+                "daemonsets": apps.list_daemon_set_for_all_namespaces,
+                "jobs": batch.list_job_for_all_namespaces,
+                "cronjobs": batch.list_cron_job_for_all_namespaces,
+                "ingresses": networking.list_ingress_for_all_namespaces,
+            }
+            results = await asyncio.gather(*[
+                self._list(name, call) for name, call in calls.items()
+            ])
+            return dict(results)
+        except KubernetesClientError:
+            raise
+        except Exception as exc:  # HTTP errors and token/config failures are intentionally sanitized.
+            raise KubernetesClientError("Kubernetes API collection failed") from exc
+        finally:
+            # ApiClient.close() is async in kubernetes-asyncio.  It is deliberately
+            # best-effort so a close failure cannot turn a successful graph stale.
+            if "api_client" in locals():
+                with suppress(Exception):
+                    await api_client.close()
+
+    async def _load_config(self, config: Any) -> None:
+        raise NotImplementedError
+
+    async def _list(self, name: str, call: Any) -> tuple[str, list[dict[str, Any]]]:
+        try:
+            response = await asyncio.wait_for(
+                call(_request_timeout=self.request_timeout_seconds),
+                timeout=self.request_timeout_seconds + 1,
+            )
+        except Exception as exc:
+            raise KubernetesClientError(f"Unable to list Kubernetes {name}") from exc
+        items = getattr(response, "items", [])
+        output: list[dict[str, Any]] = []
+        for item in items:
+            if hasattr(item, "to_dict"):
+                value = item.to_dict()
+            elif isinstance(item, Mapping):
+                value = dict(item)
+            else:
+                continue
+            output.append(value)
+        return name, output
+
+
+class InClusterKubernetesTopologyClient(_KubernetesTopologyClientBase):
+    """Use the backend Pod's projected ServiceAccount token."""
+
+    async def _load_config(self, config: Any) -> None:
+        config.load_incluster_config()
+
+
+class KubeconfigKubernetesTopologyClient(_KubernetesTopologyClientBase):
+    """Use an operator-mounted read-only kubeconfig; never API-provided data."""
+
+    def __init__(self, *, path: str, context: str = "", request_timeout_seconds: float = 20.0) -> None:
+        super().__init__(request_timeout_seconds=request_timeout_seconds)
+        self.path = path
+        self.context = context or None
+
+    async def _load_config(self, config: Any) -> None:
+        if not self.path:
+            raise KubernetesClientError("Kubernetes kubeconfig path is not configured")
+        await config.load_kube_config(config_file=self.path, context=self.context)
+
+
+def configured_kubernetes_source() -> bool:
+    """Whether the configured source has enough server-side information to run."""
+    from app.core.config import settings
+
+    if not settings.kubernetes_enabled:
+        return False
+    if settings.kubernetes_source == "kubeconfig":
+        return bool(settings.kubernetes_kubeconfig_path)
+    if settings.kubernetes_source == "auto":
+        return bool(os.environ.get("KUBERNETES_SERVICE_HOST") or settings.kubernetes_kubeconfig_path)
+    return True
+
+
+def create_kubernetes_topology_client() -> KubernetesTopologyClient:
+    """Select a credential source without loading either until sync actually runs."""
+    from app.core.config import settings
+
+    source = settings.kubernetes_source
+    if source == "in_cluster":
+        return InClusterKubernetesTopologyClient()
+    if source == "kubeconfig":
+        return KubeconfigKubernetesTopologyClient(
+            path=settings.kubernetes_kubeconfig_path,
+            context=settings.kubernetes_kubeconfig_context,
+        )
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return InClusterKubernetesTopologyClient()
+    if settings.kubernetes_kubeconfig_path:
+        return KubeconfigKubernetesTopologyClient(
+            path=settings.kubernetes_kubeconfig_path,
+            context=settings.kubernetes_kubeconfig_context,
+        )
+    # auto outside a cluster with no path has no implicit host configuration.
+    # Return the in-cluster client only so its normal, sanitized error handles
+    # the state consistently if an operator enabled it by mistake.
+    return InClusterKubernetesTopologyClient()

--- a/backend/app/services/kubernetes_sync.py
+++ b/backend/app/services/kubernetes_sync.py
@@ -1,0 +1,276 @@
+"""Persist and serve reconciled, read-only Kubernetes topology snapshots."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from time import monotonic
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.models import KubernetesCluster, KubernetesRelationship, KubernetesResource, KubernetesSyncState
+from app.schemas.kubernetes import KubernetesSyncOut, KubernetesTopologyState
+from app.services.kubernetes_client import (
+    KubernetesTopologyClient,
+    configured_kubernetes_source,
+    create_kubernetes_topology_client,
+)
+from app.services.kubernetes_topology import build_topology
+
+logger = logging.getLogger(__name__)
+_sync_lock = asyncio.Lock()
+
+
+def cluster_id(cluster_name: str | None = None) -> str:
+    return f"kubernetes://{cluster_name or settings.kubernetes_cluster_name}"
+
+
+def disabled_sync() -> KubernetesSyncOut:
+    return KubernetesSyncOut(enabled=False, configured=False, state="disabled")
+
+
+async def sync_kubernetes_topology(
+    db: AsyncSession,
+    *,
+    client: KubernetesTopologyClient | None = None,
+) -> KubernetesSyncOut:
+    """Collect then atomically replace a snapshot, retaining last-good data on errors."""
+    if not settings.kubernetes_enabled:
+        return disabled_sync()
+    if client is None and not configured_kubernetes_source():
+        return await sync_status(db)
+    if _sync_lock.locked():
+        return await sync_status(db)
+
+    async with _sync_lock:
+        started = monotonic()
+        attempted_at = _now()
+        try:
+            collected = await (client or create_kubernetes_topology_client()).collect()
+            graph = build_topology(
+                cluster_name=settings.kubernetes_cluster_name,
+                nodes=collected.get("nodes", []),
+                namespaces=collected.get("namespaces", []),
+                workloads=[
+                    *collected.get("deployments", []),
+                    *collected.get("statefulsets", []),
+                    *collected.get("daemonsets", []),
+                ],
+                replicasets=collected.get("replicasets", []),
+                jobs=collected.get("jobs", []),
+                cronjobs=collected.get("cronjobs", []),
+                pods=collected.get("pods", []),
+                services=collected.get("services", []),
+                ingresses=collected.get("ingresses", []),
+                endpoint_slices=collected.get("endpoint_slices", []),
+                endpoints=collected.get("endpoints", []),
+            )
+            _ensure_safe_topology(graph)
+            await _replace_snapshot(
+                db,
+                graph,
+                attempted_at=attempted_at,
+                duration_ms=_elapsed_ms(started),
+            )
+        except Exception:
+            await db.rollback()
+            logger.exception("Kubernetes topology sync failed")
+            await _record_failure(db, attempted_at=attempted_at, duration_ms=_elapsed_ms(started))
+        return await sync_status(db)
+
+
+async def _replace_snapshot(
+    db: AsyncSession,
+    graph: dict[str, Any],
+    *,
+    attempted_at: datetime,
+    duration_ms: int,
+) -> None:
+    """Replace one cluster snapshot in one transaction after it is fully normalized."""
+    cluster = graph["cluster"]
+    observed_cluster_id = str(cluster["id"])
+    observed_at = _now()
+    existing_cluster = await db.get(KubernetesCluster, observed_cluster_id)
+    if existing_cluster is None:
+        db.add(KubernetesCluster(id=observed_cluster_id, name=str(cluster["name"])))
+    else:
+        existing_cluster.name = str(cluster["name"])
+
+    await db.execute(delete(KubernetesRelationship).where(KubernetesRelationship.cluster_id == observed_cluster_id))
+    await db.execute(delete(KubernetesResource).where(KubernetesResource.cluster_id == observed_cluster_id))
+    for item in graph["objects"]:
+        db.add(
+            KubernetesResource(
+                id=str(item["id"]),
+                cluster_id=observed_cluster_id,
+                kind=str(item["kind"]),
+                name=str(item["name"]),
+                namespace=item.get("namespace"),
+                status=item.get("status"),
+                properties=item.get("properties"),
+                observed_at=observed_at,
+            )
+        )
+    for item in graph["relationships"]:
+        db.add(
+            KubernetesRelationship(
+                id=_relationship_id(observed_cluster_id, item),
+                cluster_id=observed_cluster_id,
+                source=str(item["source"]),
+                target=str(item["target"]),
+                kind=str(item["kind"]),
+                properties=item.get("properties"),
+            )
+        )
+
+    state = await db.get(KubernetesSyncState, observed_cluster_id)
+    if state is None:
+        state = KubernetesSyncState(cluster_id=observed_cluster_id)
+        db.add(state)
+    state.status = "fresh"
+    state.last_attempted_at = attempted_at
+    state.last_successful_at = observed_at
+    state.last_error = None
+    state.duration_ms = duration_ms
+    state.object_count = len(graph["objects"])
+    state.relationship_count = len(graph["relationships"])
+    await db.commit()
+
+
+async def _record_failure(db: AsyncSession, *, attempted_at: datetime, duration_ms: int) -> None:
+    observed_cluster_id = cluster_id()
+    cluster = await db.get(KubernetesCluster, observed_cluster_id)
+    if cluster is None:
+        db.add(KubernetesCluster(id=observed_cluster_id, name=settings.kubernetes_cluster_name))
+    state = await db.get(KubernetesSyncState, observed_cluster_id)
+    if state is None:
+        state = KubernetesSyncState(cluster_id=observed_cluster_id)
+        db.add(state)
+    state.status = "error"
+    state.last_attempted_at = attempted_at
+    # Never return exception text: Kubernetes clients can include URLs and
+    # authorization diagnostics. Operators get a stable, non-sensitive state.
+    state.last_error = "Kubernetes topology sync failed. Check backend logs."
+    state.duration_ms = duration_ms
+    await db.commit()
+
+
+async def sync_status(db: AsyncSession) -> KubernetesSyncOut:
+    if not settings.kubernetes_enabled:
+        return disabled_sync()
+    configured = configured_kubernetes_source()
+    state = await db.get(KubernetesSyncState, cluster_id())
+    if state is None:
+        return KubernetesSyncOut(enabled=True, configured=configured, state="never_synced")
+    public_state: KubernetesTopologyState
+    if state.status == "fresh" and not _snapshot_overdue(state.last_successful_at):
+        public_state = "fresh"
+    elif state.last_successful_at is not None:
+        public_state = "stale"
+    else:
+        public_state = "error"
+    return KubernetesSyncOut(
+        enabled=True,
+        configured=configured,
+        state=public_state,
+        last_success_at=state.last_successful_at,
+        last_attempt_at=state.last_attempted_at,
+        last_error=state.last_error,
+        object_count=state.object_count,
+        relationship_count=state.relationship_count,
+    )
+
+
+async def stored_topology(db: AsyncSession) -> dict[str, Any]:
+    """Return the last-good graph without making Kubernetes API calls."""
+    observed_cluster_id = cluster_id()
+    sync = await sync_status(db)
+    cluster = {"id": observed_cluster_id, "name": settings.kubernetes_cluster_name}
+    if not settings.kubernetes_enabled:
+        return {"schemaVersion": 1, "cluster": cluster, "sync": sync.model_dump(), "objects": [], "relationships": []}
+    resources = (
+        await db.execute(
+            select(KubernetesResource)
+            .where(KubernetesResource.cluster_id == observed_cluster_id)
+            .order_by(KubernetesResource.id)
+        )
+    ).scalars().all()
+    relationships = (
+        await db.execute(
+            select(KubernetesRelationship)
+            .where(KubernetesRelationship.cluster_id == observed_cluster_id)
+            .order_by(KubernetesRelationship.source, KubernetesRelationship.kind, KubernetesRelationship.target)
+        )
+    ).scalars().all()
+    return {
+        "schemaVersion": 1,
+        "cluster": cluster,
+        "sync": sync.model_dump(mode="json"),
+        "objects": [
+            {
+                "id": item.id,
+                "kind": item.kind,
+                "name": item.name,
+                "namespace": item.namespace,
+                "status": item.status,
+                "properties": item.properties,
+            }
+            for item in resources
+        ],
+        "relationships": [
+            {
+                "source": item.source,
+                "target": item.target,
+                "kind": item.kind,
+                "properties": item.properties,
+            }
+            for item in relationships
+        ],
+    }
+
+
+def _relationship_id(observed_cluster_id: str, item: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        [observed_cluster_id, item["source"], item["target"], item["kind"], item.get("properties")],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _ensure_safe_topology(graph: dict[str, Any]) -> None:
+    """Defence in depth: prevent future mapper additions from persisting secrets."""
+    forbidden = {"annotations", "configmap", "env", "label", "password", "secret", "token"}
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if any(part in str(key).lower() for part in forbidden):
+                    raise ValueError(f"Unsafe Kubernetes topology field: {key}")
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(graph)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((monotonic() - started) * 1000)
+
+
+def _snapshot_overdue(last_successful_at: datetime | None) -> bool:
+    if last_successful_at is None:
+        return False
+    if last_successful_at.tzinfo is None:
+        last_successful_at = last_successful_at.replace(tzinfo=timezone.utc)
+    return _now() - last_successful_at > timedelta(seconds=settings.kubernetes_sync_interval)

--- a/backend/app/services/kubernetes_topology.py
+++ b/backend/app/services/kubernetes_topology.py
@@ -1,0 +1,509 @@
+"""Normalize selected Kubernetes API lists into a safe topology graph.
+
+This is deliberately a pure transformation layer.  It accepts the JSON-shaped
+``items`` returned by the Kubernetes API and emits a graph without requiring a
+kubeconfig, a Kubernetes client, or any write permission.  A future importer
+can supply the lists with an in-cluster ServiceAccount or a user-selected
+kubeconfig.
+
+The graph excludes Secrets, ConfigMaps, container environment variables,
+annotations, labels, and pod logs.  Those are not necessary to explain the
+network path and would make the agent-facing representation needlessly risky.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.parse import quote
+
+Json = Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class TopologyObject:
+    id: str
+    kind: str
+    name: str
+    namespace: str | None = None
+    status: str | None = None
+    properties: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class TopologyRelationship:
+    source: str
+    target: str
+    kind: str
+    properties: dict[str, Any] | None = None
+
+
+def build_topology(
+    *,
+    cluster_name: str,
+    nodes: Iterable[Json] = (),
+    namespaces: Iterable[Json] = (),
+    workloads: Iterable[Json] = (),
+    replicasets: Iterable[Json] = (),
+    jobs: Iterable[Json] = (),
+    cronjobs: Iterable[Json] = (),
+    pods: Iterable[Json] = (),
+    services: Iterable[Json] = (),
+    ingresses: Iterable[Json] = (),
+    endpoint_slices: Iterable[Json] = (),
+    endpoints: Iterable[Json] = (),
+) -> dict[str, Any]:
+    """Build a stable graph of the runtime routing path.
+
+    The initial scope intentionally models only resources needed to answer
+    ``hostname -> ingress -> service -> ready endpoint -> workload -> node``.
+    Kubernetes UIDs anchor object IDs, so names can change without accidentally
+    colliding with a separately imported device.
+    """
+    graph_objects: dict[str, TopologyObject] = {}
+    relationships: dict[tuple[str, str, str, str], TopologyRelationship] = {}
+
+    def add_relationship(
+        source: str,
+        target: str,
+        kind: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        relationship = TopologyRelationship(source, target, kind, properties)
+        relationships[_relationship_key(relationship)] = relationship
+
+    def object_id(resource: Json) -> str | None:
+        metadata = _mapping(resource.get("metadata"))
+        uid = _string(metadata.get("uid"))
+        if not uid:
+            return None
+        return f"kubernetes://{cluster_name}/{uid}"
+
+    def add_object(
+        resource: Json,
+        *,
+        kind: str | None = None,
+        properties: dict[str, Any] | None = None,
+        status: str | None = None,
+    ) -> str | None:
+        resource_id = object_id(resource)
+        metadata = _mapping(resource.get("metadata"))
+        name = _string(metadata.get("name"))
+        if not resource_id or not name:
+            return None
+        graph_objects[resource_id] = TopologyObject(
+            id=resource_id,
+            kind=kind or _string(resource.get("kind")) or "Unknown",
+            name=name,
+            namespace=_string(metadata.get("namespace")),
+            status=status,
+            properties=properties,
+        )
+        return resource_id
+
+    cluster_id = f"kubernetes://{cluster_name}"
+    graph_objects[cluster_id] = TopologyObject(
+        id=cluster_id,
+        kind="Cluster",
+        name=cluster_name,
+    )
+
+    namespace_ids: dict[str, str] = {}
+    for namespace_resource in namespaces:
+        namespace_id = add_object(namespace_resource, kind="Namespace")
+        name = _string(_mapping(namespace_resource.get("metadata")).get("name"))
+        if namespace_id and name:
+            namespace_ids[name] = namespace_id
+            add_relationship(cluster_id, namespace_id, "contains")
+
+    node_ids: dict[str, str] = {}
+    for node in nodes:
+        node_id = add_object(
+            node,
+            kind="Node",
+            status=_node_status(node),
+            properties={"roles": _node_roles(node)},
+        )
+        name = _string(_mapping(node.get("metadata")).get("name"))
+        if node_id and name:
+            node_ids[name] = node_id
+            add_relationship(cluster_id, node_id, "contains")
+
+    workload_ids: dict[tuple[str, str, str], str] = {}
+    for workload in workloads:
+        kind = _string(workload.get("kind"))
+        if kind not in {"Deployment", "StatefulSet", "DaemonSet"}:
+            continue
+        workload_id = add_object(workload, properties=_workload_properties(workload))
+        resource_metadata = _mapping(workload.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        if workload_id and namespace and name:
+            workload_ids[(kind, namespace, name)] = workload_id
+            _add_namespace_contains(namespace_ids, namespace, workload_id, relationships)
+
+    cronjob_ids: dict[tuple[str, str], str] = {}
+    for cronjob in cronjobs:
+        cronjob_id = add_object(cronjob, kind="CronJob", properties=_cronjob_properties(cronjob))
+        resource_metadata = _mapping(cronjob.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        if cronjob_id and namespace and name:
+            cronjob_ids[(namespace, name)] = cronjob_id
+            _add_namespace_contains(namespace_ids, namespace, cronjob_id, relationships)
+
+    for job in jobs:
+        job_id = add_object(job, kind="Job", properties=_job_properties(job))
+        resource_metadata = _mapping(job.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        if not job_id or not namespace or not name:
+            continue
+        workload_ids[("Job", namespace, name)] = job_id
+        _add_namespace_contains(namespace_ids, namespace, job_id, relationships)
+        owner = _controller_owner(job)
+        if owner and owner[0] == "CronJob":
+            cronjob_id = cronjob_ids.get((namespace, owner[1]))
+            if cronjob_id:
+                add_relationship(cronjob_id, job_id, "owns")
+
+    replicaset_owners: dict[tuple[str, str], str] = {}
+    for replicaset in replicasets:
+        resource_metadata = _mapping(replicaset.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        owner = _controller_owner(replicaset)
+        if namespace and name and owner and owner[0] == "Deployment":
+            owner_id = workload_ids.get((owner[0], namespace, owner[1]))
+            if owner_id:
+                replicaset_owners[(namespace, name)] = owner_id
+
+    pod_ids: dict[tuple[str, str], str] = {}
+    for pod in pods:
+        pod_id = add_object(pod, kind="Pod", status=_pod_status(pod))
+        resource_metadata = _mapping(pod.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        if not pod_id or not namespace or not name:
+            continue
+        pod_ids[(namespace, name)] = pod_id
+        _add_namespace_contains(namespace_ids, namespace, pod_id, relationships)
+
+        owner = _controller_owner(pod)
+        if owner:
+            owner_id = workload_ids.get((owner[0], namespace, owner[1]))
+            if owner[0] == "ReplicaSet":
+                owner_id = replicaset_owners.get((namespace, owner[1]))
+            if owner_id:
+                add_relationship(owner_id, pod_id, "owns")
+
+        node_name = _string(_mapping(pod.get("spec")).get("nodeName"))
+        if node_name in node_ids:
+            add_relationship(pod_id, node_ids[node_name], "scheduled_on")
+
+    service_ids: dict[tuple[str, str], str] = {}
+    for service in services:
+        service_id = add_object(service, kind="Service", properties=_service_properties(service))
+        resource_metadata = _mapping(service.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        if service_id and namespace and name:
+            service_ids[(namespace, name)] = service_id
+            _add_namespace_contains(namespace_ids, namespace, service_id, relationships)
+
+    for ingress in ingresses:
+        ingress_id = add_object(ingress, kind="Ingress", properties=_ingress_properties(ingress))
+        namespace = _string(_mapping(ingress.get("metadata")).get("namespace"))
+        if not ingress_id or not namespace:
+            continue
+        _add_namespace_contains(namespace_ids, namespace, ingress_id, relationships)
+        for backend in _ingress_backends(ingress):
+            service_id = service_ids.get((namespace, backend["service"]))
+            if service_id:
+                add_relationship(
+                    ingress_id,
+                    service_id,
+                    "routes_to",
+                    {key: value for key, value in backend.items() if key != "service"},
+                )
+
+    slice_service_keys: set[tuple[str, str]] = set()
+    for endpoint_slice in endpoint_slices:
+        resource_metadata = _mapping(endpoint_slice.get("metadata"))
+        namespace = _string(resource_metadata.get("namespace"))
+        labels = _mapping(resource_metadata.get("labels"))
+        service_name = _string(labels.get("kubernetes.io/service-name"))
+        service_id = service_ids.get((namespace or "", service_name or ""))
+        if not service_id or not namespace:
+            continue
+        slice_service_keys.add((namespace, service_name or ""))
+        for endpoint in _list(endpoint_slice.get("endpoints")):
+            conditions = _mapping(_mapping(endpoint).get("conditions"))
+            if conditions.get("ready") is False:
+                continue
+            target_ref = _mapping(_mapping(endpoint).get("targetRef"))
+            if _string(target_ref.get("kind")) == "Pod":
+                pod_id = pod_ids.get((namespace, _string(target_ref.get("name")) or ""))
+                if not pod_id:
+                    continue
+                add_relationship(
+                    service_id,
+                    pod_id,
+                    "has_endpoint",
+                    {"ports": _endpoint_ports(endpoint_slice), "endpointType": "pod"},
+                )
+                continue
+
+            for address in _list(_mapping(endpoint).get("addresses")):
+                if not isinstance(address, str) or not address:
+                    continue
+                external_id = f"{cluster_id}/external/{quote(namespace, safe='')}/{quote(address, safe='')}"
+                graph_objects[external_id] = TopologyObject(
+                    id=external_id,
+                    kind="ExternalEndpoint",
+                    name=address,
+                    namespace=namespace,
+                    # Topology sees an address, not a health probe. Do not
+                    # imply that an external HAOS endpoint is reachable.
+                    status=None,
+                )
+                add_relationship(
+                    service_id,
+                    external_id,
+                    "has_endpoint",
+                    {"ports": _endpoint_ports(endpoint_slice), "endpointType": "external"},
+                )
+
+    # EndpointSlice is the modern source of truth. Older clusters, and some
+    # controllers, still publish core/v1 Endpoints, so use it only when the
+    # Service had no EndpointSlice at all. This prevents duplicate edges.
+    for endpoint in endpoints:
+        resource_metadata = _mapping(endpoint.get("metadata"))
+        namespace, name = _string(resource_metadata.get("namespace")), _string(resource_metadata.get("name"))
+        if not namespace or not name or (namespace, name) in slice_service_keys:
+            continue
+        service_id = service_ids.get((namespace, name))
+        if not service_id:
+            continue
+        for subset in _list(_mapping(endpoint).get("subsets")):
+            subset_map = _mapping(subset)
+            ports = _legacy_endpoint_ports(subset_map)
+            for address_item in _list(subset_map.get("addresses")):
+                address_map = _mapping(address_item)
+                target_ref = _mapping(address_map.get("targetRef"))
+                if _string(target_ref.get("kind")) == "Pod":
+                    pod_id = pod_ids.get((namespace, _string(target_ref.get("name")) or ""))
+                    if pod_id:
+                        add_relationship(
+                            service_id,
+                            pod_id,
+                            "has_endpoint",
+                            {"ports": ports, "endpointType": "pod"},
+                        )
+                    continue
+                address = _string(address_map.get("ip"))
+                if not address:
+                    continue
+                external_id = f"{cluster_id}/external/{quote(namespace, safe='')}/{quote(address, safe='')}"
+                graph_objects[external_id] = TopologyObject(
+                    id=external_id,
+                    kind="ExternalEndpoint",
+                    name=address,
+                    namespace=namespace,
+                    status=None,
+                )
+                add_relationship(
+                    service_id,
+                    external_id,
+                    "has_endpoint",
+                    {"ports": ports, "endpointType": "external"},
+                )
+
+    return {
+        "schemaVersion": 1,
+        "cluster": {"id": cluster_id, "name": cluster_name},
+        "objects": [asdict(graph_objects[key]) for key in sorted(graph_objects)],
+        "relationships": [
+            asdict(relationship)
+            for relationship in sorted(
+                relationships.values(),
+                key=lambda item: (item.source, item.kind, item.target, str(item.properties)),
+            )
+        ],
+    }
+
+
+def _add_namespace_contains(
+    namespace_ids: dict[str, str],
+    namespace: str,
+    target: str,
+    relationships: dict[tuple[str, str, str, str], TopologyRelationship],
+) -> None:
+    namespace_id = namespace_ids.get(namespace)
+    if namespace_id:
+        relationship = TopologyRelationship(namespace_id, target, "contains")
+        relationships[_relationship_key(relationship)] = relationship
+
+
+def _relationship_key(relationship: TopologyRelationship) -> tuple[str, str, str, str]:
+    return (
+        relationship.source,
+        relationship.target,
+        relationship.kind,
+        repr(relationship.properties),
+    )
+
+
+def _controller_owner(resource: Json) -> tuple[str, str] | None:
+    owners = _list(_mapping(resource.get("metadata")).get("ownerReferences"))
+    for owner in owners:
+        owner_map = _mapping(owner)
+        if owner_map.get("controller") is True:
+            kind, name = _string(owner_map.get("kind")), _string(owner_map.get("name"))
+            if kind and name:
+                return kind, name
+    return None
+
+
+def _node_roles(node: Json) -> list[str]:
+    labels = _mapping(_mapping(node.get("metadata")).get("labels"))
+    return sorted(
+        key.removeprefix("node-role.kubernetes.io/")
+        for key in labels
+        if key.startswith("node-role.kubernetes.io/")
+    )
+
+
+def _node_status(node: Json) -> str:
+    conditions = _list(_mapping(node.get("status")).get("conditions"))
+    ready = next((condition for condition in conditions if _mapping(condition).get("type") == "Ready"), None)
+    return "online" if _mapping(ready).get("status") == "True" else "offline"
+
+
+def _pod_status(pod: Json) -> str:
+    phase = _string(_mapping(pod.get("status")).get("phase"))
+    return "online" if phase == "Running" else "offline" if phase in {"Failed", "Unknown"} else "pending"
+
+
+def _workload_properties(workload: Json) -> dict[str, Any]:
+    spec = _mapping(workload.get("spec"))
+    status = _mapping(workload.get("status"))
+    return {
+        "desiredReplicas": spec.get("replicas", 1),
+        "readyReplicas": status.get("readyReplicas", 0),
+    }
+
+
+def _job_properties(job: Json) -> dict[str, Any]:
+    status = _mapping(job.get("status"))
+    return {
+        "active": status.get("active", 0),
+        "succeeded": status.get("succeeded", 0),
+        "failed": status.get("failed", 0),
+    }
+
+
+def _cronjob_properties(cronjob: Json) -> dict[str, Any]:
+    return {"schedule": _string(_mapping(cronjob.get("spec")).get("schedule"))}
+
+
+def _service_properties(service: Json) -> dict[str, Any]:
+    spec = _mapping(service.get("spec"))
+    return {
+        "type": _string(spec.get("type")) or "ClusterIP",
+        "ports": _service_ports(spec),
+    }
+
+
+def _service_ports(spec: Json) -> list[dict[str, Any]]:
+    ports: list[dict[str, Any]] = []
+    for port in _list(spec.get("ports")):
+        item = _mapping(port)
+        ports.append(
+            {
+                "name": _string(item.get("name")),
+                "port": item.get("port"),
+                "targetPort": item.get("targetPort"),
+                "protocol": _string(item.get("protocol")) or "TCP",
+            }
+        )
+    return ports
+
+
+def _endpoint_ports(endpoint_slice: Json) -> list[dict[str, Any]]:
+    ports: list[dict[str, Any]] = []
+    for port in _list(endpoint_slice.get("ports")):
+        item = _mapping(port)
+        ports.append(
+            {
+                "name": _string(item.get("name")),
+                "port": item.get("port"),
+                "protocol": _string(item.get("protocol")) or "TCP",
+            }
+        )
+    return ports
+
+
+def _legacy_endpoint_ports(subset: Json) -> list[dict[str, Any]]:
+    ports: list[dict[str, Any]] = []
+    for port in _list(subset.get("ports")):
+        item = _mapping(port)
+        ports.append(
+            {
+                "name": _string(item.get("name")),
+                "port": item.get("port"),
+                "protocol": _string(item.get("protocol")) or "TCP",
+            }
+        )
+    return ports
+
+
+def _ingress_properties(ingress: Json) -> dict[str, Any]:
+    hosts = sorted(
+        host
+        for rule in _list(_mapping(ingress.get("spec")).get("rules"))
+        if (host := _string(_mapping(rule).get("host")))
+    )
+    return {"hosts": hosts}
+
+
+def _ingress_backends(ingress: Json) -> list[dict[str, Any]]:
+    spec = _mapping(ingress.get("spec"))
+    backends: list[dict[str, Any]] = []
+    default_backend = _backend(_mapping(spec.get("defaultBackend")), host=None, path=None)
+    if default_backend:
+        backends.append(default_backend)
+    for rule in _list(spec.get("rules")):
+        rule_map = _mapping(rule)
+        host = _string(rule_map.get("host"))
+        http = _mapping(rule_map.get("http"))
+        for path in _list(http.get("paths")):
+            path_map = _mapping(path)
+            backend = _backend(_mapping(path_map.get("backend")), host=host, path=_string(path_map.get("path")))
+            if backend:
+                backends.append(backend)
+    return backends
+
+
+def _backend(backend: Json, *, host: str | None, path: str | None) -> dict[str, Any] | None:
+    service = _mapping(backend.get("service"))
+    name = _string(service.get("name"))
+    if not name:
+        return None
+    port = _mapping(service.get("port"))
+    result: dict[str, Any] = {"service": name}
+    if host:
+        result["host"] = host
+    if path:
+        result["path"] = path
+    if port.get("number") is not None:
+        result["port"] = port["number"]
+    elif _string(port.get("name")):
+        result["port"] = _string(port.get("name"))
+    return result
+
+
+def _mapping(value: object) -> Json:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,7 @@ websockets==13.1
 httpx==0.27.2
 zeroconf==0.149.16
 aiomqtt==2.3.0
+kubernetes-asyncio==33.3.0
 
 # Dev
 ruff==0.6.9

--- a/backend/tests/test_kubernetes_api.py
+++ b/backend/tests/test_kubernetes_api.py
@@ -1,0 +1,28 @@
+async def test_kubernetes_status_and_topology_are_authenticated_and_disabled_by_default(client, headers):
+    unauthenticated = await client.get("/api/v1/kubernetes/status")
+    unauthenticated_sync = await client.post("/api/v1/kubernetes/sync")
+    status = await client.get("/api/v1/kubernetes/status", headers=headers)
+    topology = await client.get("/api/v1/kubernetes/topology", headers=headers)
+    sync = await client.post("/api/v1/kubernetes/sync", headers=headers)
+
+    assert unauthenticated.status_code == 401
+    assert unauthenticated_sync.status_code == 401
+    assert status.status_code == 200
+    assert status.json() == {
+        "enabled": False,
+        "configured": False,
+        "state": "disabled",
+        "last_success_at": None,
+        "last_attempt_at": None,
+        "last_error": None,
+        "object_count": 0,
+        "relationship_count": 0,
+    }
+    assert topology.status_code == 200
+    body = topology.json()
+    assert body["schemaVersion"] == 1
+    assert body["sync"]["state"] == "disabled"
+    assert body["objects"] == []
+    assert body["relationships"] == []
+    assert sync.status_code == 200
+    assert sync.json()["state"] == "disabled"

--- a/backend/tests/test_kubernetes_client.py
+++ b/backend/tests/test_kubernetes_client.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from app.services.kubernetes_client import (
+    InClusterKubernetesTopologyClient,
+    KubeconfigKubernetesTopologyClient,
+    KubernetesClientError,
+    create_kubernetes_topology_client,
+)
+
+
+class _FakeApiClient:
+    closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeApi:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __init__(self, _: _FakeApiClient) -> None:
+        pass
+
+    def __getattr__(self, name: str):
+        async def call(**kwargs: Any) -> Any:
+            self.calls.append((name, kwargs))
+            return SimpleNamespace(items=[SimpleNamespace(to_dict=lambda: {"kind": "Pod", "metadata": {}})])
+
+        return call
+
+
+class _FailingApi(_FakeApi):
+    def __getattr__(self, _: str):
+        async def call(**__: Any) -> Any:
+            raise RuntimeError("unavailable")
+
+        return call
+
+
+async def test_in_cluster_client_lists_every_required_resource_and_closes(monkeypatch: pytest.MonkeyPatch) -> None:
+    api_client = _FakeApiClient()
+    _FakeApi.calls = []
+    fake_client = SimpleNamespace(
+        ApiClient=lambda: api_client,
+        CoreV1Api=_FakeApi,
+        AppsV1Api=_FakeApi,
+        BatchV1Api=_FakeApi,
+        NetworkingV1Api=_FakeApi,
+    )
+    fake_config = SimpleNamespace(load_incluster_config=lambda: None)
+    monkeypatch.setitem(sys.modules, "kubernetes_asyncio", SimpleNamespace(client=fake_client, config=fake_config))
+
+    collected = await InClusterKubernetesTopologyClient().collect()
+
+    assert set(collected) == {
+        "nodes", "namespaces", "pods", "services", "endpoint_slices", "endpoints", "replicasets",
+        "deployments", "statefulsets", "daemonsets", "jobs", "cronjobs", "ingresses",
+    }
+    assert {name for name, _ in _FakeApi.calls} == {
+        "list_node",
+        "list_namespace",
+        "list_pod_for_all_namespaces",
+        "list_service_for_all_namespaces",
+        "list_endpoint_slice_for_all_namespaces",
+        "list_endpoints_for_all_namespaces",
+        "list_replica_set_for_all_namespaces",
+        "list_deployment_for_all_namespaces",
+        "list_stateful_set_for_all_namespaces",
+        "list_daemon_set_for_all_namespaces",
+        "list_job_for_all_namespaces",
+        "list_cron_job_for_all_namespaces",
+        "list_ingress_for_all_namespaces",
+    }
+    assert all("_request_timeout" in kwargs for _, kwargs in _FakeApi.calls)
+    assert api_client.closed
+
+
+async def test_client_closes_api_connection_after_collection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    api_client = _FakeApiClient()
+    fake_client = SimpleNamespace(
+        ApiClient=lambda: api_client,
+        CoreV1Api=_FailingApi,
+        AppsV1Api=_FailingApi,
+        BatchV1Api=_FailingApi,
+        NetworkingV1Api=_FailingApi,
+    )
+    fake_config = SimpleNamespace(load_incluster_config=lambda: None)
+    monkeypatch.setitem(sys.modules, "kubernetes_asyncio", SimpleNamespace(client=fake_client, config=fake_config))
+
+    with pytest.raises(KubernetesClientError, match="Unable to list Kubernetes"):
+        await InClusterKubernetesTopologyClient().collect()
+
+    assert api_client.closed
+
+
+async def test_client_timeout_is_sanitized() -> None:
+    client = InClusterKubernetesTopologyClient(request_timeout_seconds=0.001)
+
+    async def never_returns(**_: Any) -> Any:
+        await asyncio.Event().wait()
+
+    with pytest.raises(KubernetesClientError, match="Unable to list Kubernetes pods"):
+        await client._list("pods", never_returns)
+
+
+def test_auto_source_prefers_in_cluster_then_read_only_kubeconfig(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "kubernetes_source", "auto")
+    monkeypatch.setattr(settings, "kubernetes_kubeconfig_path", "/run/kubeconfig/config")
+    monkeypatch.setattr(settings, "kubernetes_kubeconfig_context", "test")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    assert isinstance(create_kubernetes_topology_client(), InClusterKubernetesTopologyClient)
+
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST")
+    selected = create_kubernetes_topology_client()
+    assert isinstance(selected, KubeconfigKubernetesTopologyClient)
+    assert selected.path == "/run/kubeconfig/config"
+    assert selected.context == "test"

--- a/backend/tests/test_kubernetes_sync.py
+++ b/backend/tests/test_kubernetes_sync.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.db.models import KubernetesSyncState
+from app.services.kubernetes_client import configured_kubernetes_source
+from app.services.kubernetes_sync import stored_topology, sync_kubernetes_topology, sync_status
+
+
+class FakeClient:
+    def __init__(self, payload: dict[str, list[dict[str, Any]]]) -> None:
+        self.payload = payload
+
+    async def collect(self) -> dict[str, list[dict[str, Any]]]:
+        return self.payload
+
+
+class FailingClient:
+    async def collect(self) -> dict[str, list[dict[str, Any]]]:
+        raise RuntimeError("token=do-not-expose")
+
+
+def resource(kind: str, name: str, uid: str, namespace: str | None = None, **extra: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"name": name, "uid": uid}
+    if namespace:
+        metadata["namespace"] = namespace
+    return {"kind": kind, "metadata": metadata, **extra}
+
+
+@pytest.fixture
+def kubernetes_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "kubernetes_enabled", True)
+    monkeypatch.setattr(settings, "kubernetes_source", "in_cluster")
+    monkeypatch.setattr(settings, "kubernetes_cluster_name", "test-cluster")
+
+
+async def test_disabled_topology_is_empty_and_safe(db_session) -> None:
+    original = settings.kubernetes_enabled
+    settings.kubernetes_enabled = False
+    try:
+        assert (await sync_status(db_session)).state == "disabled"
+        topology = await stored_topology(db_session)
+    finally:
+        settings.kubernetes_enabled = original
+
+    assert topology["schemaVersion"] == 1
+    assert topology["objects"] == []
+    assert topology["relationships"] == []
+
+
+async def test_successful_sync_persists_a_sanitized_snapshot(db_session, kubernetes_enabled) -> None:
+    result = await sync_kubernetes_topology(
+        db_session,
+        client=FakeClient(
+            {
+                "namespaces": [resource("Namespace", "apps", "namespace-1")],
+                "deployments": [resource("Deployment", "api", "deployment-1", "apps")],
+                "services": [resource("Service", "api", "service-1", "apps", spec={"ports": [{"port": 80}]})],
+                "ingresses": [
+                    resource(
+                        "Ingress",
+                        "api",
+                        "ingress-1",
+                        "apps",
+                        spec={
+                            "rules": [
+                                {
+                                    "host": "api.example.test",
+                                    "http": {
+                                        "paths": [
+                                            {
+                                                "path": "/",
+                                                "backend": {"service": {"name": "api", "port": {"number": 80}}},
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    )
+                ],
+            }
+        ),
+    )
+
+    topology = await stored_topology(db_session)
+
+    assert result.state == "fresh"
+    assert topology["sync"]["state"] == "fresh"
+    assert topology["sync"]["object_count"] == len(topology["objects"])
+    assert any(item["kind"] == "Ingress" for item in topology["objects"])
+    rendered = str(topology)
+    assert "labels" not in rendered
+    assert "annotations" not in rendered
+
+
+async def test_failed_sync_keeps_last_good_graph_and_sanitizes_error(db_session, kubernetes_enabled) -> None:
+    first = FakeClient({"namespaces": [resource("Namespace", "apps", "namespace-1")]})
+    await sync_kubernetes_topology(db_session, client=first)
+    before = await stored_topology(db_session)
+
+    result = await sync_kubernetes_topology(db_session, client=FailingClient())
+    after = await stored_topology(db_session)
+
+    assert result.state == "stale"
+    assert result.last_error == "Kubernetes topology sync failed. Check backend logs."
+    assert "token=" not in (result.last_error or "")
+    assert after["objects"] == before["objects"]
+    assert after["relationships"] == before["relationships"]
+
+
+async def test_overdue_successful_snapshot_is_stale(db_session, kubernetes_enabled) -> None:
+    await sync_kubernetes_topology(
+        db_session,
+        client=FakeClient({"namespaces": [resource("Namespace", "apps", "namespace-1")]}),
+    )
+    state = (await db_session.execute(select(KubernetesSyncState))).scalar_one()
+    assert state.last_successful_at is not None
+    state.last_successful_at -= timedelta(seconds=settings.kubernetes_sync_interval + 1)
+    await db_session.commit()
+
+    assert (await sync_status(db_session)).state == "stale"
+
+
+async def test_unsafe_topology_is_not_persisted(db_session, kubernetes_enabled, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.kubernetes_sync.build_topology",
+        lambda **_: {
+            "cluster": {"id": "kubernetes://test-cluster", "name": "test-cluster"},
+            "objects": [{"id": "x", "kind": "Pod", "name": "x", "properties": {"token": "nope"}}],
+            "relationships": [],
+        },
+    )
+
+    result = await sync_kubernetes_topology(db_session, client=FakeClient({}))
+    topology = await stored_topology(db_session)
+
+    assert result.state == "error"
+    assert topology["objects"] == []
+
+
+def test_kubeconfig_source_requires_only_an_env_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "kubernetes_enabled", True)
+    monkeypatch.setattr(settings, "kubernetes_source", "kubeconfig")
+    monkeypatch.setattr(settings, "kubernetes_kubeconfig_path", "")
+    assert not configured_kubernetes_source()
+
+    monkeypatch.setattr(settings, "kubernetes_kubeconfig_path", "/run/kubeconfig/config")
+    assert configured_kubernetes_source()

--- a/backend/tests/test_kubernetes_topology.py
+++ b/backend/tests/test_kubernetes_topology.py
@@ -1,0 +1,112 @@
+from app.services.kubernetes_topology import build_topology
+
+
+def resource(kind: str, name: str, uid: str, namespace: str | None = None, *, metadata=None, **extra):
+    resource_metadata = {"name": name, "uid": uid}
+    if namespace:
+        resource_metadata["namespace"] = namespace
+    if metadata:
+        resource_metadata.update(metadata)
+    return {"kind": kind, "metadata": resource_metadata, **extra}
+
+
+def object_id(graph, kind, name):
+    return next(item["id"] for item in graph["objects"] if item["kind"] == kind and item["name"] == name)
+
+
+def test_build_topology_connects_ingress_to_ready_pod_through_service():
+    graph = build_topology(
+        cluster_name="lab",
+        namespaces=[resource("Namespace", "monitoring", "ns-1")],
+        nodes=[resource("Node", "node1", "node-1", status={"conditions": [{"type": "Ready", "status": "True"}]})],
+        workloads=[resource("Deployment", "grafana", "deploy-1", "monitoring", spec={"replicas": 1}, status={"readyReplicas": 1})],
+        replicasets=[resource("ReplicaSet", "grafana-abc", "rs-1", "monitoring", metadata={"name": "grafana-abc", "uid": "rs-1", "namespace": "monitoring", "ownerReferences": [{"controller": True, "kind": "Deployment", "name": "grafana"}]})],
+        pods=[resource("Pod", "grafana-abc-123", "pod-1", "monitoring", spec={"nodeName": "node1"}, status={"phase": "Running"}, metadata={"name": "grafana-abc-123", "uid": "pod-1", "namespace": "monitoring", "ownerReferences": [{"controller": True, "kind": "ReplicaSet", "name": "grafana-abc"}]})],
+        services=[resource("Service", "grafana", "svc-1", "monitoring", spec={"type": "ClusterIP", "ports": [{"name": "http", "port": 3000, "targetPort": 3000}]})],
+        ingresses=[resource("Ingress", "grafana", "ing-1", "monitoring", spec={"rules": [{"host": "grafana.example", "http": {"paths": [{"path": "/", "backend": {"service": {"name": "grafana", "port": {"number": 3000}}}}]}}]})],
+        endpoint_slices=[resource("EndpointSlice", "grafana-123", "slice-1", "monitoring", metadata={"name": "grafana-123", "uid": "slice-1", "namespace": "monitoring", "labels": {"kubernetes.io/service-name": "grafana"}}, ports=[{"name": "http", "port": 3000}], endpoints=[{"conditions": {"ready": True}, "targetRef": {"kind": "Pod", "name": "grafana-abc-123"}}])],
+    )
+
+    ingress_id = object_id(graph, "Ingress", "grafana")
+    service_id = object_id(graph, "Service", "grafana")
+    deployment_id = object_id(graph, "Deployment", "grafana")
+    pod_id = object_id(graph, "Pod", "grafana-abc-123")
+    node_id = object_id(graph, "Node", "node1")
+    relationships = {(item["source"], item["target"], item["kind"]) for item in graph["relationships"]}
+
+    assert (ingress_id, service_id, "routes_to") in relationships
+    assert any(item["kind"] == "routes_to" and item["properties"] == {"host": "grafana.example", "path": "/", "port": 3000} for item in graph["relationships"])
+    assert (deployment_id, pod_id, "owns") in relationships
+    assert (pod_id, node_id, "scheduled_on") in relationships
+    assert any(item["kind"] == "has_endpoint" and item["target"] == pod_id for item in graph["relationships"])
+
+
+def test_build_topology_excludes_not_ready_endpoints():
+    graph = build_topology(
+        cluster_name="lab",
+        namespaces=[resource("Namespace", "app", "ns-1")],
+        pods=[resource("Pod", "starting", "pod-1", "app", status={"phase": "Pending"})],
+        services=[resource("Service", "app", "svc-1", "app", spec={"ports": [{"port": 80}]})],
+        endpoint_slices=[resource("EndpointSlice", "app-1", "slice-1", "app", metadata={"name": "app-1", "uid": "slice-1", "namespace": "app", "labels": {"kubernetes.io/service-name": "app"}}, endpoints=[{"conditions": {"ready": False}, "targetRef": {"kind": "Pod", "name": "starting"}}])],
+    )
+
+    assert not [item for item in graph["relationships"] if item["kind"] == "has_endpoint"]
+
+
+def test_build_topology_keeps_selectorless_service_endpoint_address():
+    graph = build_topology(
+        cluster_name="lab",
+        namespaces=[resource("Namespace", "home", "ns-1")],
+        services=[resource("Service", "home-assistant", "svc-1", "home", spec={"ports": [{"port": 8123}]})],
+        endpoint_slices=[resource("EndpointSlice", "ha-1", "slice-1", "home", metadata={"name": "ha-1", "uid": "slice-1", "namespace": "home", "labels": {"kubernetes.io/service-name": "home-assistant"}}, ports=[{"port": 8123}], endpoints=[{"conditions": {"ready": True}, "addresses": ["192.168.40.20"]}])],
+    )
+
+    external_id = object_id(graph, "ExternalEndpoint", "192.168.40.20")
+    external = next(item for item in graph["objects"] if item["id"] == external_id)
+    assert external["status"] is None
+    assert any(
+        item["target"] == external_id
+        and item["kind"] == "has_endpoint"
+        and item["properties"]["endpointType"] == "external"
+        for item in graph["relationships"]
+    )
+
+
+def test_build_topology_connects_cronjob_to_job_to_pod():
+    graph = build_topology(
+        cluster_name="lab",
+        namespaces=[resource("Namespace", "maintenance", "namespace-1")],
+        cronjobs=[resource("CronJob", "nightly", "cronjob-1", "maintenance", spec={"schedule": "0 0 * * *"})],
+        jobs=[resource("Job", "nightly-1", "job-1", "maintenance", metadata={"name": "nightly-1", "uid": "job-1", "namespace": "maintenance", "ownerReferences": [{"controller": True, "kind": "CronJob", "name": "nightly"}]})],
+        pods=[resource("Pod", "nightly-1-pod", "pod-1", "maintenance", metadata={"name": "nightly-1-pod", "uid": "pod-1", "namespace": "maintenance", "ownerReferences": [{"controller": True, "kind": "Job", "name": "nightly-1"}]})],
+    )
+
+    cronjob_id = object_id(graph, "CronJob", "nightly")
+    job_id = object_id(graph, "Job", "nightly-1")
+    pod_id = object_id(graph, "Pod", "nightly-1-pod")
+    relationships = {(item["source"], item["target"], item["kind"]) for item in graph["relationships"]}
+
+    assert (cronjob_id, job_id, "owns") in relationships
+    assert (job_id, pod_id, "owns") in relationships
+
+
+def test_build_topology_uses_legacy_endpoints_only_when_no_endpoint_slice_exists():
+    graph = build_topology(
+        cluster_name="lab",
+        namespaces=[resource("Namespace", "home", "namespace-1")],
+        services=[resource("Service", "home-assistant", "service-1", "home", spec={"ports": [{"port": 8123}]})],
+        endpoints=[resource("Endpoints", "home-assistant", "endpoints-1", "home", subsets=[{"addresses": [{"ip": "192.168.40.20"}], "ports": [{"port": 8123}]}])],
+    )
+
+    external_id = object_id(graph, "ExternalEndpoint", "192.168.40.20")
+    assert any(item["kind"] == "has_endpoint" and item["target"] == external_id for item in graph["relationships"])
+
+    with_slice = build_topology(
+        cluster_name="lab",
+        namespaces=[resource("Namespace", "home", "namespace-1")],
+        services=[resource("Service", "home-assistant", "service-1", "home", spec={"ports": [{"port": 8123}]})],
+        endpoint_slices=[resource("EndpointSlice", "ha-1", "slice-1", "home", metadata={"name": "ha-1", "uid": "slice-1", "namespace": "home", "labels": {"kubernetes.io/service-name": "home-assistant"}}, endpoints=[{"addresses": ["192.168.40.20"]}])],
+        endpoints=[resource("Endpoints", "home-assistant", "endpoints-1", "home", subsets=[{"addresses": [{"ip": "192.168.40.21"}]}])],
+    )
+    external_addresses = {item["name"] for item in with_slice["objects"] if item["kind"] == "ExternalEndpoint"}
+    assert external_addresses == {"192.168.40.20"}

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -334,6 +334,24 @@ def test_start_scheduler_adds_service_job_when_enabled():
     assert "service_checks" in job_ids
 
 
+def test_start_scheduler_adds_kubernetes_job_only_when_explicitly_enabled():
+    mock_sched = MagicMock()
+    with patch("app.core.scheduler.settings") as mock_settings, patch(
+        "app.core.scheduler.AsyncIOScheduler", return_value=mock_sched
+    ):
+        mock_settings.status_checker_interval = 60
+        mock_settings.service_check_enabled = False
+        mock_settings.proxmox_sync_enabled = False
+        mock_settings.zigbee_sync_enabled = False
+        mock_settings.zwave_sync_enabled = False
+        mock_settings.kubernetes_enabled = True
+        mock_settings.kubernetes_sync_interval = 300
+        start_scheduler()
+
+    job_ids = [kw.get("id") for _, kw in mock_sched.add_job.call_args_list]
+    assert "kubernetes_sync" in job_ids
+
+
 # ---------------------------------------------------------------------------
 # Proxmox auto-sync job
 # ---------------------------------------------------------------------------

--- a/docs/kubernetes-topology.md
+++ b/docs/kubernetes-topology.md
@@ -1,0 +1,247 @@
+# Kubernetes topology
+
+Homelable can observe one Kubernetes cluster and present a **read-only**
+topology graph. This is deliberately separate from the editable canvas and
+device inventory: Kubernetes resources are reconciled observations, not
+objects Homelable creates or controls.
+
+The canonical topology is available to the UI, REST API, and MCP as a
+versioned JSON document:
+
+- `GET /api/v1/kubernetes/status` reports whether Kubernetes observation is
+  enabled and the freshness of the most recent sync.
+- `GET /api/v1/kubernetes/topology` returns the last successful, sanitized
+  topology snapshot.
+- `homelable://kubernetes/topology` exposes that same snapshot as an MCP
+  resource.
+
+The topology route serves the last complete sync; it does not make a
+Kubernetes API request for each viewer or MCP read. A failed sync keeps the
+last known-good snapshot and marks it stale or errored instead of publishing a
+partial graph.
+
+## What is mapped
+
+The graph associates Kubernetes resources using their stable UIDs:
+
+```text
+Cluster
+  ├─ Namespace
+  │   ├─ Ingress ─routes_to→ Service
+  │   └─ Service ─has_endpoint→ Pod | External endpoint
+  └─ Workload ─owns→ Pod ─scheduled_on→ Node
+```
+
+Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs are workloads.
+ReplicaSets are used to resolve Deployment ownership. The collector also reads
+EndpointSlices (and legacy Endpoints as a compatibility fallback), so a
+selectorless Service can accurately point to an external address rather than a
+Pod. A missing endpoint is represented as such; it is not treated as proof
+that the Service is healthy or unhealthy.
+
+Pods are collapsed in the visual view by default. Expand them when debugging a
+specific workload or node placement.
+
+## Enable the collector
+
+Kubernetes observation is disabled by default. Add these settings to the
+backend environment and restart the backend:
+
+```env
+KUBERNETES_ENABLED=true
+KUBERNETES_SOURCE=auto
+KUBERNETES_CLUSTER_NAME=production
+KUBERNETES_SYNC_INTERVAL=300
+```
+
+`KUBERNETES_SOURCE` accepts:
+
+| Value | Behaviour |
+|---|---|
+| `auto` | Use in-cluster credentials when available; otherwise use the configured kubeconfig path. |
+| `in_cluster` | Require projected ServiceAccount credentials. This is the recommended production setting. |
+| `kubeconfig` | Use a locally mounted kubeconfig file. This is an advanced option for external installs. |
+
+`KUBERNETES_SYNC_INTERVAL` is in seconds. Use a conservative value: topology
+is inventory data, not a real-time health monitor.
+
+### In-cluster deployment (recommended)
+
+Run Homelable's backend with the ServiceAccount below and set
+`KUBERNETES_SOURCE=in_cluster`. Kubernetes supplies a short-lived projected
+token to the Pod; no Kubernetes credential is placed in Homelable's database,
+environment, or UI.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homelable-topology
+  namespace: homelable
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homelable-topology-reader
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes", "pods", "services", "endpoints"]
+    verbs: ["list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homelable-topology-reader
+subjects:
+  - kind: ServiceAccount
+    name: homelable-topology
+    namespace: homelable
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homelable-topology-reader
+```
+
+Reference the ServiceAccount from the backend Deployment:
+
+```yaml
+spec:
+  template:
+    spec:
+      serviceAccountName: homelable-topology
+```
+
+Keep the namespace in the examples consistent with the namespace where the
+backend is deployed. Before rollout, verify the exact grant from the backend
+ServiceAccount:
+
+```bash
+kubectl auth can-i --as=system:serviceaccount:homelable:homelable-topology list pods --all-namespaces
+kubectl auth can-i --as=system:serviceaccount:homelable:homelable-topology get secrets --all-namespaces
+```
+
+The first command should return `yes`; the second must return `no`.
+
+### External installation with kubeconfig (advanced)
+
+For Docker or bare-metal installs outside Kubernetes, create a kubeconfig for
+an identity bound to the same reader ClusterRole. Mount it read-only and store
+only its path in the environment:
+
+```yaml
+services:
+  backend:
+    volumes:
+      - ./homelable-topology.kubeconfig:/run/secrets/homelable-topology.kubeconfig:ro
+    environment:
+      KUBERNETES_ENABLED: "true"
+      KUBERNETES_SOURCE: kubeconfig
+      KUBERNETES_KUBECONFIG_PATH: /run/secrets/homelable-topology.kubeconfig
+      KUBERNETES_KUBECONFIG_CONTEXT: homelable-topology
+```
+
+Do not paste kubeconfig contents into the web UI, add a token to `.env`, or
+commit the kubeconfig. The path is configuration only; the kubeconfig itself
+is a credential and must remain outside the repository with restrictive file
+permissions.
+
+## Security and data boundaries
+
+The collector requires only `list`. It does **not** request `get`,
+`watch`, create, update, patch, delete, exec, attach, port-forward, log, or
+impersonation permissions. It must not be granted access to Secrets,
+ConfigMaps, Events, `pods/log`, or `pods/exec`.
+
+The published topology intentionally excludes:
+
+- Secret and ConfigMap contents;
+- labels and annotations;
+- container environment, arguments, image pull credentials, and volumes;
+- kubeconfig material, bearer tokens, and API-server credentials;
+- logs and events.
+
+Only the minimal identity, kind, namespace/name, safe summary state, and
+topology relationships required to draw and query the graph are retained.
+Treat hostnames, IP addresses, and exposed route paths as infrastructure
+metadata: protect the REST API and MCP service accordingly.
+
+`homelable://kubernetes/topology` is a read-only MCP **resource**; it does not
+add a Kubernetes write tool. For an agent that must not receive any canvas or
+scan tool, run a separate MCP listener with a different `MCP_API_KEY` and:
+
+```env
+MCP_READ_ONLY=true
+```
+
+That listener registers resources but no tools, including no tool-call handler.
+Do not share its API key with a full-access MCP listener. Process-level
+read-only mode intentionally does not provide per-key resource filtering: the
+agent can still read the other resources served by that listener. Put strict
+topology-only access behind a separate deployment or authorization layer that
+filters resources.
+
+For Docker Compose installs, keep the additional API key in an untracked file
+such as `mcp-read-only.env`, then add a separate listener in a Compose override:
+
+```env
+# mcp-read-only.env — do not commit this file
+MCP_API_KEY=mcp_sk_different_read_only_key
+```
+
+```yaml
+# compose.read-only-mcp.yml
+services:
+  mcp-read-only:
+    image: ghcr.io/pouzor/homelable-mcp:latest
+    # Use `build: { context: ./mcp, dockerfile: Dockerfile.mcp }` for a source build.
+    restart: unless-stopped
+    env_file:
+      - .env
+      - ./mcp-read-only.env
+    environment:
+      BACKEND_URL: http://backend:8000
+      MCP_READ_ONLY: "true"
+    ports:
+      - "127.0.0.1:8002:8001"
+    depends_on:
+      - backend
+    networks:
+      - homelable
+```
+
+Start it alongside the normal Compose file with:
+
+```bash
+docker compose -f docker-compose.yml -f compose.read-only-mcp.yml up -d mcp-read-only
+```
+
+The read-only listener can share `MCP_SERVICE_KEY` with the normal listener:
+that key authenticates the MCP service to the backend. Only `MCP_API_KEY` is
+client-facing and must be distinct.
+
+## Sync state
+
+Every topology response includes a sync state:
+
+| State | Meaning |
+|---|---|
+| `disabled` | Kubernetes observation is disabled by configuration. The topology is empty. |
+| `never_synced` | Observation is enabled but no complete snapshot exists yet. Check whether a credential source is configured. |
+| `fresh` | The most recent scheduled or manual sync completed successfully. |
+| `stale` | The last good snapshot is still available, but a later sync did not complete or the successful snapshot is overdue. |
+| `error` | No complete topology snapshot is available; inspect the status endpoint and backend logs. |
+
+Topology represents Kubernetes' declared and discovered routing relationships.
+It is not a network-policy analyzer, a request trace, or a health guarantee.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import { bootstrapAuth } from '@/auth/bootstrap'
 import { RackCanvas } from '@/rack/components/RackCanvas'
 import { RackCablePanel } from '@/rack/components/RackCablePanel'
 import { useRackStore } from '@/rack/store'
+import { KubernetesTopologyView } from '@/components/kubernetes/KubernetesTopologyView'
 import type { NodeData, EdgeData, CustomStyleDef, DesignType, FloorMapConfig, NodeType } from '@/types'
 import type { ZigbeeNode, ZigbeeEdge } from '@/components/zigbee/types'
 import type { ZwaveNode, ZwaveEdge } from '@/components/zwave/types'
@@ -142,6 +143,9 @@ export default function App() {
   const [zigbeeImportOpen, setZigbeeImportOpen] = useState(false)
   const [zwaveImportOpen, setZwaveImportOpen] = useState(false)
   const [proxmoxImportOpen, setProxmoxImportOpen] = useState(false)
+  // This is intentionally separate from designs: Kubernetes resources are
+  // observed state, never editable canvas data.
+  const [showKubernetes, setShowKubernetes] = useState(false)
 
   // Declare handleSave before the Ctrl+S effect so it is in scope.
   // Returns true on success, false on failure — the design-switch effect relies
@@ -1041,9 +1045,11 @@ export default function App() {
             onOpenSettings={() => setSettingsOpen(true)}
             onOpenHistory={() => setScanHistoryOpen(true)}
             onOpenInventory={openInventoryModal}
+            onOpenKubernetes={() => setShowKubernetes((current) => !current)}
+            showKubernetes={showKubernetes}
           />
           <div className="flex flex-col flex-1 min-w-0">
-            {loadError && (
+            {loadError && !showKubernetes && (
               <div
                 role="alert"
                 className="flex items-center justify-between gap-3 bg-[#3d1418] border-b border-[#f85149] px-4 py-2 text-sm text-[#ffa198]"
@@ -1058,50 +1064,52 @@ export default function App() {
                 </button>
               </div>
             )}
-            <Toolbar
-              onSave={handleSave}
-              onAutoLayout={handleAutoLayout}
-              onExport={handleExport}
-              onChangeStyle={() => setThemeModalOpen(true)}
-              onUndo={undo}
-              onRedo={redo}
-              onShortcuts={() => setShortcutsOpen(true)}
-              onExportMd={handleExportMd}
-              onExportYaml={handleExportYaml}
-              onImportYaml={handleImportYaml}
-              onViewOnly={handleViewOnly}
-            />
-            <div className="flex flex-1 min-h-0">
-              <div ref={canvasRef} className="flex-1 min-w-0 h-full">
-                {isRackDesign ? (
-                  <RackCanvas />
-                ) : (
-                  <CanvasContainer
-                    onConnect={handleEdgeConnect}
-                    onEdgeDoubleClick={handleEdgeDoubleClick}
-                    onNodeDoubleClick={handleNodeDoubleClick}
-                    onNodeDragStart={snapshotHistory}
-                    onRequestAddToGroup={setPendingGroupAdd}
-                    onRequestAddToContainer={setPendingContainerAdd}
-                    onRequestAddToZone={setPendingZoneAdd}
-                    onOpenInventory={(deviceId) => openInventoryModal(deviceId)}
-                  />
-                )}
-              </div>
-              {/* Rack designs keep the full width for mounted gear — a mount is
-                  edited in its own modal — but a selected cable has no plate to
-                  double-click, so it gets the rail. */}
-              {isRackDesign
-                ? <RackCablePanel />
-                : (selectedNodeId || selectedNodeIds.length > 1) && (
-                    <DetailPanel
-                      onEdit={handleEditNode}
-                      // Standalone has no Device Inventory to open (ADR-001 style
-                      // gate: the whole scan surface is backend-only).
-                      onOpenInventory={STANDALONE ? undefined : (deviceId) => openInventoryModal(deviceId)}
+            {showKubernetes ? <KubernetesTopologyView /> : <>
+              <Toolbar
+                onSave={handleSave}
+                onAutoLayout={handleAutoLayout}
+                onExport={handleExport}
+                onChangeStyle={() => setThemeModalOpen(true)}
+                onUndo={undo}
+                onRedo={redo}
+                onShortcuts={() => setShortcutsOpen(true)}
+                onExportMd={handleExportMd}
+                onExportYaml={handleExportYaml}
+                onImportYaml={handleImportYaml}
+                onViewOnly={handleViewOnly}
+              />
+              <div className="flex flex-1 min-h-0">
+                <div ref={canvasRef} className="flex-1 min-w-0 h-full">
+                  {isRackDesign ? (
+                    <RackCanvas />
+                  ) : (
+                    <CanvasContainer
+                      onConnect={handleEdgeConnect}
+                      onEdgeDoubleClick={handleEdgeDoubleClick}
+                      onNodeDoubleClick={handleNodeDoubleClick}
+                      onNodeDragStart={snapshotHistory}
+                      onRequestAddToGroup={setPendingGroupAdd}
+                      onRequestAddToContainer={setPendingContainerAdd}
+                      onRequestAddToZone={setPendingZoneAdd}
+                      onOpenInventory={(deviceId) => openInventoryModal(deviceId)}
                     />
                   )}
-            </div>
+                </div>
+                {/* Rack designs keep the full width for mounted gear — a mount is
+                    edited in its own modal — but a selected cable has no plate to
+                    double-click, so it gets the rail. */}
+                {isRackDesign
+                  ? <RackCablePanel />
+                  : (selectedNodeId || selectedNodeIds.length > 1) && (
+                      <DetailPanel
+                        onEdit={handleEditNode}
+                        // Standalone has no Device Inventory to open (ADR-001 style
+                        // gate: the whole scan surface is backend-only).
+                        onOpenInventory={STANDALONE ? undefined : (deviceId) => openInventoryModal(deviceId)}
+                      />
+                    )}
+              </div>
+            </>}
           </div>
         </div>
 

--- a/frontend/src/api/__tests__/kubernetes.test.ts
+++ b/frontend/src/api/__tests__/kubernetes.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({ get: vi.fn() }))
+vi.mock('../client', () => ({ api: { get: hoisted.get } }))
+
+import { kubernetesApi } from '../kubernetes'
+
+describe('kubernetesApi', () => {
+  it('only exposes read-only status and topology endpoints', () => {
+    kubernetesApi.status()
+    kubernetesApi.topology()
+
+    expect(hoisted.get).toHaveBeenNthCalledWith(1, '/kubernetes/status')
+    expect(hoisted.get).toHaveBeenNthCalledWith(2, '/kubernetes/topology')
+    expect(Object.keys(kubernetesApi)).toEqual(['status', 'topology'])
+  })
+})

--- a/frontend/src/api/kubernetes.ts
+++ b/frontend/src/api/kubernetes.ts
@@ -1,0 +1,8 @@
+import { api } from './client'
+import type { KubernetesStatus, KubernetesTopology } from '@/types/kubernetes'
+
+/** Read-only Kubernetes topology endpoints. There are intentionally no CRUD calls here. */
+export const kubernetesApi = {
+  status: () => api.get<KubernetesStatus>('/kubernetes/status'),
+  topology: () => api.get<KubernetesTopology>('/kubernetes/topology'),
+}

--- a/frontend/src/components/kubernetes/KubernetesTopologyView.tsx
+++ b/frontend/src/components/kubernetes/KubernetesTopologyView.tsx
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { kubernetesApi } from '@/api/kubernetes'
+import type {
+  KubernetesStatus,
+  KubernetesSync,
+  KubernetesSyncState,
+  KubernetesTopology,
+  KubernetesTopologyObject,
+  KubernetesTopologyRelationship,
+} from '@/types/kubernetes'
+
+const PRIMARY_KINDS = new Set(['Ingress', 'Service', 'Deployment', 'StatefulSet', 'DaemonSet'])
+const WORKLOAD_KINDS = new Set(['Deployment', 'StatefulSet', 'DaemonSet', 'Job', 'CronJob'])
+const SAFE_PROPERTY_KEYS = new Set(['host', 'path', 'port', 'ports', 'endpointType', 'type', 'clusterIP', 'externalName'])
+
+type LoadState = 'loading' | 'ready' | 'disabled' | 'error'
+
+function syncTone(state: KubernetesSyncState | undefined): string {
+  switch (state) {
+    case 'fresh': return 'border-[#39d353]/40 bg-[#39d353]/10 text-[#7ee787]'
+    case 'stale': return 'border-[#e3b341]/40 bg-[#e3b341]/10 text-[#e3b341]'
+    case 'error': return 'border-[#f85149]/40 bg-[#f85149]/10 text-[#ffa198]'
+    case 'syncing': return 'border-[#00d4ff]/40 bg-[#00d4ff]/10 text-[#00d4ff]'
+    default: return 'border-border bg-[#21262d] text-muted-foreground'
+  }
+}
+
+function syncLabel(state: KubernetesSyncState | undefined): string {
+  return (state ?? 'never_synced').replace('_', ' ')
+}
+
+function formatTime(value?: string | null): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+function isVisibleObject(
+  object: KubernetesTopologyObject,
+  namespace: string,
+  kind: string,
+  search: string,
+): boolean {
+  if (namespace !== 'all' && object.namespace !== namespace) return false
+  if (kind !== 'all' && object.kind !== kind) return false
+  const needle = search.trim().toLowerCase()
+  if (!needle) return true
+  return [object.name, object.namespace, object.kind, object.status]
+    .filter((value): value is string => Boolean(value))
+    .some((value) => value.toLowerCase().includes(needle))
+}
+
+function propertyText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(propertyText).join(', ')
+  if (typeof value === 'string' || typeof value === 'number') return String(value)
+  return ''
+}
+
+function relationshipProperty(relationship: KubernetesTopologyRelationship, key: string): string {
+  return propertyText(relationship.properties?.[key])
+}
+
+function routeLabel(relationship: KubernetesTopologyRelationship): string {
+  const host = relationshipProperty(relationship, 'host')
+  const path = relationshipProperty(relationship, 'path') || '/'
+  const port = relationshipProperty(relationship, 'port')
+  return [host && `${host}${path}`, port && `:${port}`].filter(Boolean).join(' ') || 'default backend'
+}
+
+function relationTargets(
+  relationships: KubernetesTopologyRelationship[],
+  source: string,
+  kind: string,
+): string[] {
+  return relationships
+    .filter((relationship) => relationship.source === source && relationship.kind === kind)
+    .map((relationship) => relationship.target)
+}
+
+interface ResourceCardProps {
+  object: KubernetesTopologyObject
+  selected: boolean
+  onSelect: (object: KubernetesTopologyObject) => void
+  children?: React.ReactNode
+  testId?: string
+}
+
+function ResourceCard({ object, selected, onSelect, children, testId }: ResourceCardProps) {
+  return (
+    <article
+      data-testid={testId}
+      className={`rounded-lg border p-3 shadow-sm transition-colors ${selected ? 'border-[#00d4ff] bg-[#00d4ff]/10' : 'border-border bg-[#161b22]'}`}
+    >
+      <button
+        type="button"
+        aria-pressed={selected}
+        onClick={() => onSelect(object)}
+        className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#00d4ff] rounded"
+      >
+        <span className="block text-[11px] font-medium uppercase tracking-wide text-[#00d4ff]">{object.kind}</span>
+        <span className="mt-1 block break-words text-sm font-medium text-foreground">{object.name}</span>
+        {object.namespace && <span className="mt-0.5 block text-xs text-muted-foreground">{object.namespace}</span>}
+        {object.status && <span className="mt-1 block text-xs text-muted-foreground">{object.status}</span>}
+      </button>
+      {children}
+    </article>
+  )
+}
+
+function EmptyColumn({ children }: { children: React.ReactNode }) {
+  return <p className="rounded-lg border border-dashed border-border px-3 py-4 text-xs text-muted-foreground">{children}</p>
+}
+
+export function KubernetesTopologyView() {
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [status, setStatus] = useState<KubernetesStatus | null>(null)
+  const [topology, setTopology] = useState<KubernetesTopology | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [namespace, setNamespace] = useState('all')
+  const [kind, setKind] = useState('all')
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<KubernetesTopologyObject | null>(null)
+  const [expandedWorkloads, setExpandedWorkloads] = useState<Set<string>>(() => new Set())
+
+  const load = useCallback(async () => {
+    setLoadState('loading')
+    setError(null)
+    try {
+      const statusResponse = await kubernetesApi.status()
+      setStatus(statusResponse.data)
+      if (!statusResponse.data.enabled) {
+        setTopology(null)
+        setLoadState('disabled')
+        return
+      }
+      const topologyResponse = await kubernetesApi.topology()
+      setTopology(topologyResponse.data)
+      setLoadState('ready')
+    } catch {
+      setLoadState('error')
+      setError('Could not load the Kubernetes topology. The saved canvas is unaffected.')
+    }
+  }, [])
+
+  useEffect(() => {
+    // Queue the initial request after mount. `load` also backs the explicit
+    // Refresh control; queuing avoids a synchronous state update during the
+    // effect itself while preserving a single loading implementation.
+    const request = window.setTimeout(() => { void load() }, 0)
+    return () => window.clearTimeout(request)
+  }, [load])
+
+  const effectiveSync: KubernetesSync | null = topology?.sync ?? status
+  const objectsById = useMemo(
+    () => new Map(topology?.objects.map((object) => [object.id, object]) ?? []),
+    [topology],
+  )
+  const namespaces = useMemo(
+    () => Array.from(new Set((topology?.objects ?? []).map((object) => object.namespace).filter((value): value is string => Boolean(value)))).sort(),
+    [topology],
+  )
+  const kinds = useMemo(
+    () => Array.from(new Set((topology?.objects ?? []).map((object) => object.kind))).sort(),
+    [topology],
+  )
+  const visibleObjects = useMemo(
+    () => (topology?.objects ?? []).filter((object) => isVisibleObject(object, namespace, kind, search)),
+    [topology, namespace, kind, search],
+  )
+  const visibleIds = useMemo(() => new Set(visibleObjects.map((object) => object.id)), [visibleObjects])
+  const relationships = topology?.relationships ?? []
+  const ingresses = visibleObjects.filter((object) => object.kind === 'Ingress')
+  const services = visibleObjects.filter((object) => object.kind === 'Service')
+  const workloads = visibleObjects.filter((object) => WORKLOAD_KINDS.has(object.kind))
+  const nonPrimaryMatches = visibleObjects.filter((object) => !PRIMARY_KINDS.has(object.kind) && !['Cluster', 'Namespace'].includes(object.kind))
+
+  const toggleWorkload = useCallback((id: string) => {
+    setExpandedWorkloads((current) => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  if (loadState === 'loading') {
+    return <main className="flex h-full flex-1 items-center justify-center text-sm text-muted-foreground" aria-live="polite">Loading Kubernetes topology…</main>
+  }
+
+  if (loadState === 'disabled') {
+    return (
+      <main className="flex h-full flex-1 items-center justify-center p-6">
+        <section className="max-w-lg rounded-lg border border-border bg-[#161b22] p-6 text-center" aria-labelledby="kubernetes-disabled-title">
+          <h1 id="kubernetes-disabled-title" className="text-lg font-semibold">Kubernetes topology is disabled</h1>
+          <p className="mt-2 text-sm text-muted-foreground">Enable and configure the read-only Kubernetes source to see observed workload routing here.</p>
+        </section>
+      </main>
+    )
+  }
+
+  if (loadState === 'error') {
+    return (
+      <main className="flex h-full flex-1 items-center justify-center p-6">
+        <section className="max-w-lg rounded-lg border border-[#f85149]/40 bg-[#3d1418] p-6 text-center" role="alert">
+          <h1 className="text-lg font-semibold text-[#ffa198]">Kubernetes topology unavailable</h1>
+          <p className="mt-2 text-sm text-[#ffa198]">{error}</p>
+          <button type="button" onClick={() => void load()} className="mt-4 rounded border border-[#f85149] px-3 py-1.5 text-sm text-[#ffa198] hover:bg-[#f85149]/20">Retry</button>
+        </section>
+      </main>
+    )
+  }
+
+  const serviceEndpoints = (service: KubernetesTopologyObject) => relationTargets(relationships, service.id, 'has_endpoint')
+  const workloadPods = (workload: KubernetesTopologyObject) => relationTargets(relationships, workload.id, 'owns')
+  const serviceWorkloads = (service: KubernetesTopologyObject) => Array.from(new Set(
+    serviceEndpoints(service).flatMap((endpointId) => relationships
+      .filter((relationship) => relationship.target === endpointId && relationship.kind === 'owns')
+      .map((relationship) => relationship.source))
+      .map((id) => objectsById.get(id))
+      .filter((object): object is KubernetesTopologyObject => Boolean(object)),
+  ))
+
+  return (
+    <main className="flex h-full min-h-0 flex-1 flex-col bg-[#0d1117]" aria-labelledby="kubernetes-topology-title">
+      <header className="flex flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h1 id="kubernetes-topology-title" className="text-base font-semibold">Kubernetes topology</h1>
+            <span className={`rounded-full border px-2 py-0.5 text-xs capitalize ${syncTone(effectiveSync?.state)}`} data-testid="kubernetes-sync-state">
+              {syncLabel(effectiveSync?.state)}
+            </span>
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {topology?.cluster.name ?? 'Cluster'} · observed read-only state
+            {formatTime(effectiveSync?.last_success_at) && ` · last synchronized ${formatTime(effectiveSync?.last_success_at)}`}
+          </p>
+        </div>
+        <button type="button" onClick={() => void load()} className="rounded border border-border bg-[#21262d] px-3 py-1.5 text-sm hover:border-[#00d4ff]">Refresh</button>
+      </header>
+
+      {effectiveSync?.state === 'stale' && (
+        <p className="border-b border-[#e3b341]/40 bg-[#e3b341]/10 px-4 py-2 text-sm text-[#e3b341]" role="status">Showing the last successful topology snapshot; it may be out of date.</p>
+      )}
+      {effectiveSync?.state === 'error' && (
+        <p className="border-b border-[#f85149]/40 bg-[#3d1418] px-4 py-2 text-sm text-[#ffa198]" role="alert">{effectiveSync.last_error || 'The latest Kubernetes synchronization failed. Showing the last known snapshot when available.'}</p>
+      )}
+
+      <section className="flex flex-wrap items-end gap-3 border-b border-border bg-[#161b22] px-4 py-3" aria-label="Topology filters">
+        <label className="flex min-w-48 flex-1 flex-col gap-1 text-xs text-muted-foreground">
+          Search resources
+          <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Name, namespace, kind" className="rounded border border-border bg-[#0d1117] px-2 py-1.5 text-sm text-foreground" />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Namespace
+          <select value={namespace} onChange={(event) => setNamespace(event.target.value)} className="rounded border border-border bg-[#0d1117] px-2 py-1.5 text-sm text-foreground">
+            <option value="all">All namespaces</option>
+            {namespaces.map((value) => <option key={value} value={value}>{value}</option>)}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Kind
+          <select value={kind} onChange={(event) => setKind(event.target.value)} className="rounded border border-border bg-[#0d1117] px-2 py-1.5 text-sm text-foreground">
+            <option value="all">All kinds</option>
+            {kinds.map((value) => <option key={value} value={value}>{value}</option>)}
+          </select>
+        </label>
+      </section>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-auto p-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.25fr)_minmax(16rem,0.8fr)]">
+        <TopologyColumn title="Ingresses" count={ingresses.length}>
+          {ingresses.length === 0 ? <EmptyColumn>No matching Ingresses.</EmptyColumn> : ingresses.map((ingress) => {
+            const routes = relationships.filter((relationship) => relationship.source === ingress.id && relationship.kind === 'routes_to')
+            return (
+              <ResourceCard key={ingress.id} object={ingress} selected={selected?.id === ingress.id} onSelect={setSelected} testId="kubernetes-ingress-card">
+                {routes.length > 0 && <ul className="mt-2 space-y-1 border-t border-border pt-2 text-xs text-muted-foreground" aria-label={`${ingress.name} routes`}>
+                  {routes.map((route) => <li key={`${route.target}-${routeLabel(route)}`}><span className="text-[#00d4ff]">→</span> {objectsById.get(route.target)?.name ?? 'Unknown service'} <span className="text-[#8b949e]">{routeLabel(route)}</span></li>)}
+                </ul>}
+              </ResourceCard>
+            )
+          })}
+        </TopologyColumn>
+
+        <TopologyColumn title="Services" count={services.length}>
+          {services.length === 0 ? <EmptyColumn>No matching Services.</EmptyColumn> : services.map((service) => {
+            const endpoints = serviceEndpoints(service).filter((id) => visibleIds.has(id) || kind === 'all')
+            const targetWorkloads = serviceWorkloads(service)
+            const externalEndpoints = endpoints.map((id) => objectsById.get(id)).filter((object): object is KubernetesTopologyObject => object?.kind === 'ExternalEndpoint')
+            return (
+              <ResourceCard key={service.id} object={service} selected={selected?.id === service.id} onSelect={setSelected} testId="kubernetes-service-card">
+                <p className="mt-2 border-t border-border pt-2 text-xs text-muted-foreground">{endpoints.length} ready endpoint{endpoints.length === 1 ? '' : 's'}</p>
+                {targetWorkloads.length > 0 && <p className="mt-1 text-xs text-muted-foreground"><span className="text-[#00d4ff]">→</span> {targetWorkloads.map((workload) => workload.name).join(', ')}</p>}
+                {externalEndpoints.length > 0 && <p className="mt-1 text-xs text-muted-foreground">External: {externalEndpoints.map((endpoint) => endpoint.name).join(', ')}</p>}
+              </ResourceCard>
+            )
+          })}
+        </TopologyColumn>
+
+        <TopologyColumn title="Workloads" count={workloads.length}>
+          {workloads.length === 0 ? <EmptyColumn>No matching workloads.</EmptyColumn> : workloads.map((workload) => {
+            const podIds = workloadPods(workload)
+            const isExpanded = expandedWorkloads.has(workload.id)
+            return (
+              <ResourceCard key={workload.id} object={workload} selected={selected?.id === workload.id} onSelect={setSelected} testId="kubernetes-workload-card">
+                <button
+                  type="button"
+                  aria-expanded={isExpanded}
+                  onClick={() => toggleWorkload(workload.id)}
+                  className="mt-2 rounded border border-border px-2 py-1 text-xs text-muted-foreground hover:border-[#00d4ff] hover:text-foreground"
+                >
+                  {isExpanded ? 'Hide pods and nodes' : `Show pods and nodes (${podIds.length})`}
+                </button>
+                {isExpanded && <ul className="mt-2 space-y-2 border-t border-border pt-2" aria-label={`${workload.name} pods and nodes`}>
+                  {podIds.length === 0 ? <li className="text-xs text-muted-foreground">No observed Pods.</li> : podIds.map((podId) => {
+                    const pod = objectsById.get(podId)
+                    if (!pod) return null
+                    const node = relationTargets(relationships, pod.id, 'scheduled_on').map((id) => objectsById.get(id)).find(Boolean)
+                    return <li key={pod.id} className="rounded border border-border bg-[#0d1117] p-2 text-xs">
+                      <button type="button" onClick={() => setSelected(pod)} className="block text-left text-foreground hover:text-[#00d4ff]">Pod: {pod.name}</button>
+                      {node && <button type="button" onClick={() => setSelected(node)} className="mt-1 block text-left text-muted-foreground hover:text-[#00d4ff]">Node: {node.name}</button>}
+                    </li>
+                  })}
+                </ul>}
+              </ResourceCard>
+            )
+          })}
+        </TopologyColumn>
+
+        <aside className="min-w-0" aria-label="Resource details">
+          <h2 className="mb-2 text-sm font-semibold">Details</h2>
+          {selected ? <ResourceDetails object={selected} /> : <EmptyColumn>Select a resource to inspect its safe topology details.</EmptyColumn>}
+          {kind !== 'all' && !PRIMARY_KINDS.has(kind) && nonPrimaryMatches.length > 0 && (
+            <section className="mt-5">
+              <h2 className="mb-2 text-sm font-semibold">Matching resources</h2>
+              <div className="space-y-2">{nonPrimaryMatches.map((object) => <ResourceCard key={object.id} object={object} selected={selected?.id === object.id} onSelect={setSelected} />)}</div>
+            </section>
+          )}
+        </aside>
+      </div>
+    </main>
+  )
+}
+
+function TopologyColumn({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return <section className="min-w-0"><h2 className="mb-2 text-sm font-semibold">{title} <span className="font-mono text-xs font-normal text-muted-foreground">{count}</span></h2><div className="space-y-3">{children}</div></section>
+}
+
+function ResourceDetails({ object }: { object: KubernetesTopologyObject }) {
+  const safeProperties = Object.entries(object.properties ?? {}).filter(([key]) => SAFE_PROPERTY_KEYS.has(key)).map(([key, value]) => [key, propertyText(value)] as const).filter(([, value]) => Boolean(value))
+  return (
+    <section className="rounded-lg border border-border bg-[#161b22] p-3 text-sm" data-testid="kubernetes-detail-panel">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-[#00d4ff]">{object.kind}</p>
+      <h3 className="mt-1 break-words font-medium">{object.name}</h3>
+      <dl className="mt-3 space-y-2 text-xs">
+        {object.namespace && <DetailRow label="Namespace" value={object.namespace} />}
+        {object.status && <DetailRow label="Status" value={object.status} />}
+        {safeProperties.map(([key, value]) => <DetailRow key={key} label={key} value={value} />)}
+      </dl>
+      <p className="mt-4 border-t border-border pt-3 text-xs text-muted-foreground">Observed read-only topology. Kubernetes manifests, labels, annotations, and credentials are not shown.</p>
+    </section>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return <div><dt className="text-muted-foreground">{label}</dt><dd className="mt-0.5 break-words font-mono text-foreground">{value}</dd></div>
+}

--- a/frontend/src/components/kubernetes/__tests__/KubernetesTopologyView.test.tsx
+++ b/frontend/src/components/kubernetes/__tests__/KubernetesTopologyView.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@/api/kubernetes', () => ({
+  kubernetesApi: {
+    status: vi.fn(),
+    topology: vi.fn(),
+  },
+}))
+
+import { kubernetesApi } from '@/api/kubernetes'
+import { KubernetesTopologyView } from '../KubernetesTopologyView'
+
+const status = {
+  enabled: true,
+  configured: true,
+  state: 'fresh' as const,
+  last_success_at: '2026-08-30T12:00:00Z',
+  last_attempt_at: '2026-08-30T12:00:00Z',
+  last_error: null,
+  object_count: 7,
+  relationship_count: 7,
+}
+
+const topology = {
+  schemaVersion: 1,
+  cluster: { id: 'kubernetes://homelab', name: 'homelab' },
+  sync: status,
+  objects: [
+    { id: 'ingress', kind: 'Ingress', name: 'grafana', namespace: 'monitoring', status: null },
+    { id: 'service', kind: 'Service', name: 'grafana', namespace: 'monitoring', status: null },
+    { id: 'deployment', kind: 'Deployment', name: 'grafana', namespace: 'monitoring', status: 'available' },
+    { id: 'pod', kind: 'Pod', name: 'grafana-7cdb8d', namespace: 'monitoring', status: 'running' },
+    { id: 'node', kind: 'Node', name: 'k8s-node1', status: 'ready', properties: { roles: ['control-plane'], labels: { unsafe: true } } },
+    { id: 'external-service', kind: 'Service', name: 'home-assistant', namespace: 'home-assistant', status: null },
+    { id: 'external-endpoint', kind: 'ExternalEndpoint', name: '192.168.40.20', namespace: 'home-assistant', status: 'online' },
+  ],
+  relationships: [
+    { source: 'ingress', target: 'service', kind: 'routes_to', properties: { host: 'grafana.trash.lan', path: '/', port: 3000 } },
+    { source: 'service', target: 'pod', kind: 'has_endpoint', properties: { endpointType: 'pod' } },
+    { source: 'deployment', target: 'pod', kind: 'owns' },
+    { source: 'pod', target: 'node', kind: 'scheduled_on' },
+    { source: 'external-service', target: 'external-endpoint', kind: 'has_endpoint', properties: { endpointType: 'external' } },
+  ],
+}
+
+function mockReady(overrides: Partial<typeof topology> = {}) {
+  vi.mocked(kubernetesApi.status).mockResolvedValue({ data: status } as never)
+  vi.mocked(kubernetesApi.topology).mockResolvedValue({ data: { ...topology, ...overrides } } as never)
+}
+
+describe('KubernetesTopologyView', () => {
+  beforeEach(() => {
+    vi.mocked(kubernetesApi.status).mockReset()
+    vi.mocked(kubernetesApi.topology).mockReset()
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders the collapsed ingress → service → workload path and route labels', async () => {
+    mockReady()
+    render(<KubernetesTopologyView />)
+
+    await waitFor(() => expect(screen.getByText('Kubernetes topology')).toBeInTheDocument())
+    expect(screen.getByTestId('kubernetes-sync-state')).toHaveTextContent('fresh')
+    expect(screen.getByTestId('kubernetes-ingress-card')).toHaveTextContent('grafana')
+    expect(screen.getByTestId('kubernetes-ingress-card')).toHaveTextContent('grafana.trash.lan/')
+    expect(screen.getByTestId('kubernetes-ingress-card')).toHaveTextContent(':3000')
+    expect(screen.getAllByTestId('kubernetes-service-card')[0]).toHaveTextContent('1 ready endpoint')
+    expect(screen.getByTestId('kubernetes-workload-card')).toHaveTextContent('grafana')
+    expect(screen.queryByText('Pod: grafana-7cdb8d')).not.toBeInTheDocument()
+  })
+
+  it('expands a workload to show its pods and scheduled nodes', async () => {
+    const user = userEvent.setup()
+    mockReady()
+    render(<KubernetesTopologyView />)
+
+    await screen.findByRole('button', { name: 'Show pods and nodes (1)' })
+    await user.click(screen.getByRole('button', { name: 'Show pods and nodes (1)' }))
+
+    expect(screen.getByText('Pod: grafana-7cdb8d')).toBeInTheDocument()
+    expect(screen.getByText('Node: k8s-node1')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Hide pods and nodes' })).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('filters by namespace, kind, and searchable resource text', async () => {
+    const user = userEvent.setup()
+    mockReady()
+    render(<KubernetesTopologyView />)
+
+    await screen.findByTestId('kubernetes-ingress-card')
+    await user.selectOptions(screen.getByLabelText('Namespace'), 'home-assistant')
+    expect(screen.queryByTestId('kubernetes-ingress-card')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId('kubernetes-service-card')).toHaveLength(1)
+    expect(screen.getAllByTestId('kubernetes-service-card')[0]).toHaveTextContent('home-assistant')
+
+    await user.selectOptions(screen.getByLabelText('Kind'), 'ExternalEndpoint')
+    expect(screen.getByText('Matching resources')).toBeInTheDocument()
+    expect(screen.getByText('192.168.40.20')).toBeInTheDocument()
+
+    await user.clear(screen.getByLabelText('Search resources'))
+    await user.type(screen.getByLabelText('Search resources'), 'does-not-exist')
+    expect(screen.queryByText('192.168.40.20')).not.toBeInTheDocument()
+  })
+
+  it('shows stale state without hiding the last successful topology', async () => {
+    const stale = { ...status, state: 'stale' as const }
+    vi.mocked(kubernetesApi.status).mockResolvedValue({ data: stale } as never)
+    vi.mocked(kubernetesApi.topology).mockResolvedValue({ data: { ...topology, sync: stale } } as never)
+    render(<KubernetesTopologyView />)
+
+    await screen.findByText(/Showing the last successful topology snapshot/)
+    expect(screen.getAllByTestId('kubernetes-service-card')[0]).toHaveTextContent('grafana')
+  })
+
+  it('reports disabled sources without trying to fetch topology', async () => {
+    vi.mocked(kubernetesApi.status).mockResolvedValue({ data: { ...status, enabled: false, configured: false, state: 'disabled' } } as never)
+    render(<KubernetesTopologyView />)
+
+    await screen.findByText('Kubernetes topology is disabled')
+    expect(kubernetesApi.topology).not.toHaveBeenCalled()
+  })
+
+  it('shows a retryable error when status cannot be loaded', async () => {
+    vi.mocked(kubernetesApi.status).mockRejectedValue(new Error('offline'))
+    render(<KubernetesTopologyView />)
+
+    await screen.findByText('Kubernetes topology unavailable')
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('has no editable canvas controls and does not disclose arbitrary properties', async () => {
+    const user = userEvent.setup()
+    mockReady()
+    render(<KubernetesTopologyView />)
+
+    await screen.findByTestId('kubernetes-ingress-card')
+    await user.click(screen.getByRole('button', { name: 'Show pods and nodes (1)' }))
+    await user.click(screen.getByRole('button', { name: 'Node: k8s-node1' }))
+    expect(screen.getByTestId('kubernetes-detail-panel')).not.toHaveTextContent('unsafe')
+    expect(screen.queryByRole('button', { name: /save|edit|delete|add node|connect/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/panels/Sidebar.tsx
+++ b/frontend/src/components/panels/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { Plus, Save, ScanLine, ChevronLeft, ChevronRight, LayoutDashboard, Clock, EyeOff, Square, Settings, LogOut, Network, RadioTower, Server, Type, PlusCircle, Pencil, Trash2, Rows3 } from 'lucide-react'
+import { Plus, Save, ScanLine, ChevronLeft, ChevronRight, LayoutDashboard, Clock, EyeOff, Square, Settings, LogOut, Network, RadioTower, Server, Type, PlusCircle, Pencil, Trash2, Rows3, Boxes } from 'lucide-react'
 import { Logo } from '@/components/ui/Logo'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCanvasStore } from '@/stores/canvasStore'
@@ -35,9 +35,12 @@ interface SidebarProps {
   onOpenSettings: () => void
   onOpenHistory: () => void
   onOpenInventory: (deviceId?: string, status?: 'pending' | 'hidden') => void
+  /** Opens the observed, non-editable Kubernetes topology view. */
+  onOpenKubernetes?: () => void
+  showKubernetes?: boolean
 }
 
-export function Sidebar({ onAddNode, onAddGroupRect, onAddText, onScan, onZigbeeImport, onZwaveImport, onProxmoxImport, onSave, onOpenSettings, onOpenHistory, onOpenInventory }: SidebarProps) {
+export function Sidebar({ onAddNode, onAddGroupRect, onAddText, onScan, onZigbeeImport, onZwaveImport, onProxmoxImport, onSave, onOpenSettings, onOpenHistory, onOpenInventory, onOpenKubernetes, showKubernetes = false }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(false)
   const logout = useAuthStore((s) => s.logout)
   const { designs, activeDesignId, activeDesignType, setActiveDesign, addDesign, updateDesign, removeDesign } = useDesignStore()
@@ -243,8 +246,18 @@ export function Sidebar({ onAddNode, onAddGroupRect, onAddText, onScan, onZigbee
           icon={isRack ? Rows3 : LayoutDashboard}
           label={isRack ? 'Rack view' : 'Canvas'}
           collapsed={collapsed}
-          active
+          active={!showKubernetes}
+          onClick={showKubernetes ? () => onOpenKubernetes?.() : undefined}
         />
+        {!STANDALONE && onOpenKubernetes && (
+          <SidebarItem
+            icon={Boxes}
+            label="Kubernetes"
+            collapsed={collapsed}
+            active={showKubernetes}
+            onClick={onOpenKubernetes}
+          />
+        )}
         {!STANDALONE && PENDING_TRIGGERS.map((t) => (
           <SidebarItem
             key={t.kind}

--- a/frontend/src/types/kubernetes.ts
+++ b/frontend/src/types/kubernetes.ts
@@ -1,0 +1,59 @@
+/**
+ * The deliberately small, read-only contract served by `/kubernetes/topology`.
+ *
+ * These are observed Kubernetes resources, not editable Homelable canvas nodes.
+ * Keep this contract free of labels, annotations, manifests, and credentials so
+ * the same payload is safe to use in the visual view and the agent-facing MCP
+ * resource.
+ */
+export type KubernetesSyncState =
+  | 'disabled'
+  | 'never_synced'
+  | 'syncing'
+  | 'fresh'
+  | 'stale'
+  | 'error'
+
+export interface KubernetesCluster {
+  id: string
+  name: string
+}
+
+export interface KubernetesSync {
+  state: KubernetesSyncState
+  last_success_at?: string | null
+  last_attempt_at?: string | null
+  last_error?: string | null
+  object_count?: number
+  relationship_count?: number
+}
+
+export interface KubernetesTopologyObject {
+  id: string
+  kind: string
+  name: string
+  namespace?: string | null
+  status?: string | null
+  /** A bounded set of safe summary facts (for example ingress host/path/port). */
+  properties?: Record<string, unknown> | null
+}
+
+export interface KubernetesTopologyRelationship {
+  source: string
+  target: string
+  kind: 'contains' | 'owns' | 'scheduled_on' | 'routes_to' | 'has_endpoint' | string
+  properties?: Record<string, unknown> | null
+}
+
+export interface KubernetesTopology {
+  schemaVersion: number
+  cluster: KubernetesCluster
+  sync: KubernetesSync
+  objects: KubernetesTopologyObject[]
+  relationships: KubernetesTopologyRelationship[]
+}
+
+export interface KubernetesStatus extends KubernetesSync {
+  enabled: boolean
+  configured: boolean
+}

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -10,3 +10,8 @@ MCP_SERVICE_KEY=svc_changeme
 
 # Backend URL — use http://backend:8000 in Docker, http://localhost:8000 for local dev
 BACKEND_URL=http://localhost:8000
+
+# Set true only on a separate MCP listener/API key for topology-only or other
+# read-only agents. Resources remain available, but no canvas mutation or scan
+# tools are registered. The default false preserves the full MCP feature set.
+MCP_READ_ONLY=false

--- a/mcp/app/config.py
+++ b/mcp/app/config.py
@@ -5,6 +5,9 @@ class Settings(BaseSettings):
     mcp_api_key: str = "mcp_sk_changeme"       # AI client → MCP server
     mcp_service_key: str = "svc_changeme"       # MCP server → backend
     backend_url: str = "http://backend:8000"
+    # Run a separate MCP process with this enabled for agents that must only
+    # read resources. The default preserves the existing canvas tools.
+    mcp_read_only: bool = False
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -6,13 +6,25 @@ from starlette.routing import Mount
 
 from .auth import ApiKeyMiddleware
 from .backend_client import backend
+from .config import settings
 from .resources import register_resources
 from .tools import register_tools
 
 
-mcp_server = Server("homelable")
-register_resources(mcp_server)
-register_tools(mcp_server)
+def create_mcp_server(*, read_only: bool | None = None) -> Server:
+    """Build an MCP server with resources and, unless requested, canvas tools.
+
+    A separate process with ``MCP_READ_ONLY=true`` can share the backend but
+    expose no tools to topology-only agents. Keeping this process-level avoids
+    accidentally granting write capabilities through a shared API key.
+    """
+    server = Server("homelable")
+    register_resources(server)
+    register_tools(server, read_only=settings.mcp_read_only if read_only is None else read_only)
+    return server
+
+
+mcp_server = create_mcp_server()
 
 session_manager = StreamableHTTPSessionManager(
     app=mcp_server,

--- a/mcp/app/resources.py
+++ b/mcp/app/resources.py
@@ -9,6 +9,12 @@ RESOURCE_LIST = [
     Resource(uri="homelable://edges",          name="Edges",           description="All network edges/links", mimeType="application/json"),
     Resource(uri="homelable://scan/pending",   name="Pending devices", description="Discovered devices awaiting approval", mimeType="application/json"),
     Resource(uri="homelable://scan/runs",      name="Scan history",    description="Recent scan run history", mimeType="application/json"),
+    Resource(
+        uri="homelable://kubernetes/topology",
+        name="Kubernetes topology",
+        description="Read-only, sanitized observed Kubernetes topology (resources, relationships, and sync state)",
+        mimeType="application/json",
+    ),
 ]
 
 ROUTES = {
@@ -17,6 +23,7 @@ ROUTES = {
     "homelable://edges":        "/api/v1/edges",
     "homelable://scan/pending": "/api/v1/scan/pending",
     "homelable://scan/runs":    "/api/v1/scan/runs",
+    "homelable://kubernetes/topology": "/api/v1/kubernetes/topology",
 }
 
 

--- a/mcp/app/tools.py
+++ b/mcp/app/tools.py
@@ -204,16 +204,20 @@ def _build_tools() -> list[Tool]:
 TOOLS = _build_tools()
 
 
-def register_tools(server: Server):
+def register_tools(server: Server, *, read_only: bool = False):
 
     @server.list_tools()
     async def list_tools():
-        return TOOLS
+        return [] if read_only else TOOLS
 
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict):
-        result = await _dispatch(name, arguments)
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    # Deliberately do not register a call_tool handler in read-only mode. This
+    # makes a dedicated read-only MCP process safe even if a client bypasses
+    # tool discovery and attempts to call a legacy canvas mutation tool.
+    if not read_only:
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict):
+            result = await _dispatch(name, arguments)
+            return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
 
 def _slim_canvas(raw: dict) -> dict:

--- a/mcp/tests/test_read_only.py
+++ b/mcp/tests/test_read_only.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.main import create_mcp_server
+from app.tools import register_tools
+
+
+class CapturingServer:
+    """Minimal decorator-compatible Server fake for capability registration."""
+
+    def list_resources(self):
+        def register(handler):
+            self.list_resources_handler = handler
+            return handler
+
+        return register
+
+    def read_resource(self):
+        def register(handler):
+            self.read_resource_handler = handler
+            return handler
+
+        return register
+
+    def list_tools(self):
+        def register(handler):
+            self.list_tools_handler = handler
+            return handler
+
+        return register
+
+    def call_tool(self):
+        def register(handler):
+            self.call_tool_handler = handler
+            return handler
+
+        return register
+
+
+@pytest.mark.anyio
+async def test_read_only_registration_lists_no_tools_and_has_no_tool_handler():
+    server = CapturingServer()
+
+    register_tools(server, read_only=True)
+
+    assert await server.list_tools_handler() == []
+    assert not hasattr(server, "call_tool_handler")
+
+
+@pytest.mark.anyio
+async def test_default_tool_registration_preserves_existing_tools():
+    server = CapturingServer()
+
+    register_tools(server)
+
+    assert await server.list_tools_handler()
+    assert hasattr(server, "call_tool_handler")
+
+
+@pytest.mark.anyio
+async def test_read_only_server_keeps_kubernetes_resource_readable():
+    server = CapturingServer()
+    with patch("app.main.Server", return_value=server):
+        create_mcp_server(read_only=True)
+
+    resources = await server.list_resources_handler()
+    assert any(str(item.uri) == "homelable://kubernetes/topology" for item in resources)
+    assert await server.list_tools_handler() == []
+
+    with patch("app.resources.backend") as backend:
+        backend.get = AsyncMock(return_value={"schemaVersion": 1, "objects": [], "relationships": []})
+        result = await server.read_resource_handler("homelable://kubernetes/topology")
+
+    backend.get.assert_called_once_with("/api/v1/kubernetes/topology")
+    assert result[0].type == "text"

--- a/mcp/tests/test_resources.py
+++ b/mcp/tests/test_resources.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import AnyUrl
 from unittest.mock import AsyncMock, patch
 from app.resources import read_resource
+from app.resources import RESOURCE_LIST
 
 
 @pytest.fixture
@@ -40,6 +41,23 @@ async def test_read_single_node(mock_backend):
 async def test_read_scan_pending(mock_backend):
     await read_resource("homelable://scan/pending")
     mock_backend.get.assert_called_once_with("/api/v1/scan/pending")
+
+
+@pytest.mark.anyio
+async def test_read_kubernetes_topology(mock_backend):
+    result = await read_resource("homelable://kubernetes/topology")
+
+    mock_backend.get.assert_called_once_with("/api/v1/kubernetes/topology")
+    assert len(result) == 1
+    assert result[0].type == "text"
+
+
+def test_kubernetes_topology_is_a_read_only_resource():
+    resource = next(item for item in RESOURCE_LIST if str(item.uri) == "homelable://kubernetes/topology")
+
+    assert resource.name == "Kubernetes topology"
+    assert resource.mimeType == "application/json"
+    assert "read-only" in resource.description.lower()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Revives #385 (closed by its author as "needs further testing") against current `main`, and fixes the three things that stopped it working against a real cluster. Draft, per your invitation on that PR to reopen it as one. Closes #330 if it lands.

### What was broken

1. **`EndpointSlice` was requested from the wrong API.** `CoreV1Api` has no `list_endpoint_slice_for_all_namespaces` — the type is `discovery.k8s.io/v1`, so `collect()` died on an `AttributeError` before making a single call.
2. **`kubernetes_asyncio`'s `V1EndpointSlice` model rejects `endpoints: null`**, which a slice with no ready addresses legitimately sends: `ValueError: Invalid value for 'endpoints', must not be None`.
3. **Either failure emptied the whole graph.** `_list` raised `KubernetesClientError`, which aborted `collect()`, so one unreadable resource meant zero objects. It now logs and yields nothing for that resource — which also covers a kind the ServiceAccount's RBAC omits.

### Verification

Running in-cluster on a 6-node Talos cluster, via a `list`-only ServiceAccount:

```
state=fresh  objects=275  relationships=288
Pod 103 · Service 54 · ExternalEndpoint 44 · Namespace 31 · Job 17 · Ingress 16 · Node 6 · CronJob 3
```

RBAC used — `list` only, nothing else:

| apiGroup | resources |
|---|---|
| `""` | nodes, namespaces, pods, services, endpoints |
| `discovery.k8s.io` | endpointslices |
| `apps` | deployments, replicasets, statefulsets, daemonsets |
| `batch` | jobs, cronjobs |
| `networking.k8s.io` | ingresses |

The original author's design is unchanged — in-cluster or read-only kubeconfig, credentials never accepted by the API, `MCP_READ_ONLY` respected. I only made it run.

Happy to split the three fixes out if you'd rather review them separately, or to hand them to @LeahArmstrong if she'd prefer to carry #385 herself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)