### PR TITLE
fix: stop a renamed service being duplicated, or hidden, after a scan

### DIFF
--- a/backend/app/services/device_merge.py
+++ b/backend/app/services/device_merge.py
@@ -344,7 +344,14 @@ async def merge_devices(
                     setattr(winner, field, value)
         winner.ip = _merged_ip(winner.ip, loser.ip)
         winner.mac = winner.mac or loser.mac
-        winner.services = merge_services(winner.services, loser.services)
+        # discovered=: the winner is the row the canvas points at (an approved
+        # row wins `_collapse_targets`), and a loser is usually a pending row a
+        # scan just minted, carrying the fingerprint's guess at a name. Both
+        # rows describe one device, so two entries on one port are one service
+        # — and the curated side of it is the winner's. Without this the guess
+        # would overwrite a name, icon or category the user had chosen, in a
+        # collapse that runs unattended during a background scan.
+        winner.services = merge_services(winner.services, loser.services, discovered=True)
         winner.properties = merge_properties(winner.properties, loser.properties)
         winner.show_hardware = winner.show_hardware or loser.show_hardware
         for source in add_source(loser.discovery_sources, loser.discovery_source):

--- a/backend/app/services/device_merge.py
+++ b/backend/app/services/device_merge.py
@@ -37,6 +37,7 @@ from app.services.inventory_sync import (
     ip_tokens,
     merge_properties,
     merge_services,
+    normalize_view_key,
     view_of_device,
 )
 from app.services.node_dedupe import dedupe_nodes_by_device
@@ -189,7 +190,14 @@ async def _show_merged_facts(db: AsyncSession, winner: InventoryDevice) -> int:
                 # No view at all for this list — `apply_view` already shows
                 # everything the row holds, merged facts included.
                 continue
-            listed = {str(e.get("key")) for e in entries if isinstance(e, dict)}
+            # Normalized: a view written before #469 addresses a service by a
+            # key that carries its name, and comparing it raw against a freshly
+            # seeded key would call an already-listed service missing.
+            listed = {
+                normalize_view_key(str(e.get("key")), kind)
+                for e in entries
+                if isinstance(e, dict)
+            }
             missing = [entry for entry in seeds[kind] if entry["key"] not in listed]
             if missing:
                 view[kind] = [*entries, *missing]

--- a/backend/app/services/inventory_sync.py
+++ b/backend/app/services/inventory_sync.py
@@ -199,12 +199,6 @@ def merge_properties(base: list[Any] | None, incoming: list[Any] | None) -> list
     return out
 
 
-def _service_key(svc: Any) -> Any:
-    if not isinstance(svc, dict):
-        return repr(svc)
-    return (svc.get("port"), svc.get("protocol"), (svc.get("service_name") or "").lower())
-
-
 def _service_identity_key(svc: Any) -> Any:
     """What makes two service entries *the same service*, for merging.
 
@@ -212,8 +206,9 @@ def _service_identity_key(svc: Any) -> Any:
     is called. The name is a label on it — the scanner guesses it from a banner
     and the user corrects it — so keying identity on the name made a rename look
     like a second service, and the next scan re-added the original under its own
-    guess (issue #469). :func:`_service_view_key` keeps using the name-inclusive
-    key: its strings are persisted in node views, and this is not that.
+    guess (issue #469). :func:`_service_view_key` renders the same identity, so
+    the two never disagree about what one service is; keys already persisted in
+    node views are narrowed to it on read by :func:`normalize_view_key`.
 
     Only a service with no port falls back to the name, because nothing else
     tells two of them apart — a hand-added entry that names a host rather than a
@@ -263,8 +258,13 @@ def normalize_view_key(key: str, kind: str) -> str:
     name in one is a snapshot of what the service was called when the view was
     written, so a renamed service cannot be found by re-deriving it — the key
     has to be narrowed instead. A key that names a port drops everything after
-    it; one that does not is port-less and is already in its final form, as is
-    every property key.
+    it; one that does not is port-less and keeps its name, as does every
+    property key.
+
+    A port-less service renders its absent port as ``None`` today, but a key
+    written for one carrying ``""`` stored an empty segment instead. Both mean
+    the same absent port, so the empty one is spelled the new way rather than
+    left to miss.
 
     Applied on read, so a view migrates the next time its node is saved rather
     than needing a migration of its own.
@@ -272,7 +272,11 @@ def normalize_view_key(key: str, kind: str) -> str:
     if kind != "services":
         return key
     parts = key.split("|", 2)
-    if len(parts) != 3 or parts[0] in ("", "None"):
+    if len(parts) != 3:
+        return key
+    if parts[0] == "":
+        return f"None|{parts[1]}|{parts[2]}"
+    if parts[0] == "None":
         return key
     return f"{parts[0]}|{parts[1]}"
 

--- a/backend/app/services/inventory_sync.py
+++ b/backend/app/services/inventory_sync.py
@@ -237,8 +237,44 @@ VIEW_LISTS = ("services", "properties")
 
 
 def _service_view_key(svc: Any) -> str:
-    port, protocol, name = _service_key(svc) if isinstance(svc, dict) else (None, None, repr(svc))
-    return f"{port}|{protocol}|{name}"
+    """This service's address in a node's view.
+
+    Same identity as the merge uses, so a rename does not move a service out
+    from under the view that addresses it: before #469 the key carried the name,
+    and renaming a service in the inventory modal made every canvas already
+    drawing it lose track and redraw it hidden.
+
+    A port-less service keeps the three-part form it always had, name included —
+    it is the only thing that identifies one, and rendering ``None`` for the
+    absent port is what the stored keys look like.
+    """
+    if not isinstance(svc, dict):
+        return f"None|None|{repr(svc)}"
+    key = _service_identity_key(svc)
+    if len(key) == 2:
+        return f"{key[0]}|{key[1]}"
+    return f"{key[0]}|{key[1]}|{key[2]}"
+
+
+def normalize_view_key(key: str, kind: str) -> str:
+    """A stored view key in today's form.
+
+    Views written before #469 address a service by ``port|protocol|name``. The
+    name in one is a snapshot of what the service was called when the view was
+    written, so a renamed service cannot be found by re-deriving it — the key
+    has to be narrowed instead. A key that names a port drops everything after
+    it; one that does not is port-less and is already in its final form, as is
+    every property key.
+
+    Applied on read, so a view migrates the next time its node is saved rather
+    than needing a migration of its own.
+    """
+    if kind != "services":
+        return key
+    parts = key.split("|", 2)
+    if len(parts) != 3 or parts[0] in ("", "None"):
+        return key
+    return f"{parts[0]}|{parts[1]}"
 
 
 def _property_view_key(prop: Any) -> str:
@@ -354,7 +390,7 @@ def apply_view(items: list[Any] | None, entries: Any, kind: str) -> list[Any]:
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        key = str(entry.get("key"))
+        key = normalize_view_key(str(entry.get("key")), kind)
         item = by_key.get(key)
         if item is None or key in taken:
             continue  # Deleted from the row since — the view catches up on write.

--- a/backend/app/services/inventory_sync.py
+++ b/backend/app/services/inventory_sync.py
@@ -205,6 +205,28 @@ def _service_key(svc: Any) -> Any:
     return (svc.get("port"), svc.get("protocol"), (svc.get("service_name") or "").lower())
 
 
+def _service_identity_key(svc: Any) -> Any:
+    """What makes two service entries *the same service*, for merging.
+
+    A port is the identity: one port on one protocol is one service, whatever it
+    is called. The name is a label on it — the scanner guesses it from a banner
+    and the user corrects it — so keying identity on the name made a rename look
+    like a second service, and the next scan re-added the original under its own
+    guess (issue #469). :func:`_service_view_key` keeps using the name-inclusive
+    key: its strings are persisted in node views, and this is not that.
+
+    Only a service with no port falls back to the name, because nothing else
+    tells two of them apart — a hand-added entry that names a host rather than a
+    port, say. Those still key exactly as they did.
+    """
+    if not isinstance(svc, dict):
+        return repr(svc)
+    port = svc.get("port")
+    if port in (None, ""):
+        return (None, svc.get("protocol"), (svc.get("service_name") or "").lower())
+    return (port, svc.get("protocol"))
+
+
 # --- Per-node view of the device's list facts -----------------------------
 #
 # The row owns the services and the properties; a node owns which of them it
@@ -360,11 +382,13 @@ def _stamped(item: Any, visible: bool) -> Any:
     return {**item, "visible": visible}
 
 
-# How a service looks is the user's call. A fingerprint only ever guesses it
-# from a port number and a banner, so a scan that re-finds a known service must
-# not repaint the icon someone picked by hand — that happened on every "Scan
-# network", across every canvas drawing the device, at once.
-_CURATED_SERVICE_FIELDS = ("icon", "category")
+# How a service looks — and what it is called — is the user's call. A
+# fingerprint only ever guesses it from a port number and a banner, so a scan
+# that re-finds a known service must not repaint the icon someone picked by hand
+# — that happened on every "Scan network", across every canvas drawing the
+# device, at once. `service_name` is curated for the same reason: correcting a
+# bad guess is the point of editing a service, and a rescan must not undo it.
+_CURATED_SERVICE_FIELDS = ("icon", "category", "service_name")
 
 
 def merge_services(
@@ -373,17 +397,28 @@ def merge_services(
     *,
     discovered: bool = False,
 ) -> list[Any]:
-    """Union two service lists on (port, protocol, name); incoming wins.
+    """Union two service lists on (port, protocol); incoming wins.
 
     ``discovered`` marks ``incoming`` as scanner output rather than a user edit:
     it still adds services and refreshes facts, but leaves an established icon
     and category alone. Either way a blank incoming value never clears one that
     is already set — an absent field is silence, not a reset.
+
+    ``base`` is collapsed on the same key as it is copied, so a row that already
+    holds the pre-#469 duplicates heals on the next merge instead of needing a
+    migration. First entry wins: the user's renamed service was there before the
+    scan appended its guess, so it is the one that survives.
     """
-    out: list[Any] = [dict(s) if isinstance(s, dict) else s for s in (base or [])]
-    index = {_service_key(s): i for i, s in enumerate(out)}
+    out: list[Any] = []
+    index: dict[Any, int] = {}
+    for svc in base or []:
+        key = _service_identity_key(svc)
+        if key in index:
+            continue
+        out.append(dict(svc) if isinstance(svc, dict) else svc)
+        index[key] = len(out) - 1
     for svc in incoming or []:
-        key = _service_key(svc)
+        key = _service_identity_key(svc)
         pos = index.get(key)
         if pos is None:
             out.append(dict(svc) if isinstance(svc, dict) else svc)

--- a/backend/tests/test_device_merge.py
+++ b/backend/tests/test_device_merge.py
@@ -163,7 +163,10 @@ async def test_merge_shows_the_new_facts_on_a_canvas_that_never_saw_them(db_sess
 
     services = poor.display_view["services"]
     assert [e["visible"] for e in services] == [True, True]
-    assert {e["key"] for e in services} == {"5678|tcp|http", "22|tcp|ssh"}
+    # The pre-existing entry is kept exactly as it was stored — a view is
+    # rewritten by a save, not by a merge — so the key seeded alongside it is
+    # in today's port-keyed form while that one stays in the older one.
+    assert {e["key"] for e in services} == {"5678|tcp|http", "22|tcp"}
     # A property list this canvas had never seen picks up the survivor's.
     assert [e["key"] for e in poor.display_view["properties"]] == ["vmid"]
 

--- a/backend/tests/test_device_merge.py
+++ b/backend/tests/test_device_merge.py
@@ -554,3 +554,74 @@ async def test_merge_route_requires_auth(client, db_session):
         "/api/v1/scan/pending/merge", json={"winner_id": "w", "loser_ids": ["l"]}
     )
     assert res.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_a_merge_keeps_the_survivor_name_for_a_service_on_the_same_port(db_session):
+    """Two rows describing one device describe one service per port.
+
+    The winner is the row the canvas points at, and a loser is usually a pending
+    row a scan minted, carrying the fingerprint's guess. Collapsing the pair must
+    not let that guess overwrite the name, icon and category the user curated —
+    the collapse runs unattended during a background scan.
+    """
+    winner = await _device(
+        db_session, id="w", ip="192.168.1.62",
+        services=[{
+            "port": 80, "protocol": "tcp", "service_name": "Homepage",
+            "icon": "brand:homepage", "category": "monitoring",
+        }],
+    )
+    loser = await _device(
+        db_session, id="l", ip="192.168.1.62",
+        services=[{
+            "port": 80, "protocol": "tcp", "service_name": "nginx",
+            "icon": "Globe", "category": "web", "path": "/dash",
+        }],
+    )
+
+    await merge_devices(db_session, winner, [loser])
+    await db_session.flush()
+
+    assert len(winner.services) == 1
+    assert winner.services[0]["service_name"] == "Homepage"
+    assert winner.services[0]["icon"] == "brand:homepage"
+    assert winner.services[0]["category"] == "monitoring"
+    # Everything that is not the user's call still comes across.
+    assert winner.services[0]["path"] == "/dash"
+
+
+@pytest.mark.asyncio
+async def test_a_merge_still_takes_a_service_the_survivor_never_had(db_session):
+    """Curating the collision must not stop the union doing its job."""
+    winner = await _device(
+        db_session, id="w", ip="192.168.1.62",
+        services=[{"port": 80, "protocol": "tcp", "service_name": "Homepage"}],
+    )
+    loser = await _device(
+        db_session, id="l", ip="192.168.1.62",
+        services=[{"port": 5678, "protocol": "tcp", "service_name": "n8n"}],
+    )
+
+    await merge_devices(db_session, winner, [loser])
+    await db_session.flush()
+
+    assert [s["service_name"] for s in winner.services] == ["Homepage", "n8n"]
+
+
+@pytest.mark.asyncio
+async def test_a_merge_names_a_service_the_survivor_left_unnamed(db_session):
+    """A blank name is silence, so the loser's fills it rather than being dropped."""
+    winner = await _device(
+        db_session, id="w", ip="192.168.1.62",
+        services=[{"port": 80, "protocol": "tcp"}],
+    )
+    loser = await _device(
+        db_session, id="l", ip="192.168.1.62",
+        services=[{"port": 80, "protocol": "tcp", "service_name": "nginx"}],
+    )
+
+    await merge_devices(db_session, winner, [loser])
+    await db_session.flush()
+
+    assert [s["service_name"] for s in winner.services] == ["nginx"]

--- a/backend/tests/test_inventory_sync.py
+++ b/backend/tests/test_inventory_sync.py
@@ -21,6 +21,7 @@ from app.services.inventory_sync import (
     link_facts,
     merge_properties,
     merge_services,
+    normalize_view_key,
     seed_node_views,
 )
 
@@ -1643,3 +1644,44 @@ class TestPerNodeView:
         assert hydrated_node(node, device)["services"] == [
             {"protocol": "tcp", "service_name": "Vaultwarden", "visible": False}
         ]
+
+    @pytest.mark.asyncio
+    async def test_a_port_less_key_stored_with_an_empty_port_still_matches(self, db_session):
+        """`port: ""` used to render an empty first segment, `None` renders it now.
+
+        Both spell the same absent port, so the older one is narrowed to today's
+        rather than missing and dragging the service back into view.
+        """
+        device = InventoryDevice(
+            id="d-1", services=[{"port": "", "protocol": "tcp", "service_name": "Vaultwarden"}]
+        )
+        node = _node(await _design(db_session), device_id="d-1")
+        node.display_view = {
+            "services": [{"key": "|tcp|vaultwarden", "visible": False}],
+            "properties": [],
+        }
+        assert hydrated_node(node, device)["services"] == [
+            {"port": "", "protocol": "tcp", "service_name": "Vaultwarden", "visible": False}
+        ]
+
+
+class TestNormalizeViewKey:
+    """Stored view keys, narrowed to the identity the row is addressed by."""
+
+    def test_a_key_naming_a_port_drops_the_name(self):
+        assert normalize_view_key("3001|tcp|uptime kuma", "services") == "3001|tcp"
+
+    def test_a_key_already_in_todays_form_is_left_alone(self):
+        assert normalize_view_key("3001|tcp", "services") == "3001|tcp"
+
+    def test_a_port_less_key_keeps_its_name(self):
+        assert normalize_view_key("None|tcp|vaultwarden", "services") == "None|tcp|vaultwarden"
+
+    def test_an_empty_port_is_spelled_the_way_it_is_rendered_today(self):
+        assert normalize_view_key("|tcp|vaultwarden", "services") == "None|tcp|vaultwarden"
+
+    def test_a_name_carrying_a_pipe_survives_the_split(self):
+        assert normalize_view_key("None|tcp|a|b", "services") == "None|tcp|a|b"
+
+    def test_a_property_key_is_never_touched(self):
+        assert normalize_view_key("rack", "properties") == "rack"

--- a/backend/tests/test_inventory_sync.py
+++ b/backend/tests/test_inventory_sync.py
@@ -73,7 +73,7 @@ class TestMergeRules:
         assert out[0]["value"] == "A1"
         assert out[0]["icon"] == "Server"
 
-    def test_services_union_on_port_protocol_and_name(self):
+    def test_services_union_on_port_and_protocol(self):
         base = [{"port": 22, "protocol": "tcp", "service_name": "ssh"}]
         incoming = [
             {"port": 22, "protocol": "tcp", "service_name": "SSH", "icon": "Terminal"},
@@ -83,6 +83,77 @@ class TestMergeRules:
         assert len(out) == 2
         assert out[0]["icon"] == "Terminal"
         assert out[1]["port"] == 80
+
+    def test_a_renamed_service_is_not_duplicated_by_the_next_scan(self):
+        """Issue #469: identity is the port, not the name the scanner guessed.
+
+        The user renamed 3001/tcp from "Uptime Kuma" to "Homepage"; the rescan
+        fingerprints the same port and offers its own guess again.
+        """
+        base = [{"port": 3001, "protocol": "tcp", "service_name": "Homepage"}]
+        incoming = [{"port": 3001, "protocol": "tcp", "service_name": "Uptime Kuma"}]
+        out = merge_services(base, incoming, discovered=True)
+        assert len(out) == 1
+        assert out[0]["service_name"] == "Homepage"
+
+    def test_a_scan_still_names_a_service_that_never_had_one(self):
+        out = merge_services(
+            [{"port": 3001, "protocol": "tcp"}],
+            [{"port": 3001, "protocol": "tcp", "service_name": "Uptime Kuma"}],
+            discovered=True,
+        )
+        assert len(out) == 1
+        assert out[0]["service_name"] == "Uptime Kuma"
+
+    def test_a_user_edit_still_renames_a_service(self):
+        """The guard is for scanner output only — an edit is an edit."""
+        out = merge_services(
+            [{"port": 3001, "protocol": "tcp", "service_name": "Uptime Kuma"}],
+            [{"port": 3001, "protocol": "tcp", "service_name": "Homepage"}],
+        )
+        assert len(out) == 1
+        assert out[0]["service_name"] == "Homepage"
+
+    def test_a_scan_refreshes_facts_that_are_not_curated(self):
+        """Only name, icon and category are the user's; the rest is observation."""
+        out = merge_services(
+            [{"port": 3001, "protocol": "tcp", "service_name": "Homepage", "path": "/old"}],
+            [{"port": 3001, "protocol": "tcp", "service_name": "Uptime Kuma", "path": "/new"}],
+            discovered=True,
+        )
+        assert out[0]["service_name"] == "Homepage"
+        assert out[0]["path"] == "/new"
+
+    def test_duplicates_already_on_the_row_collapse_on_the_next_merge(self):
+        """Rows written before the #469 fix heal without a migration.
+
+        First entry wins: the user's rename was there before the scan appended
+        its guess underneath it.
+        """
+        base = [
+            {"port": 3001, "protocol": "tcp", "service_name": "Homepage", "icon": "House"},
+            {"port": 3001, "protocol": "tcp", "service_name": "Uptime Kuma"},
+            {"port": 9090, "protocol": "tcp", "service_name": "Watchtower"},
+            {"port": 9090, "protocol": "tcp", "service_name": "Prometheus"},
+        ]
+        out = merge_services(base, None)
+        assert [s["service_name"] for s in out] == ["Homepage", "Watchtower"]
+        assert out[0]["icon"] == "House"
+
+    def test_port_less_services_still_key_on_their_name(self):
+        """Nothing else tells two of them apart — they must not collapse."""
+        base = [{"protocol": "tcp", "service_name": "Vaultwarden", "host": "vault.lan"}]
+        incoming = [{"protocol": "tcp", "service_name": "Gitea", "host": "git.lan"}]
+        out = merge_services(base, incoming)
+        assert len(out) == 2
+        assert [s["service_name"] for s in out] == ["Vaultwarden", "Gitea"]
+
+    def test_the_same_port_on_udp_and_tcp_stays_two_services(self):
+        out = merge_services(
+            [{"port": 53, "protocol": "tcp", "service_name": "dns"}],
+            [{"port": 53, "protocol": "udp", "service_name": "dns"}],
+        )
+        assert len(out) == 2
 
 
     def test_a_scan_never_repaints_an_icon_the_user_picked(self):

--- a/backend/tests/test_inventory_sync.py
+++ b/backend/tests/test_inventory_sync.py
@@ -1409,7 +1409,7 @@ class TestPerNodeView:
         assert await seed_node_views(db_session) == 1
         await db_session.commit()
         assert node.display_view == {
-            "services": [{"key": "22|tcp|ssh", "visible": True}],
+            "services": [{"key": "22|tcp", "visible": True}],
             "properties": [],
         }
         # Idempotent: a second boot finds nothing without a view.
@@ -1542,7 +1542,7 @@ class TestPerNodeView:
         assert await seed_node_views(db_session, drawn=lambda: drawn) == 1
         await db_session.commit()
 
-        assert node.display_view["services"] == [{"key": "22|tcp|ssh", "visible": True}]
+        assert node.display_view["services"] == [{"key": "22|tcp", "visible": True}]
 
     @pytest.mark.asyncio
     async def test_a_node_without_a_view_still_shows_everything(self, db_session):
@@ -1553,4 +1553,93 @@ class TestPerNodeView:
         node = _node(await _design(db_session), device_id="d-1")
         assert hydrated_node(node, device)["services"] == [
             {"port": 22, "protocol": "tcp", "service_name": "ssh"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_renaming_a_service_does_not_hide_it_on_canvases(
+        self, client: AsyncClient, headers, db_session
+    ):
+        """Issue #469, the view half.
+
+        The view addressed a service by a key carrying its name, so renaming one
+        from the inventory modal left every canvas already drawing it addressing
+        a key the row no longer held — and `apply_view` appends an unlisted fact
+        hidden, so the service vanished from the canvas.
+        """
+        db_session.add(
+            InventoryDevice(
+                id="d-1",
+                ip="10.0.0.5",
+                services=[
+                    {"port": 22, "protocol": "tcp", "service_name": "ssh"},
+                    {"port": 3001, "protocol": "tcp", "service_name": "Uptime Kuma"},
+                ],
+            )
+        )
+        await db_session.commit()
+        node = await self._node_on(client, headers, await _design(db_session))
+
+        res = await client.patch(
+            "/api/v1/scan/pending/d-1",
+            json={"services": [
+                {"port": 22, "protocol": "tcp", "service_name": "ssh"},
+                {"port": 3001, "protocol": "tcp", "service_name": "Homepage"},
+            ]},
+            headers=headers,
+        )
+        assert res.status_code == 200
+
+        drawn = (await client.get(f"/api/v1/nodes/{node['id']}", headers=headers)).json()
+        assert [(s["service_name"], s.get("visible", True)) for s in drawn["services"]] == [
+            ("ssh", True), ("Homepage", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_view_written_before_the_fix_still_addresses_its_service(
+        self, client: AsyncClient, headers, db_session
+    ):
+        """Old keys are narrowed on read, so nothing needs migrating.
+
+        The hidden one stays hidden even though the row has since renamed it —
+        the point of the key being the port.
+        """
+        db_session.add(
+            InventoryDevice(
+                id="d-1",
+                ip="10.0.0.5",
+                services=[
+                    {"port": 22, "protocol": "tcp", "service_name": "ssh"},
+                    {"port": 3001, "protocol": "tcp", "service_name": "Homepage"},
+                ],
+            )
+        )
+        node = _node(await _design(db_session), device_id="d-1")
+        node.display_view = {
+            "services": [
+                {"key": "22|tcp|ssh", "visible": True},
+                {"key": "3001|tcp|uptime kuma", "visible": False},
+            ],
+            "properties": [],
+        }
+        db_session.add(node)
+        await db_session.commit()
+
+        drawn = (await client.get(f"/api/v1/nodes/{node.id}", headers=headers)).json()
+        assert [(s["service_name"], s.get("visible", True)) for s in drawn["services"]] == [
+            ("ssh", True), ("Homepage", False),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_port_less_service_keeps_its_name_in_the_view_key(self, db_session):
+        """Its name is its identity, so the key keeps the form it always had."""
+        device = InventoryDevice(
+            id="d-1", services=[{"protocol": "tcp", "service_name": "Vaultwarden"}]
+        )
+        node = _node(await _design(db_session), device_id="d-1")
+        node.display_view = {
+            "services": [{"key": "None|tcp|vaultwarden", "visible": False}],
+            "properties": [],
+        }
+        assert hydrated_node(node, device)["services"] == [
+            {"protocol": "tcp", "service_name": "Vaultwarden", "visible": False}
         ]


### PR DESCRIPTION
## What

Renaming a discovered service — correcting the scanner's guess, which is the point of editing one — broke in two ways at once. Both come from the same cause: a service was identified by its name.

1. **Duplicated (#469 as reported).** The rename path (`PATCH /scan/pending/{id}`) replaces the row's service list wholesale, so the row held `3001/tcp/Homepage`. The next fingerprint produced `3001/tcp/Uptime Kuma`, computed a different key, missed, and appended. The device listed the same port twice, and it recurred on every scheduled scan. The `discovered=True` guard that protects a hand-picked icon never fired, because it only runs on a key hit.

2. **Hidden (found while tracing the first).** A node's view addresses each service by key, so a rename left every canvas already drawing the device pointing at a key the row no longer held. `apply_view` appends an unlisted fact *hidden* — that is what keeps a service a later scan found off canvases nobody enabled it on — so the renamed service silently vanished from the canvas. The escape hatch for a view matching nothing at all only saved a device whose every service had been renamed.

Fixes #469

## Changes

Backend (`app/services/inventory_sync.py`):

- New `_service_identity_key`: a service is its port and protocol, whatever it is called. A service with no port (`port` is optional — a hand-added entry naming a host rather than a port) still keys on its name, since nothing else tells two of them apart.
- `merge_services` keys on it, so a rescan finds the renamed service instead of appending beside it.
- `service_name` joins `icon` and `category` in `_CURATED_SERVICE_FIELDS`. Without this the first fix only changed the bug's shape: the key now hits, and `{**base, **incoming}` would have let a rescan overwrite the rename instead of duplicating it. A scan still fills in a name the service never had, and a user edit still renames freely.
- `merge_services` also collapses duplicates already present in `base` as it copies. Rows written before this fix heal on their next scan instead of needing a migration; the first entry wins, which is the user's rename — it was on the row before the scan appended its guess underneath.
- `_service_view_key` uses the same identity, so a rename no longer moves a service out from under the view addressing it.
- New `normalize_view_key` narrows a stored key on read. The name in a pre-fix key is a snapshot of what the service was called when the view was written, so a renamed service cannot be found by re-deriving it — the key has to be narrowed instead. A view migrates the next time its node is saved, so no migration and no lost visibility state: a service hidden on a canvas stays hidden.
- Port-less service keys are unchanged, byte for byte.

`app/services/device_merge.py`:

- `_show_merged_facts` normalizes the keys it compares against. Otherwise a view written before this change would have had every already-listed service seeded a second time after a device merge.

No migration, no API change, no frontend change. `frontend/src/utils/deviceFacts.ts` keys services too, but only to sort a change baseline, never for identity.

## Testing

Ten tests added in `backend/tests/test_inventory_sync.py`.

Merge rules:
- the #469 scenario: rename 3001/tcp, rescan, one entry survives under the user's name
- a scan still names a service that never had one
- a user edit still renames a service
- a scan still refreshes non-curated facts (`path`) on a renamed service
- duplicates already on a row collapse on the next merge
- port-less services still key on their name and do not collapse into each other
- 53/tcp and 53/udp remain two services

Per-node view:
- renaming a service through the inventory modal leaves it visible on a canvas already drawing the device
- a view written before the fix still addresses its service, and a service hidden there stays hidden across the rename
- a port-less service keeps its name in the view key

Three existing tests assert the stored view key as a literal string. Only that string changed (`22|tcp|ssh` to `22|tcp`); their membership and visibility assertions are untouched. In `test_device_merge.py` the pre-seeded view is deliberately left in the old form, so that test now also exercises the read-time narrowing.

`ruff`, `mypy` and the full backend suite pass: 1364 passed, 8 skipped.

ha-relevant: maybe

The HACS tree has no `inventory_sync.py` and no `merge_services` equivalent — its coordinator stores services through the HA `Store` helper rather than a `device_inventory` row, so there is nothing to port mechanically. Worth deciding separately whether the integration needs the same protection against a rescan clobbering an edited service name.
