### PR TITLE
fix: stop a non-address IP field linking two unrelated devices

### DIFF
--- a/backend/app/api/routes/scan.py
+++ b/backend/app/api/routes/scan.py
@@ -23,6 +23,8 @@ from app.db.models import (
 )
 from app.schemas.nodes import NodeCreate
 from app.schemas.scan import (
+    DeviceMatchNode,
+    DeviceMatchResponse,
     InventoryDeviceCreate,
     InventoryDeviceResponse,
     InventoryDeviceUpdate,
@@ -31,7 +33,12 @@ from app.schemas.scan import (
 from app.services.device_merge import merge_devices
 from app.services.discovery_sources import add_source
 from app.services.doc_links import unlink_documents
-from app.services.inventory_sync import find_device_for, merge_properties, merge_services
+from app.services.inventory_sync import (
+    find_device_for,
+    identity_ip_tokens,
+    merge_properties,
+    merge_services,
+)
 from app.services.mac_utils import normalize_mac
 from app.services.node_dedupe import dedupe_nodes_by_device, find_duplicate_node
 from app.services.scanner import (
@@ -443,9 +450,10 @@ async def create_pending(
     """
     # One device is one row. If this host is already known — by ieee, ip or mac —
     # the user is documenting the device they already have, so fill in what the
-    # row is missing rather than splitting it in two.
+    # row is missing rather than splitting it in two. `force` overrides that:
+    # the caller has been shown the match and asked for a separate row anyway.
     mac = normalize_mac(body.mac)
-    existing = await find_device_for(db, ip=body.ip, mac=mac, ieee=None)
+    existing = None if body.force else await find_device_for(db, ip=body.ip, mac=mac, ieee=None)
     if existing is not None:
         for field in (
             "hostname", "ip", "os", "suggested_type", "model", "vendor", "label", "type",
@@ -502,6 +510,65 @@ async def create_pending(
     await db.commit()
     await db.refresh(device)
     return (await _with_canvas_counts(db, [device]))[0]
+
+
+@router.get("/match", response_model=DeviceMatchResponse)
+async def match_device(
+    ip: str | None = None,
+    mac: str | None = None,
+    ieee: str | None = None,
+    exclude_node_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(get_current_user),
+) -> DeviceMatchResponse:
+    """The inventory row these addresses would link to. Writes nothing.
+
+    A node editor cannot be answered with a 409: its Save writes to the canvas
+    store, and the whole canvas is persisted later in one request carrying every
+    node. So it asks here first, while the user is still in the dialog, and can
+    offer the choice the save itself has no way to put to them — link to the
+    device found, or keep this node on one of its own.
+
+    ``exclude_node_id`` drops the node being edited from ``nodes``: it is the one
+    asking, and listing it back as a reason not to link makes no sense.
+    """
+    normalized = normalize_mac(mac)
+    device = await find_device_for(db, ip=ip, mac=normalized, ieee=ieee)
+    if device is None:
+        return DeviceMatchResponse()
+
+    # Report the address that actually matched, in find_device_for's own
+    # precedence — the user may have typed three and only one is the reason.
+    shared = [t for t in identity_ip_tokens(ip) if t in set(identity_ip_tokens(device.ip))]
+    matched_on: str | None = None
+    matched_value: str | None = None
+    if ieee and (device.ieee_address or "").lower() == ieee.lower():
+        matched_on, matched_value = "ieee", ieee
+    elif shared:
+        matched_on, matched_value = "ip", shared[0]
+    elif normalized and device.mac == normalized:
+        matched_on, matched_value = "mac", normalized
+
+    rows = (
+        await db.execute(
+            select(Node.id, Node.label, Node.design_id, Design.name)
+            .outerjoin(Design, Design.id == Node.design_id)
+            .where(Node.device_id == device.id)
+            .order_by(Node.created_at, Node.id)
+        )
+    ).all()
+
+    await _with_canvas_counts(db, [device])
+    return DeviceMatchResponse(
+        device=InventoryDeviceResponse.model_validate(device),
+        matched_on=matched_on,
+        matched_value=matched_value,
+        nodes=[
+            DeviceMatchNode(id=r[0], label=r[1], design_id=r[2], design_name=r[3])
+            for r in rows
+            if r[0] != exclude_node_id
+        ],
+    )
 
 
 @router.patch("/pending/{device_id}", response_model=InventoryDeviceResponse)

--- a/backend/app/schemas/scan.py
+++ b/backend/app/schemas/scan.py
@@ -138,6 +138,12 @@ class InventoryDeviceCreate(BaseModel):
     show_hardware: bool = False
     check_method: str | None = None
     check_target: str | None = None
+    # One device is one row, so an address already known fills that row in rather
+    # than splitting it. `force` says the user knows and wants a separate row
+    # anyway — two containers on one host, a second PSU. Same escape hatch as
+    # `NodeCreate.force`, and what the node modal's "create a separate device"
+    # sends.
+    force: bool = False
 
     @field_validator("discovery_source")
     @classmethod
@@ -145,6 +151,37 @@ class InventoryDeviceCreate(BaseModel):
         if v not in MANUAL_SOURCES:
             raise ValueError(f"discovery_source must be one of {sorted(MANUAL_SOURCES)}")
         return v
+
+
+class DeviceMatchNode(BaseModel):
+    """A canvas node already drawing the matched device."""
+
+    id: str
+    label: str
+    design_id: str | None
+    design_name: str | None
+
+
+class DeviceMatchResponse(BaseModel):
+    """What an address would be linked to, asked before anything is written.
+
+    The node editor saves into the canvas store and the whole canvas is persisted
+    later in one request, so there is no per-node round trip to answer with a
+    409. The editor asks here instead, while the user is still in the dialog, and
+    offers to link to `device` or to keep the node separate.
+
+    `device` is null when nothing matches — the address is new, and saving will
+    mint a row for it.
+    """
+
+    device: InventoryDeviceResponse | None = None
+    # Which address identified it, in find_device_for's own precedence, so the
+    # prompt can name the reason ("matches on 192.168.0.100").
+    matched_on: str | None = None
+    matched_value: str | None = None
+    # Every node drawing that row, this canvas or another — linking to it means
+    # sharing the device's facts with all of them.
+    nodes: list[DeviceMatchNode] = []
 
 
 class InventoryDeviceUpdate(BaseModel):

--- a/backend/app/services/inventory_sync.py
+++ b/backend/app/services/inventory_sync.py
@@ -13,6 +13,7 @@ Nothing here commits — the caller owns the transaction.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 from collections.abc import Callable, Mapping
@@ -63,6 +64,31 @@ def ip_tokens(ip: str | None) -> list[str]:
     from addresses shares this rule, the scanner included.
     """
     return [t.strip() for t in ip.split(",") if t.strip()] if ip else []
+
+
+def identity_ip_tokens(ip: str | None) -> list[str]:
+    """The tokens of an ``ip`` field that are actually addresses.
+
+    The field is free text and users write more than addresses in it: a docker
+    port mapping (``:3001``, ``9000:9000``), a placeholder (``-``, ``N/A``,
+    ``dhcp``), a note. Two devices sharing one of those share nothing — but the
+    matcher used to read them as the same host and merge the pair into a single
+    inventory row, which is #475: editing one node edited the other, and no edit
+    could separate them again.
+
+    So identity needs a real address. Everything else stays in the field, shown
+    and saved as the user typed it, and is simply not evidence of who the device
+    is. Matching on the rest — ``ieee``, ``mac``, an explicit ``device_id`` — is
+    untouched.
+    """
+    out = []
+    for token in ip_tokens(ip):
+        try:
+            ipaddress.ip_address(token)
+        except ValueError:
+            continue
+        out.append(token)
+    return out
 
 
 def _blank(value: Any) -> bool:
@@ -126,8 +152,13 @@ async def find_device_for(
     bulk-approve skip order so a device is identified the same way everywhere.
     Hidden rows are eligible: a hidden device is still that device, and silently
     minting a second row for it would resurrect the duplicate the user hid.
+
+    Only the parts of ``ip`` that are addresses count — see
+    :func:`identity_ip_tokens`. With nothing identifying left, the answer is
+    ``None`` and the caller mints a row of its own, which is the right outcome:
+    two devices the user only described are two devices.
     """
-    ip_toks = ip_tokens(ip)
+    ip_toks = identity_ip_tokens(ip)
     conds = []
     if ieee:
         # Case-insensitive: `0x00124B00…` and `0x00124b00…` are the same radio,

--- a/backend/app/services/node_dedupe.py
+++ b/backend/app/services/node_dedupe.py
@@ -18,8 +18,8 @@ from typing import Any
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Document, Edge, Node, RackDevice
-from app.services.inventory_sync import find_device_for
+from app.db.models import Document, Edge, InventoryDevice, Node, RackDevice
+from app.services.inventory_sync import find_device_for, identity_ip_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +58,10 @@ async def find_duplicate_node(
     # same precedence find_device_for used: ieee > ip > mac.
     match: str
     value: str | None
-    device_ips = {t.strip() for t in (device.ip or "").split(",") if t.strip()}
-    shared_ip = next((t.strip() for t in (ip or "").split(",") if t.strip() in device_ips), None)
+    # Only real addresses identify — the same rule find_device_for just used, so
+    # the reported match is the one it actually made (see identity_ip_tokens).
+    device_ips = set(identity_ip_tokens(device.ip))
+    shared_ip = next((t for t in identity_ip_tokens(ip) if t in device_ips), None)
     if ieee and device.ieee_address == ieee:
         match, value = "ieee", ieee
     elif shared_ip:
@@ -77,11 +79,32 @@ async def find_duplicate_node(
     }
 
 
+async def _identified_by_address(db: AsyncSession, device_ids: set[str]) -> set[str]:
+    """Of ``device_ids``, those whose row carries an address worth trusting.
+
+    An ieee, a mac, or at least one ip token that really is an address. A row
+    with none of the three names no host: whatever put two nodes on it was not
+    identity, and merging them would destroy one of the two on a guess.
+    """
+    if not device_ids:
+        return set()
+    devices = (
+        await db.execute(select(InventoryDevice).where(InventoryDevice.id.in_(device_ids)))
+    ).scalars().all()
+    return {
+        d.id
+        for d in devices
+        if d.ieee_address or d.mac or identity_ip_tokens(d.ip)
+    }
+
+
 async def dedupe_nodes_by_device(db: AsyncSession) -> int:
     """Merge duplicate nodes drawing the same device on the same canvas.
 
     Returns the number of nodes removed. Idempotent. Nodes drawing one device on
-    *different* designs are left alone — that is valid cross-canvas placement.
+    *different* designs are left alone — that is valid cross-canvas placement,
+    and so are nodes on a row that carries no address at all (see
+    :func:`_identified_by_address`).
     The device facts live on the inventory row, so nothing has to be merged out
     of the extras: only edges and parent links are re-pointed before they go.
     Does not commit — the caller owns the transaction.
@@ -98,9 +121,20 @@ async def dedupe_nodes_by_device(db: AsyncSession) -> int:
     for node in rows:
         groups.setdefault((node.device_id, node.design_id), []).append(node)  # type: ignore[arg-type]
 
+    identified = await _identified_by_address(
+        db, {device_id for (device_id, _), nodes in groups.items() if len(nodes) > 1}
+    )
+
     removed = 0
     for (device_id, _design), nodes in groups.items():
         if len(nodes) < 2:
+            continue
+        # Collapsing deletes a node, so the row has to have been identified by
+        # something real. A row carrying no address at all was matched on a
+        # value the user typed into the ip field that is not one — a port
+        # mapping, a placeholder — and the two nodes are two devices that only
+        # look alike (#475). Leave them; the device picker separates them.
+        if device_id not in identified:
             continue
         canonical, *dups = nodes  # oldest first (ordered above)
         dup_ids = {d.id for d in dups}

--- a/backend/tests/scan/test_scan_routes.py
+++ b/backend/tests/scan/test_scan_routes.py
@@ -565,3 +565,123 @@ async def test_get_run_returns_status(client: AsyncClient, headers, pending_devi
 async def test_get_run_unknown_id_404(client: AsyncClient, headers):
     res = await client.get(f"/api/v1/scan/runs/{uuid.uuid4()}", headers=headers)
     assert res.status_code == 404
+
+
+# --- forcing a separate row -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_pending_folds_into_a_row_with_the_same_address(
+    client: AsyncClient, headers, pending_device
+):
+    """The default: one device is one row."""
+    res = await client.post(
+        "/api/v1/scan/pending",
+        json={"hostname": "same-host", "ip": "192.168.1.100", "discovery_source": "manual"},
+        headers=headers,
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["id"] == pending_device.id
+
+
+@pytest.mark.asyncio
+async def test_create_pending_force_mints_a_second_row(
+    client: AsyncClient, headers, pending_device
+):
+    """Two services on one host are two devices when the user says so.
+
+    Without this the node modal's "create a separate device" would be handed
+    back the very row it is trying to split away from.
+    """
+    res = await client.post(
+        "/api/v1/scan/pending",
+        json={
+            "hostname": "same-host",
+            "ip": "192.168.1.100",
+            "discovery_source": "manual",
+            "force": True,
+        },
+        headers=headers,
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["id"] != pending_device.id
+
+    listed = (await client.get("/api/v1/scan/pending", headers=headers)).json()
+    assert len([d for d in listed if d["ip"] == "192.168.1.100"]) == 2
+
+
+# --- match lookup -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_match_requires_auth(client: AsyncClient):
+    assert (await client.get("/api/v1/scan/match?ip=192.168.1.100")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_match_reports_the_device_and_the_address_that_found_it(
+    client: AsyncClient, headers, pending_device
+):
+    res = await client.get("/api/v1/scan/match?ip=10.0.0.1,192.168.1.100", headers=headers)
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["device"]["id"] == pending_device.id
+    assert data["matched_on"] == "ip"
+    assert data["matched_value"] == "192.168.1.100"
+
+
+@pytest.mark.asyncio
+async def test_match_normalizes_the_mac_before_looking(
+    client: AsyncClient, headers, pending_device
+):
+    res = await client.get("/api/v1/scan/match?mac=AA-BB-CC-DD-EE-FF", headers=headers)
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["device"]["id"] == pending_device.id
+    assert data["matched_on"] == "mac"
+
+
+@pytest.mark.asyncio
+async def test_match_is_empty_for_an_unknown_address(client: AsyncClient, headers):
+    data = (await client.get("/api/v1/scan/match?ip=10.9.9.9", headers=headers)).json()
+    assert data == {"device": None, "matched_on": None, "matched_value": None, "nodes": []}
+
+
+@pytest.mark.asyncio
+async def test_match_is_empty_for_a_port_mapping(client: AsyncClient, headers, db_session):
+    """#475 — `:3001` is a note, not an address, so it links to nothing."""
+    db_session.add(InventoryDevice(id=str(uuid.uuid4()), ip=":3001", status="approved"))
+    await db_session.commit()
+
+    data = (await client.get("/api/v1/scan/match?ip=:3001", headers=headers)).json()
+    assert data["device"] is None
+
+
+@pytest.mark.asyncio
+async def test_match_lists_the_nodes_already_drawing_the_device(
+    client: AsyncClient, headers, db_session
+):
+    """Linking shares the row's facts with every node on it — name them."""
+    design_id = await _add_design(db_session, "Home")
+    node = await _node_for(db_session, design_id, ip="192.168.1.50")
+    node.label = "NAS"
+    await db_session.commit()
+
+    data = (await client.get("/api/v1/scan/match?ip=192.168.1.50", headers=headers)).json()
+    assert [(n["label"], n["design_name"]) for n in data["nodes"]] == [("NAS", "Home")]
+
+
+@pytest.mark.asyncio
+async def test_match_leaves_out_the_node_that_is_asking(
+    client: AsyncClient, headers, db_session
+):
+    design_id = await _add_design(db_session, "Home")
+    node = await _node_for(db_session, design_id, ip="192.168.1.51")
+
+    data = (
+        await client.get(
+            f"/api/v1/scan/match?ip=192.168.1.51&exclude_node_id={node.id}", headers=headers
+        )
+    ).json()
+    assert data["device"] is not None
+    assert data["nodes"] == []

--- a/backend/tests/test_inventory_sync.py
+++ b/backend/tests/test_inventory_sync.py
@@ -18,6 +18,7 @@ from app.services.inventory_sync import (
     changed_facts,
     find_device_for,
     hydrated_node,
+    identity_ip_tokens,
     link_facts,
     merge_properties,
     merge_services,
@@ -307,6 +308,62 @@ class TestFindDeviceFor:
             db_session, ip=None, mac=None, ieee="0x00124B0022334455"
         )
         assert found is not None and found.id == "d-1"
+
+    @pytest.mark.asyncio
+    async def test_ignores_an_ip_field_that_is_not_an_address(self, db_session):
+        """#475 — two containers described by a docker port mapping.
+
+        The user writes `:3001` in the ip field of both. That is a note, not an
+        address, and reading it as identity merged two unrelated containers onto
+        one row: editing one edited the other, with no way back.
+        """
+        db_session.add(InventoryDevice(id="d-noteshare", ip=":3001"))
+        await db_session.commit()
+
+        assert await find_device_for(db_session, ip=":3001", mac=None, ieee=None) is None
+
+    @pytest.mark.asyncio
+    async def test_ignores_a_port_mapping_list(self, db_session):
+        db_session.add(InventoryDevice(id="d-caddy", ip="4381:4381, 1025:1025"))
+        await db_session.commit()
+
+        assert await find_device_for(
+            db_session, ip="4381:4381, 1025:1025", mac=None, ieee=None
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_still_matches_the_real_address_beside_a_placeholder(self, db_session):
+        """The junk is dropped, not the whole field."""
+        db_session.add(InventoryDevice(id="d-1", ip="dhcp, 10.0.0.5"))
+        await db_session.commit()
+
+        found = await find_device_for(db_session, ip="10.0.0.5", mac=None, ieee=None)
+        assert found is not None and found.id == "d-1"
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_mac_when_the_ip_field_is_not_an_address(self, db_session):
+        db_session.add(InventoryDevice(id="d-1", ip=":3001", mac="aa:bb:cc:dd:ee:ff"))
+        await db_session.commit()
+
+        found = await find_device_for(
+            db_session, ip=":3001", mac="aa:bb:cc:dd:ee:ff", ieee=None
+        )
+        assert found is not None and found.id == "d-1"
+
+
+class TestIdentityIpTokens:
+    def test_keeps_addresses_and_drops_everything_else(self):
+        assert identity_ip_tokens("10.0.0.5, fd00::1") == ["10.0.0.5", "fd00::1"]
+        assert identity_ip_tokens(":3001") == []
+        assert identity_ip_tokens("9000:9000, 9001:9001") == []
+        assert identity_ip_tokens("dhcp, N/A, -") == []
+        assert identity_ip_tokens("nas.local") == []
+        assert identity_ip_tokens("10.0.0.5/24") == []
+        assert identity_ip_tokens(None) == []
+        assert identity_ip_tokens("") == []
+
+    def test_keeps_the_user_spelling_of_what_it_keeps(self):
+        assert identity_ip_tokens(" 10.0.0.5 , :3001 ") == ["10.0.0.5"]
 
 
 class TestIeeeCollisions:

--- a/backend/tests/test_node_dedupe.py
+++ b/backend/tests/test_node_dedupe.py
@@ -166,3 +166,48 @@ async def test_idempotent_noop_when_unique(db_session):
     await db_session.flush()
     assert await dedupe_nodes_by_device(db_session) == 0
     assert await dedupe_nodes_by_device(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_keeps_nodes_on_a_row_with_no_address(db_session):
+    """#475 — a shared row nothing identified must not cost a node.
+
+    Two containers whose ip field holds a docker port mapping (`:3001`) were
+    matched as one host and put on a single inventory row. Collapsing them here
+    would delete one of the two on the next scan.
+    """
+    d = await _design(db_session)
+    device = await _device(db_session, ieee=None, ip=":3001")
+    db_session.add(Node(label="NoteShare", type="docker_container", design_id=d.id, device_id=device.id))
+    await db_session.flush()
+    db_session.add(Node(label="gitea", type="docker_container", design_id=d.id, device_id=device.id))
+    await db_session.flush()
+
+    assert await dedupe_nodes_by_device(db_session) == 0
+    kept = (await db_session.execute(select(Node).where(Node.device_id == device.id))).scalars().all()
+    assert {n.label for n in kept} == {"NoteShare", "gitea"}
+
+
+@pytest.mark.asyncio
+async def test_collapses_when_the_row_carries_a_real_ip(db_session):
+    """The guard is about addresses, not about how the row was born."""
+    d = await _design(db_session)
+    device = await _device(db_session, ieee=None, ip="192.168.1.10")
+    db_session.add(Node(label="NAS", type="nas", design_id=d.id, device_id=device.id))
+    await db_session.flush()
+    db_session.add(Node(label="NAS", type="nas", design_id=d.id, device_id=device.id))
+    await db_session.flush()
+
+    assert await dedupe_nodes_by_device(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_collapses_when_the_row_carries_only_a_mac(db_session):
+    d = await _design(db_session)
+    device = await _device(db_session, ieee=None, ip=None, mac="aa:bb:cc:dd:ee:ff")
+    db_session.add(Node(label="AP", type="ap", design_id=d.id, device_id=device.id))
+    await db_session.flush()
+    db_session.add(Node(label="AP", type="ap", design_id=d.id, device_id=device.id))
+    await db_session.flush()
+
+    assert await dedupe_nodes_by_device(db_session) == 1

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -154,7 +154,7 @@ export interface DuplicateNodeConflict {
  */
 export const scanApi = {
   trigger: (deepScan?: Partial<DeepScanConfig>) => api.post('/scan/trigger', deepScan ?? {}),
-  pending: () => api.get('/scan/pending'),
+  pending: () => api.get<InventoryEntry[]>('/scan/pending'),
   /** Add an inventory entry by hand, for hardware no scan can discover. */
   createPending: (data: {
     hostname: string
@@ -165,7 +165,19 @@ export const scanApi = {
     vendor?: string | null
     /** "manual" (default) or "rack" for gear created from a rack canvas. */
     discovery_source?: 'manual' | 'rack'
-  }) => api.post<{ id: string; hostname: string | null }>('/scan/pending', data),
+    label?: string | null
+    type?: string | null
+    os?: string | null
+    notes?: string | null
+    check_method?: string | null
+    check_target?: string | null
+    /**
+     * Skip the fold into a row that already carries one of these addresses.
+     * One device is one row by default; this says the caller means a separate
+     * one anyway — two services on one host, split apart from the node editor.
+     */
+    force?: boolean
+  }) => api.post<InventoryEntry>('/scan/pending', data),
   /**
    * Edit an inventory row. Partial: only the keys sent are applied, so a caller
    * touching one field never clears the rest. Lifecycle (`status`) and discovery
@@ -181,7 +193,7 @@ export const scanApi = {
    */
   rescanDevice: (id: string, opts?: { full_ports?: boolean; ports?: string; http_probe_enabled?: boolean; verify_tls?: boolean }) =>
     api.post<ScanRunSummary>(`/scan/pending/${id}/rescan`, opts ?? {}),
-  hidden: () => api.get('/scan/hidden'),
+  hidden: () => api.get<InventoryEntry[]>('/scan/hidden'),
   /**
    * Inventory rows for the guests a Proxmox host runs, resolved from the
    * host→guest links the Proxmox import records. Empty for a non-host device.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -144,6 +144,28 @@ export interface DuplicateNodeConflict {
   value: string
 }
 
+/** A node already drawing the device an address matched. */
+export interface DeviceMatchNode {
+  id: string
+  label: string
+  design_id: string | null
+  design_name: string | null
+}
+
+/**
+ * What an address would link to, asked before anything is written.
+ *
+ * `device` is null when nothing matches — the address is new, and saving mints
+ * a row for it. `nodes` is every node already drawing the row, since linking
+ * shares its facts with all of them.
+ */
+export interface DeviceMatch {
+  device: InventoryEntry | null
+  matched_on: 'ieee' | 'ip' | 'mac' | null
+  matched_value: string | null
+  nodes: DeviceMatchNode[]
+}
+
 /**
  * The Device Inventory rides the scan routes.
  *
@@ -155,6 +177,20 @@ export interface DuplicateNodeConflict {
 export const scanApi = {
   trigger: (deepScan?: Partial<DeepScanConfig>) => api.post('/scan/trigger', deepScan ?? {}),
   pending: () => api.get<InventoryEntry[]>('/scan/pending'),
+  /**
+   * Which inventory row these addresses would link to. Writes nothing.
+   *
+   * The node editor saves into the canvas store and the canvas is persisted
+   * later in one request, so a duplicate cannot be reported as a 409 the user
+   * would still be there to answer. It asks here instead, while the dialog is
+   * open, and offers to link or to keep the node separate.
+   */
+  matchDevice: (params: {
+    ip?: string
+    mac?: string
+    ieee?: string
+    exclude_node_id?: string
+  }) => api.get<DeviceMatch>('/scan/match', { params }),
   /** Add an inventory entry by hand, for hardware no scan can discover. */
   createPending: (data: {
     hostname: string

--- a/frontend/src/components/modals/DevicePickerModal.tsx
+++ b/frontend/src/components/modals/DevicePickerModal.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from 'react'
+import { Check, Plus, Search } from 'lucide-react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import type { InventoryEntry } from '@/types'
+import { deviceName } from '@/utils/mergeWinner'
+import { deviceAddresses } from '@/utils/deviceFacts'
+
+/** Everything a search term is matched against — names and addresses alike. */
+function haystack(device: InventoryEntry): string {
+  return [
+    device.label,
+    device.friendly_name,
+    device.hostname,
+    device.ip,
+    device.mac,
+    device.ieee_address,
+    device.type,
+    device.suggested_type,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+interface DevicePickerModalProps {
+  open: boolean
+  /** The inventory to choose from, already filtered of anything unlinkable. */
+  devices: InventoryEntry[]
+  /** The row the node draws today, ticked in the list. */
+  currentDeviceId?: string | null
+  /** True while a new row is being created — the dialog stays up, disabled. */
+  busy?: boolean
+  onPick: (device: InventoryEntry) => void
+  onCreate: () => void
+  onClose: () => void
+}
+
+/**
+ * Which Device Inventory row a canvas node draws.
+ *
+ * A homelab inventory runs to hundreds of rows, most of them named after the
+ * same handful of hosts, and a dropdown gave no way to tell two `proxmox-1`
+ * apart or to find one by address. So: a search over every name and address a
+ * row answers to, the addresses printed beside each name, and the way out —
+ * a device of its own — as a button rather than the last item of a long list.
+ */
+export function DevicePickerModal({
+  open,
+  devices,
+  currentDeviceId,
+  busy = false,
+  onPick,
+  onCreate,
+  onClose,
+}: DevicePickerModalProps) {
+  const [query, setQuery] = useState('')
+
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    const list = needle
+      ? devices.filter((d) => haystack(d).includes(needle))
+      : [...devices]
+    // The row already linked first — it is the one the user is deciding about.
+    return list.sort((a, b) => {
+      if (a.id === currentDeviceId) return -1
+      if (b.id === currentDeviceId) return 1
+      return deviceName(a).localeCompare(deviceName(b))
+    })
+  }, [devices, query, currentDeviceId])
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="bg-[#161b22] border-[#30363d] text-foreground max-w-[calc(100%-2rem)] sm:max-w-xl p-0 gap-0">
+        <DialogHeader className="px-4 py-3 border-b border-[#30363d]">
+          <DialogTitle className="text-sm font-semibold">Link to a device</DialogTitle>
+        </DialogHeader>
+
+        <div className="px-4 py-3 border-b border-[#30363d]">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/60" />
+            <Input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name, address or hostname"
+              aria-label="Search devices"
+              className="bg-[#21262d] border-[#30363d] text-sm h-8 pl-8"
+            />
+          </div>
+        </div>
+
+        <div className="max-h-[46vh] overflow-y-auto py-1">
+          {matches.length === 0 ? (
+            <p className="px-4 py-6 text-center text-xs text-muted-foreground">
+              {devices.length === 0
+                ? 'The Device Inventory is empty.'
+                : `No device matches "${query.trim()}".`}
+            </p>
+          ) : (
+            matches.map((device) => {
+              const addresses = deviceAddresses(device)
+              const isCurrent = device.id === currentDeviceId
+              return (
+                <button
+                  key={device.id}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => onPick(device)}
+                  className={`w-full flex items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-[#21262d] disabled:opacity-50 ${isCurrent ? 'bg-[#00d4ff]/5' : ''}`}
+                >
+                  <span className="flex flex-col min-w-0 flex-1">
+                    <span className={`text-sm truncate ${isCurrent ? 'text-[#00d4ff]' : 'text-foreground'}`}>
+                      {deviceName(device)}
+                    </span>
+                    {addresses && (
+                      <span className="text-[10px] font-mono text-muted-foreground/70 truncate">
+                        {addresses}
+                      </span>
+                    )}
+                  </span>
+                  {isCurrent && <Check className="w-3.5 h-3.5 shrink-0 text-[#00d4ff]" />}
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 px-4 py-3 border-t border-[#30363d]">
+          <Button
+            type="button"
+            disabled={busy}
+            onClick={onCreate}
+            className="h-8 px-3 text-xs bg-[#21262d] hover:bg-[#30363d] text-foreground"
+          >
+            <Plus className="w-3.5 h-3.5 mr-1.5" />
+            Create a separate device
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            className="h-8 px-3 text-xs text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/modals/NodeModal.tsx
+++ b/frontend/src/components/modals/NodeModal.tsx
@@ -10,7 +10,9 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { NODE_TYPE_LABELS, type InventoryEntry, type NodeData, type NodeType, type CheckMethod, type NodeTypeStyle } from '@/types'
 import { scanApi, type DeviceMatch } from '@/api/client'
-import { deviceFactsToNodeData } from '@/utils/deviceFacts'
+import { DevicePickerModal } from './DevicePickerModal'
+import { deviceName } from '@/utils/mergeWinner'
+import { deviceAddresses, deviceFactsToNodeData } from '@/utils/deviceFacts'
 import { useThemeStore } from '@/stores/themeStore'
 import { resolveNodeColors } from '@/utils/nodeColors'
 import { ICON_REGISTRY, NODE_TYPE_DEFAULT_ICONS, isBrandIconKey, brandIconSlug, brandIconUrl } from '@/utils/nodeIcons'
@@ -23,33 +25,6 @@ import { NODE_TYPE_GROUPS, isFurnitureType } from '@/utils/nodeTypeGroups'
 // The link is a full-mode concept end to end — see ADR-001 for the same rule
 // applied to uploads.
 const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
-
-// Sentinel values for the device picker. Real ids are uuids, so neither can
-// collide with one.
-const DEVICE_NONE = '__none__'
-const DEVICE_NEW = '__new__'
-
-/** A device as the picker names it, falling back until something is printable. */
-function deviceName(device: InventoryEntry): string {
-  return (
-    device.label
-    || device.friendly_name
-    || device.hostname
-    || device.ip
-    || device.mac
-    || 'Unnamed device'
-  )
-}
-
-/**
- * A device as one row of the picker: its name, then its addresses so two rows
- * named the same can be told apart. One text node — the list renders inside an
- * option, which takes no markup of its own.
- */
-function deviceLabel(device: InventoryEntry): string {
-  const addresses = [device.ip, device.mac, device.ieee_address].filter(Boolean).join(' · ')
-  return addresses ? `${deviceName(device)} — ${addresses}` : deviceName(device)
-}
 
 /**
  * Gear created from a rack canvas. It documents a mount — a patch panel, a
@@ -198,6 +173,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
   // ip field and could not be undone (#475); it is a choice here.
   const [devices, setDevices] = useState<InventoryEntry[]>([])
   const [deviceBusy, setDeviceBusy] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
   const showDevicePicker = !STANDALONE && !isFurniture
 
   useEffect(() => {
@@ -248,6 +224,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
       })
       setDevices((list) => [...list, data])
       set('device_id', data.id)
+      setPickerOpen(false)
       toast.success('Separate device created')
     } catch {
       toast.error('Could not create the device')
@@ -306,14 +283,9 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
     setMatch(null)
   }
 
-  const onPickDevice = (value: string | null) => {
-    if (value === DEVICE_NEW) {
-      void createDevice()
-      return
-    }
-    if (value === DEVICE_NONE) return
-    const picked = devices.find((d) => d.id === value)
-    if (picked) linkDevice(picked)
+  const onPickDevice = (device: InventoryEntry) => {
+    linkDevice(device)
+    setPickerOpen(false)
   }
 
   const customStyle = useThemeStore((s) => s.customStyle)
@@ -358,6 +330,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
   }
 
   return (
+    <>
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="bg-[#161b22] border-[#30363d] text-foreground max-w-[calc(100%-2rem)] sm:max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
@@ -608,35 +581,29 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                     </div>
                   </div>
                 )}
-                <Select
-                  value={form.device_id ?? DEVICE_NONE}
-                  onValueChange={onPickDevice}
+                <button
+                  type="button"
                   disabled={deviceBusy}
+                  onClick={() => setPickerOpen(true)}
+                  aria-label="Device inventory selector"
+                  className={`flex items-center justify-between gap-2 h-8 px-3 bg-[#21262d] border border-[#30363d] text-sm text-left cursor-pointer disabled:opacity-50 ${modalStyles['modal-interactive']} ${modalStyles['modal-radius']}`}
                 >
-                  <SelectTrigger className={`bg-[#21262d] border-[#30363d] text-sm h-8 cursor-pointer ${modalStyles['modal-interactive']} ${modalStyles['modal-radius']}`} aria-label="Device inventory selector">
-                    <SelectValue>
+                  <span className="flex flex-col min-w-0">
+                    <span className="truncate">
                       {linkedDevice
                         ? deviceName(linkedDevice)
                         : form.device_id
                           ? 'Linked device'
                           : 'Not linked yet'}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent className="bg-[#21262d] border-[#30363d]">
-                    {!form.device_id && (
-                      <SelectItem value={DEVICE_NONE} className="text-sm">Not linked yet</SelectItem>
-                    )}
-                    {devices.map((d) => (
-                      <SelectItem key={d.id} value={d.id} className="text-sm">
-                        {deviceLabel(d)}
-                      </SelectItem>
-                    ))}
-                    <SelectSeparator />
-                    <SelectItem value={DEVICE_NEW} className="text-sm">
-                      Create a separate device
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                    </span>
+                  </span>
+                  <span className="text-xs text-muted-foreground shrink-0">Change</span>
+                </button>
+                {linkedDevice && deviceAddresses(linkedDevice) && (
+                  <span className="text-[10px] font-mono text-muted-foreground/70">
+                    {deviceAddresses(linkedDevice)}
+                  </span>
+                )}
                 <span className="text-[10px] text-muted-foreground/60">
                   The inventory row this node draws. It owns the fields above, so
                   every node on the same device shows — and edits — the same
@@ -879,5 +846,18 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
         </form>
       </DialogContent>
     </Dialog>
+
+    {showDevicePicker && (
+      <DevicePickerModal
+        open={pickerOpen}
+        devices={devices}
+        currentDeviceId={form.device_id}
+        busy={deviceBusy}
+        onPick={onPickDevice}
+        onCreate={() => void createDevice()}
+        onClose={() => setPickerOpen(false)}
+      />
+    )}
+    </>
   )
 }

--- a/frontend/src/components/modals/NodeModal.tsx
+++ b/frontend/src/components/modals/NodeModal.tsx
@@ -1,4 +1,5 @@
-import { Fragment, createElement, useState } from 'react'
+import { Fragment, createElement, useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import modalStyles from './modal-interactive.module.css'
 import { RotateCcw, ChevronDown, Palette } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -7,7 +8,9 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { NODE_TYPE_LABELS, type NodeData, type NodeType, type CheckMethod, type NodeTypeStyle } from '@/types'
+import { NODE_TYPE_LABELS, type InventoryEntry, type NodeData, type NodeType, type CheckMethod, type NodeTypeStyle } from '@/types'
+import { scanApi } from '@/api/client'
+import { deviceFactsToNodeData } from '@/utils/deviceFacts'
 import { useThemeStore } from '@/stores/themeStore'
 import { resolveNodeColors } from '@/utils/nodeColors'
 import { ICON_REGISTRY, NODE_TYPE_DEFAULT_ICONS, isBrandIconKey, brandIconSlug, brandIconUrl } from '@/utils/nodeIcons'
@@ -15,6 +18,47 @@ import { IconPickerPanel } from './IconPickerPanel'
 import { MAX_HANDLES, MIN_HANDLES, clampHandles, sideDefault, handleCountField, type Side } from '@/utils/handleUtils'
 import { isValidParentNode } from '@/utils/virtualEdgeParent'
 import { NODE_TYPE_GROUPS, isFurnitureType } from '@/utils/nodeTypeGroups'
+
+// No backend in standalone mode, so no Device Inventory to point a node at.
+// The link is a full-mode concept end to end — see ADR-001 for the same rule
+// applied to uploads.
+const STANDALONE = import.meta.env.VITE_STANDALONE === 'true'
+
+// Sentinel values for the device picker. Real ids are uuids, so neither can
+// collide with one.
+const DEVICE_NONE = '__none__'
+const DEVICE_NEW = '__new__'
+
+/** A device as the picker names it, falling back until something is printable. */
+function deviceName(device: InventoryEntry): string {
+  return (
+    device.label
+    || device.friendly_name
+    || device.hostname
+    || device.ip
+    || device.mac
+    || 'Unnamed device'
+  )
+}
+
+/**
+ * A device as one row of the picker: its name, then its addresses so two rows
+ * named the same can be told apart. One text node — the list renders inside an
+ * option, which takes no markup of its own.
+ */
+function deviceLabel(device: InventoryEntry): string {
+  const addresses = [device.ip, device.mac, device.ieee_address].filter(Boolean).join(' · ')
+  return addresses ? `${deviceName(device)} — ${addresses}` : deviceName(device)
+}
+
+/**
+ * Gear created from a rack canvas. It documents a mount — a patch panel, a
+ * shelf — not a host to draw on a logical canvas, and the backend refuses to
+ * approve one onto a design, so the picker does not offer it either.
+ */
+function isRackOnly(device: InventoryEntry): boolean {
+  return device.discovery_source === 'rack' || (device.discovery_sources ?? []).includes('rack')
+}
 
 // Maps a side to its per-type default field on NodeTypeStyle.
 const SIDE_STYLE_KEY: Record<Side, keyof NodeTypeStyle> = {
@@ -147,6 +191,80 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
 
   const set = (key: keyof NodeData, value: unknown) =>
     setForm((f) => ({ ...f, [key]: value }))
+
+  // ── Device Inventory link ────────────────────────────────────────────────
+  // Which row this node draws. It owns the facts above, so two nodes on one row
+  // show — and edit — the same device. That used to be decided silently from the
+  // ip field and could not be undone (#475); it is a choice here.
+  const [devices, setDevices] = useState<InventoryEntry[]>([])
+  const [deviceBusy, setDeviceBusy] = useState(false)
+  const showDevicePicker = !STANDALONE && !isFurniture
+
+  useEffect(() => {
+    if (!open || !showDevicePicker) return
+    let cancelled = false
+    scanApi
+      .pending()
+      .then((res) => {
+        if (!cancelled) setDevices(res.data.filter((d) => !isRackOnly(d)))
+      })
+      // The picker is one field in a large form. A failed list leaves the node
+      // on the row it already has, which is the status quo, not an error worth
+      // interrupting the edit for.
+      .catch(() => undefined)
+    return () => { cancelled = true }
+  }, [open, showDevicePicker])
+
+  const linkedDevice = devices.find((d) => d.id === form.device_id)
+
+  /**
+   * Adopt a row: point the node at it and show what it will actually display.
+   *
+   * The facts on screen belong to the old row. Leaving them would have the user
+   * save a device they can see and reload into a different one, so they are
+   * replaced here the same way the server hydrates them on read.
+   */
+  const linkDevice = (device: InventoryEntry) =>
+    setForm((f) => ({ ...f, ...deviceFactsToNodeData(device), device_id: device.id }))
+
+  /** Split this node onto a row of its own, whatever the addresses suggest. */
+  const createDevice = async () => {
+    setDeviceBusy(true)
+    try {
+      const { data } = await scanApi.createPending({
+        hostname: form.hostname || form.label || 'device',
+        ip: form.ip || null,
+        mac: form.mac || null,
+        os: form.os || null,
+        notes: form.notes || null,
+        label: form.label || null,
+        type: form.type ?? null,
+        check_method: form.check_method ?? null,
+        check_target: form.check_target || null,
+        discovery_source: 'manual',
+        // Without this the new row folds straight back into the one this node
+        // is trying to leave.
+        force: true,
+      })
+      setDevices((list) => [...list, data])
+      set('device_id', data.id)
+      toast.success('Separate device created')
+    } catch {
+      toast.error('Could not create the device')
+    } finally {
+      setDeviceBusy(false)
+    }
+  }
+
+  const onPickDevice = (value: string | null) => {
+    if (value === DEVICE_NEW) {
+      void createDevice()
+      return
+    }
+    if (value === DEVICE_NONE) return
+    const picked = devices.find((d) => d.id === value)
+    if (picked) linkDevice(picked)
+  }
 
   const customStyle = useThemeStore((s) => s.customStyle)
   // Effective default count for a side: the per-type style default if set,
@@ -398,6 +516,47 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
                 </div>
               )
             })()}
+
+            {/* Device Inventory link */}
+            {showDevicePicker && (
+              <div className="flex flex-col gap-1.5 col-span-2">
+                <Label className="text-xs text-muted-foreground">Device</Label>
+                <Select
+                  value={form.device_id ?? DEVICE_NONE}
+                  onValueChange={onPickDevice}
+                  disabled={deviceBusy}
+                >
+                  <SelectTrigger className={`bg-[#21262d] border-[#30363d] text-sm h-8 cursor-pointer ${modalStyles['modal-interactive']} ${modalStyles['modal-radius']}`} aria-label="Device inventory selector">
+                    <SelectValue>
+                      {linkedDevice
+                        ? deviceName(linkedDevice)
+                        : form.device_id
+                          ? 'Linked device'
+                          : 'Not linked yet'}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent className="bg-[#21262d] border-[#30363d]">
+                    {!form.device_id && (
+                      <SelectItem value={DEVICE_NONE} className="text-sm">Not linked yet</SelectItem>
+                    )}
+                    {devices.map((d) => (
+                      <SelectItem key={d.id} value={d.id} className="text-sm">
+                        {deviceLabel(d)}
+                      </SelectItem>
+                    ))}
+                    <SelectSeparator />
+                    <SelectItem value={DEVICE_NEW} className="text-sm">
+                      Create a separate device
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <span className="text-[10px] text-muted-foreground/60">
+                  The inventory row this node draws. It owns the fields above, so
+                  every node on the same device shows — and edits — the same
+                  values.
+                </span>
+              </div>
+            )}
 
             {/* Container mode */}
             {CONTAINER_MODE_TYPES.includes((form.type ?? 'generic') as NodeType) && (

--- a/frontend/src/components/modals/NodeModal.tsx
+++ b/frontend/src/components/modals/NodeModal.tsx
@@ -9,7 +9,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { NODE_TYPE_LABELS, type InventoryEntry, type NodeData, type NodeType, type CheckMethod, type NodeTypeStyle } from '@/types'
-import { scanApi } from '@/api/client'
+import { scanApi, type DeviceMatch } from '@/api/client'
 import { deviceFactsToNodeData } from '@/utils/deviceFacts'
 import { useThemeStore } from '@/stores/themeStore'
 import { resolveNodeColors } from '@/utils/nodeColors'
@@ -256,6 +256,56 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
     }
   }
 
+  // ── Address match prompt ─────────────────────────────────────────────────
+  // An address the inventory already knows means this node is about to share a
+  // device with whatever else carries it. Asked here, on blur, because the save
+  // cannot ask: it writes to the canvas store and the whole canvas is persisted
+  // later, long after this dialog closed.
+  const [match, setMatch] = useState<DeviceMatch | null>(null)
+  // Rows the user has already said this node is not. Keyed by device id rather
+  // than by the address, so correcting a typo and typing it back does not
+  // re-open a question that was answered.
+  const [notThisDevice, setNotThisDevice] = useState<string[]>([])
+
+  const checkAddressMatch = async () => {
+    const ip = (form.ip ?? '').trim()
+    const mac = (form.mac ?? '').trim()
+    if (!showDevicePicker || (!ip && !mac)) {
+      setMatch(null)
+      return
+    }
+    try {
+      const { data } = await scanApi.matchDevice({
+        ip: ip || undefined,
+        mac: mac || undefined,
+        // Declared on NodeData only through its index signature, so it arrives
+        // as unknown and has to be narrowed before it can be a query param.
+        ieee: typeof form.ieee_address === 'string' ? form.ieee_address || undefined : undefined,
+        exclude_node_id: currentNodeId,
+      })
+      const found = data.device
+      // Nothing to ask when the node already draws that row, or when the user
+      // has answered for it.
+      setMatch(
+        found && found.id !== form.device_id && !notThisDevice.includes(found.id) ? data : null,
+      )
+    } catch {
+      // The picker below still works; a failed lookup is not worth a toast in
+      // the middle of typing an address.
+      setMatch(null)
+    }
+  }
+
+  const acceptMatch = () => {
+    if (match?.device) linkDevice(match.device)
+    setMatch(null)
+  }
+
+  const rejectMatch = () => {
+    if (match?.device) setNotThisDevice((ids) => [...ids, match.device!.id])
+    setMatch(null)
+  }
+
   const onPickDevice = (value: string | null) => {
     if (value === DEVICE_NEW) {
       void createDevice()
@@ -441,6 +491,7 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
               <Input
                 value={form.ip ?? ''}
                 onChange={(e) => set('ip', e.target.value)}
+                onBlur={() => void checkAddressMatch()}
                 placeholder="192.168.1.x, 2001:db8::1"
                 className={`bg-[#21262d] border-[#30363d] font-mono text-sm h-8 ${modalStyles['modal-radius']}`}
               />
@@ -521,6 +572,42 @@ export function NodeModal({ open, onClose, onSubmit, initial, title = 'Add Node'
             {showDevicePicker && (
               <div className="flex flex-col gap-1.5 col-span-2">
                 <Label className="text-xs text-muted-foreground">Device</Label>
+                {match?.device && (
+                  <div
+                    role="status"
+                    className="flex flex-col gap-2 rounded-md border border-[#e3b341]/40 bg-[#e3b341]/10 px-3 py-2"
+                  >
+                    <p className="text-xs text-foreground">
+                      <span className="font-mono">{match.matched_value}</span>
+                      {' already describes '}
+                      <strong className="font-semibold">{deviceName(match.device)}</strong>
+                      {match.nodes.length > 0
+                        ? `, drawn as ${match.nodes.map((n) => n.label).join(', ')}.`
+                        : ', not on any canvas yet.'}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground/70">
+                      Linking makes this node the same device: both show, and edit,
+                      one set of values.
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        onClick={acceptMatch}
+                        className="h-7 px-2.5 text-xs bg-[#21262d] hover:bg-[#30363d] text-foreground"
+                      >
+                        Link to it
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={rejectMatch}
+                        className="h-7 px-2.5 text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        Keep separate
+                      </Button>
+                    </div>
+                  </div>
+                )}
                 <Select
                   value={form.device_id ?? DEVICE_NONE}
                   onValueChange={onPickDevice}

--- a/frontend/src/components/modals/__tests__/DevicePickerModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/DevicePickerModal.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * The device picker dialog.
+ *
+ * A dropdown could not carry this list: a homelab inventory runs to hundreds of
+ * rows, many of them named after the same host, and the names were clipped to
+ * the width of the field below them. Search, addresses and an explicit create
+ * button are the point of the component.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DevicePickerModal } from '../DevicePickerModal'
+import type { InventoryEntry } from '@/types'
+
+function makeDevice(over: Partial<InventoryEntry> = {}): InventoryEntry {
+  return {
+    id: 'dev-1',
+    ip: null,
+    mac: null,
+    hostname: null,
+    os: null,
+    services: [],
+    suggested_type: null,
+    status: 'approved',
+    discovered_at: '2026-01-01T00:00:00Z',
+    ...over,
+  }
+}
+
+const DEVICES = [
+  makeDevice({ id: 'dev-1', label: 'proxmox-1', ip: '192.168.50.10' }),
+  makeDevice({ id: 'dev-2', label: 'proxmox-1', ip: '192.168.50.11', mac: 'aa:bb:cc:dd:ee:ff' }),
+  makeDevice({ id: 'dev-3', label: 'pihole', ip: '192.168.50.20' }),
+  makeDevice({ id: 'dev-4', hostname: 'nas-8bay' }),
+]
+
+function renderPicker(props: Partial<Parameters<typeof DevicePickerModal>[0]> = {}) {
+  const onPick = vi.fn()
+  const onCreate = vi.fn()
+  const onClose = vi.fn()
+  render(
+    <DevicePickerModal
+      open
+      devices={DEVICES}
+      onPick={onPick}
+      onCreate={onCreate}
+      onClose={onClose}
+      {...props}
+    />,
+  )
+  return { onPick, onCreate, onClose }
+}
+
+const search = (value: string) =>
+  fireEvent.change(screen.getByLabelText('Search devices'), { target: { value } })
+
+describe('DevicePickerModal', () => {
+  it('renders nothing when closed', () => {
+    renderPicker({ open: false })
+    expect(screen.queryByLabelText('Search devices')).not.toBeInTheDocument()
+  })
+
+  it('prints every address, so two rows with one name can be told apart', () => {
+    renderPicker()
+    expect(screen.getByText('192.168.50.10')).toBeInTheDocument()
+    expect(screen.getByText('192.168.50.11 · aa:bb:cc:dd:ee:ff')).toBeInTheDocument()
+  })
+
+  it('falls back to the hostname when a row was never named', () => {
+    renderPicker()
+    expect(screen.getByRole('button', { name: /nas-8bay/ })).toBeInTheDocument()
+  })
+
+  it('searches names and addresses alike', () => {
+    renderPicker()
+
+    search('pih')
+    expect(screen.getByRole('button', { name: /pihole/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /proxmox/ })).not.toBeInTheDocument()
+
+    search('50.11')
+    expect(screen.getByRole('button', { name: /192\.168\.50\.11/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /192\.168\.50\.10/ })).not.toBeInTheDocument()
+
+    search('AA:BB')
+    expect(screen.getByRole('button', { name: /192\.168\.50\.11/ })).toBeInTheDocument()
+  })
+
+  it('says when nothing matches, and when there is nothing to match', () => {
+    const { onClose } = renderPicker()
+    search('nope')
+    expect(screen.getByText('No device matches "nope".')).toBeInTheDocument()
+
+    onClose.mockClear()
+    render(
+      <DevicePickerModal
+        open
+        devices={[]}
+        onPick={vi.fn()}
+        onCreate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('The Device Inventory is empty.')).toBeInTheDocument()
+  })
+
+  it('puts the row already linked first, then sorts by name', () => {
+    renderPicker({ currentDeviceId: 'dev-3' })
+    const names = screen
+      .getAllByRole('button')
+      .map((b) => b.textContent ?? '')
+      .filter((t) => t.includes('proxmox') || t.includes('pihole') || t.includes('nas'))
+    expect(names[0]).toContain('pihole')
+  })
+
+  it('hands back the device picked', () => {
+    const { onPick } = renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /pihole/ }))
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: 'dev-3' }))
+  })
+
+  it('offers creating a separate device as its own action', () => {
+    const { onCreate } = renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: /Create a separate device/ }))
+    expect(onCreate).toHaveBeenCalled()
+  })
+
+  it('disables every choice while a row is being created', () => {
+    renderPicker({ busy: true })
+    expect(screen.getByRole('button', { name: /pihole/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Create a separate device/ })).toBeDisabled()
+  })
+
+  it('closes on cancel', () => {
+    const { onClose } = renderPicker()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/modals/__tests__/NodeModalDevice.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModalDevice.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * The Device Inventory picker in the node editor.
+ *
+ * A node draws one inventory row, and that row owns its facts — so two nodes on
+ * one row are one device, edited twice. The link used to be decided silently
+ * from the ip field, which merged two containers a user had only described by
+ * their port (#475) and gave them no way back. It is a field here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { NodeModal } from '../NodeModal'
+import { scanApi } from '@/api/client'
+import type { InventoryEntry, NodeData } from '@/types'
+
+vi.mock('sonner', async () => (await import('@/test/mocks')).mockSonner())
+
+vi.mock('@/api/client', () => ({
+  scanApi: {
+    pending: vi.fn(),
+    createPending: vi.fn(),
+  },
+}))
+
+// Shadcn's Select is a portal-driven listbox; a native <select> is what the
+// rest of this modal's tests drive, so the options are assertable.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ value, onValueChange, children }: {
+    value?: string; onValueChange?: (v: string) => void; children: React.ReactNode
+  }) => (
+    <select value={value} onChange={(e) => onValueChange?.(e.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectLabel: () => null,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectSeparator: () => null,
+}))
+
+function makeDevice(over: Partial<InventoryEntry> = {}): InventoryEntry {
+  return {
+    id: 'dev-1',
+    ip: '192.168.1.10',
+    mac: null,
+    hostname: 'nas.lan',
+    os: null,
+    services: [],
+    suggested_type: null,
+    status: 'approved',
+    discovered_at: '2026-01-01T00:00:00Z',
+    ...over,
+  }
+}
+
+const BASE: Partial<NodeData> = {
+  type: 'docker_container', label: 'gitea', ip: ':3001', check_method: 'ping', services: [],
+}
+
+/** The picker is the last <select> the modal renders. */
+const devicePicker = () => {
+  const all = screen.getAllByRole('combobox') as HTMLSelectElement[]
+  return all[all.length - 1]
+}
+
+function renderModal(props: Partial<Parameters<typeof NodeModal>[0]> = {}) {
+  const onSubmit = vi.fn()
+  render(<NodeModal open onClose={vi.fn()} onSubmit={onSubmit} initial={BASE} title="Edit Node" {...props} />)
+  return { onSubmit }
+}
+
+describe('NodeModal — device inventory link', () => {
+  beforeEach(() => {
+    vi.mocked(scanApi.pending).mockResolvedValue({ data: [] } as never)
+    vi.mocked(scanApi.createPending).mockResolvedValue({ data: makeDevice() } as never)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists the inventory and names the row this node draws', async () => {
+    vi.mocked(scanApi.pending).mockResolvedValue({
+      data: [makeDevice({ id: 'dev-1', label: 'NoteShare' }), makeDevice({ id: 'dev-2', label: 'NAS' })],
+    } as never)
+    renderModal({ initial: { ...BASE, device_id: 'dev-2' } })
+
+    expect(await screen.findByRole('option', { name: /NoteShare/ })).toBeInTheDocument()
+    expect(devicePicker().value).toBe('dev-2')
+  })
+
+  it('offers "not linked yet" only while the node has no row', async () => {
+    vi.mocked(scanApi.pending).mockResolvedValue({ data: [makeDevice()] } as never)
+    const { unmount } = render(
+      <NodeModal open onClose={vi.fn()} onSubmit={vi.fn()} initial={BASE} />,
+    )
+    expect(await screen.findByRole('option', { name: 'Not linked yet' })).toBeInTheDocument()
+    unmount()
+
+    render(
+      <NodeModal open onClose={vi.fn()} onSubmit={vi.fn()} initial={{ ...BASE, device_id: 'dev-1' }} />,
+    )
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('option', { name: 'Not linked yet' })).not.toBeInTheDocument()
+  })
+
+  it('points the node at the device picked, and shows the facts it will display', async () => {
+    vi.mocked(scanApi.pending).mockResolvedValue({
+      data: [makeDevice({ id: 'dev-2', label: 'NAS', ip: '192.168.1.50', hostname: 'nas.lan' })],
+    } as never)
+    const { onSubmit } = renderModal()
+    await screen.findByRole('option', { name: /NAS/ })
+
+    fireEvent.change(devicePicker(), { target: { value: 'dev-2' } })
+
+    // The addresses on screen belong to the row now, not to what the node had:
+    // saving a device you can see and reloading into another one is the bug.
+    expect(screen.getByPlaceholderText('192.168.1.x, 2001:db8::1')).toHaveValue('192.168.1.50')
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ device_id: 'dev-2', ip: '192.168.1.50', label: 'NAS' }),
+    )
+  })
+
+  it('leaves rack-created gear out — it is a mount, not a host', async () => {
+    vi.mocked(scanApi.pending).mockResolvedValue({
+      data: [
+        makeDevice({ id: 'dev-1', label: 'Patch panel', discovery_source: 'rack' }),
+        makeDevice({ id: 'dev-2', label: 'Shelf', discovery_sources: ['rack'] }),
+        makeDevice({ id: 'dev-3', label: 'NAS' }),
+      ],
+    } as never)
+    renderModal()
+
+    expect(await screen.findByRole('option', { name: /NAS/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Patch panel/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Shelf/ })).not.toBeInTheDocument()
+  })
+
+  it('creates a separate row on demand, forcing past the address already taken', async () => {
+    vi.mocked(scanApi.createPending).mockResolvedValue({
+      data: makeDevice({ id: 'dev-new', label: 'gitea' }),
+    } as never)
+    const { onSubmit } = renderModal()
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+
+    fireEvent.change(devicePicker(), { target: { value: '__new__' } })
+
+    await waitFor(() => expect(scanApi.createPending).toHaveBeenCalled())
+    // Without `force` the new row folds straight back into the one this node is
+    // trying to leave, and nothing is separated.
+    expect(vi.mocked(scanApi.createPending).mock.calls[0][0]).toMatchObject({
+      force: true,
+      label: 'gitea',
+      ip: ':3001',
+    })
+    await waitFor(() => expect(devicePicker().value).toBe('dev-new'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ device_id: 'dev-new' }))
+  })
+
+  it('keeps the node on its row when the inventory cannot be loaded', async () => {
+    vi.mocked(scanApi.pending).mockRejectedValue(new Error('offline'))
+    const { onSubmit } = renderModal({ initial: { ...BASE, device_id: 'dev-7' } })
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ device_id: 'dev-7' }))
+  })
+
+  it('is absent for canvas furniture, which describes no device', async () => {
+    render(
+      <NodeModal
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        initial={{ type: 'text', label: 'A note' }}
+      />,
+    )
+    await waitFor(() => expect(scanApi.pending).not.toHaveBeenCalled())
+    expect(screen.queryByText(/The inventory row this node draws/)).not.toBeInTheDocument()
+  })
+})
+
+describe('NodeModal — device inventory link (standalone)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.clearAllMocks()
+  })
+
+  it('is absent without a backend — there is no inventory to point at', async () => {
+    vi.stubEnv('VITE_STANDALONE', 'true')
+    vi.resetModules()
+    const { NodeModal: NM } = await import('../NodeModal')
+    const { scanApi: api } = await import('@/api/client')
+    vi.mocked(api.pending).mockResolvedValue({ data: [] } as never)
+
+    render(<NM open onClose={vi.fn()} onSubmit={vi.fn()} initial={BASE} />)
+
+    expect(screen.queryByText(/The inventory row this node draws/)).not.toBeInTheDocument()
+    expect(api.pending).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/modals/__tests__/NodeModalDevice.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModalDevice.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/api/client', () => ({
   scanApi: {
     pending: vi.fn(),
     createPending: vi.fn(),
+    matchDevice: vi.fn(),
   },
 }))
 
@@ -204,5 +205,140 @@ describe('NodeModal — device inventory link (standalone)', () => {
 
     expect(screen.queryByText(/The inventory row this node draws/)).not.toBeInTheDocument()
     expect(api.pending).not.toHaveBeenCalled()
+  })
+})
+
+describe('NodeModal — address match prompt', () => {
+  beforeEach(() => {
+    vi.mocked(scanApi.pending).mockResolvedValue({ data: [] } as never)
+    vi.mocked(scanApi.matchDevice).mockResolvedValue({
+      data: { device: null, matched_on: null, matched_value: null, nodes: [] },
+    } as never)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const typeIp = (value: string) => {
+    const input = screen.getByPlaceholderText('192.168.1.x, 2001:db8::1')
+    fireEvent.change(input, { target: { value } })
+    fireEvent.blur(input)
+    return input
+  }
+
+  const matching = (over: Partial<InventoryEntry> = {}, nodes: { id: string; label: string; design_id: string | null; design_name: string | null }[] = []) => ({
+    data: {
+      device: makeDevice({ id: 'dev-9', label: 'HomeAssistant', ...over }),
+      matched_on: 'ip',
+      matched_value: '192.168.0.100',
+      nodes,
+    },
+  })
+
+  it('asks before an address makes this node someone else’s device', async () => {
+    vi.mocked(scanApi.matchDevice).mockResolvedValue(
+      matching({}, [{ id: 'n-1', label: 'HomeAssist', design_id: 'd-1', design_name: 'Home' }]) as never,
+    )
+    renderModal()
+
+    typeIp('192.168.0.100')
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /192\.168\.0\.100 already describes HomeAssistant, drawn as HomeAssist\./,
+    )
+  })
+
+  it('says so when the matched device is on no canvas yet', async () => {
+    vi.mocked(scanApi.matchDevice).mockResolvedValue(matching() as never)
+    renderModal()
+
+    typeIp('192.168.0.100')
+
+    expect(await screen.findByRole('status')).toHaveTextContent(/not on any canvas yet/)
+  })
+
+  it('links the node to the match, facts and all', async () => {
+    vi.mocked(scanApi.matchDevice).mockResolvedValue(
+      matching({ ip: '192.168.0.100', hostname: 'ha.lan' }) as never,
+    )
+    const { onSubmit } = renderModal()
+    typeIp('192.168.0.100')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Link to it' }))
+
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ device_id: 'dev-9', label: 'HomeAssistant' }),
+    )
+  })
+
+  it('keeps the node separate, and does not ask about that device again', async () => {
+    vi.mocked(scanApi.matchDevice).mockResolvedValue(matching() as never)
+    const { onSubmit } = renderModal()
+    typeIp('192.168.0.100')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Keep separate' }))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    // Re-blurring the same address must not re-open a question already answered.
+    typeIp('192.168.0.100')
+    await waitFor(() => expect(scanApi.matchDevice).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    // No link was made: the node is saved without one, and mints a row of its
+    // own when it lands.
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty('device_id')
+  })
+
+  it('stays quiet when the address is new', async () => {
+    renderModal()
+    typeIp('10.9.9.9')
+
+    await waitFor(() => expect(scanApi.matchDevice).toHaveBeenCalled())
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('stays quiet when the node already draws the matched device', async () => {
+    vi.mocked(scanApi.matchDevice).mockResolvedValue(matching() as never)
+    renderModal({ initial: { ...BASE, device_id: 'dev-9' } })
+
+    typeIp('192.168.0.100')
+
+    await waitFor(() => expect(scanApi.matchDevice).toHaveBeenCalled())
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('does not ask at all for an empty address', async () => {
+    renderModal({ initial: { ...BASE, ip: '' } })
+    typeIp('')
+
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+    expect(scanApi.matchDevice).not.toHaveBeenCalled()
+  })
+
+  it('excludes the node being edited from the nodes it names', async () => {
+    vi.mocked(scanApi.matchDevice).mockResolvedValue(matching() as never)
+    renderModal({ currentNodeId: 'node-42' })
+
+    typeIp('192.168.0.100')
+
+    await waitFor(() => expect(scanApi.matchDevice).toHaveBeenCalled())
+    expect(vi.mocked(scanApi.matchDevice).mock.calls[0][0]).toMatchObject({
+      ip: '192.168.0.100',
+      exclude_node_id: 'node-42',
+    })
+  })
+
+  it('says nothing when the lookup fails — the picker still works', async () => {
+    vi.mocked(scanApi.matchDevice).mockRejectedValue(new Error('offline'))
+    renderModal()
+
+    typeIp('192.168.0.100')
+
+    await waitFor(() => expect(scanApi.matchDevice).toHaveBeenCalled())
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/modals/__tests__/NodeModalDevice.test.tsx
+++ b/frontend/src/components/modals/__tests__/NodeModalDevice.test.tsx
@@ -62,11 +62,13 @@ const BASE: Partial<NodeData> = {
   type: 'docker_container', label: 'gitea', ip: ':3001', check_method: 'ping', services: [],
 }
 
-/** The picker is the last <select> the modal renders. */
-const devicePicker = () => {
-  const all = screen.getAllByRole('combobox') as HTMLSelectElement[]
-  return all[all.length - 1]
-}
+/** Open the device picker from the node editor's Device field. */
+const openPicker = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Device inventory selector' }))
+
+/** The name the Device field currently shows. */
+const linkedName = () =>
+  screen.getByRole('button', { name: 'Device inventory selector' }).textContent
 
 function renderModal(props: Partial<Parameters<typeof NodeModal>[0]> = {}) {
   const onSubmit = vi.fn()
@@ -84,29 +86,49 @@ describe('NodeModal — device inventory link', () => {
     vi.clearAllMocks()
   })
 
-  it('lists the inventory and names the row this node draws', async () => {
+  it('names the row this node draws, and lists the inventory to change it', async () => {
     vi.mocked(scanApi.pending).mockResolvedValue({
       data: [makeDevice({ id: 'dev-1', label: 'NoteShare' }), makeDevice({ id: 'dev-2', label: 'NAS' })],
     } as never)
     renderModal({ initial: { ...BASE, device_id: 'dev-2' } })
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
 
-    expect(await screen.findByRole('option', { name: /NoteShare/ })).toBeInTheDocument()
-    expect(devicePicker().value).toBe('dev-2')
+    expect(linkedName()).toContain('NAS')
+    openPicker()
+    expect(await screen.findByRole('button', { name: /NoteShare/ })).toBeInTheDocument()
   })
 
-  it('offers "not linked yet" only while the node has no row', async () => {
-    vi.mocked(scanApi.pending).mockResolvedValue({ data: [makeDevice()] } as never)
-    const { unmount } = render(
-      <NodeModal open onClose={vi.fn()} onSubmit={vi.fn()} initial={BASE} />,
-    )
-    expect(await screen.findByRole('option', { name: 'Not linked yet' })).toBeInTheDocument()
-    unmount()
+  it('says so when the node has no row yet', async () => {
+    renderModal()
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+    expect(linkedName()).toContain('Not linked yet')
+  })
 
-    render(
-      <NodeModal open onClose={vi.fn()} onSubmit={vi.fn()} initial={{ ...BASE, device_id: 'dev-1' }} />,
-    )
-    await waitFor(() => expect(scanApi.pending).toHaveBeenCalledTimes(2))
-    expect(screen.queryByRole('option', { name: 'Not linked yet' })).not.toBeInTheDocument()
+  it('searches the inventory by name and by address', async () => {
+    vi.mocked(scanApi.pending).mockResolvedValue({
+      data: [
+        makeDevice({ id: 'dev-1', label: 'proxmox-1', ip: '192.168.50.10' }),
+        makeDevice({ id: 'dev-2', label: 'proxmox-1', ip: '192.168.50.11' }),
+        makeDevice({ id: 'dev-3', label: 'pihole', ip: '192.168.50.20' }),
+      ],
+    } as never)
+    renderModal()
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+    openPicker()
+
+    // Two rows named the same are told apart by their address, and found by it.
+    fireEvent.change(await screen.findByLabelText('Search devices'), {
+      target: { value: '50.11' },
+    })
+    expect(screen.getByRole('button', { name: /192\.168\.50\.11/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /192\.168\.50\.10/ })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Search devices'), { target: { value: 'pih' } })
+    expect(screen.getByRole('button', { name: /pihole/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /proxmox/ })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Search devices'), { target: { value: 'nope' } })
+    expect(screen.getByText('No device matches "nope".')).toBeInTheDocument()
   })
 
   it('points the node at the device picked, and shows the facts it will display', async () => {
@@ -114,9 +136,10 @@ describe('NodeModal — device inventory link', () => {
       data: [makeDevice({ id: 'dev-2', label: 'NAS', ip: '192.168.1.50', hostname: 'nas.lan' })],
     } as never)
     const { onSubmit } = renderModal()
-    await screen.findByRole('option', { name: /NAS/ })
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+    openPicker()
 
-    fireEvent.change(devicePicker(), { target: { value: 'dev-2' } })
+    fireEvent.click(await screen.findByRole('button', { name: /NAS/ }))
 
     // The addresses on screen belong to the row now, not to what the node had:
     // saving a device you can see and reloading into another one is the bug.
@@ -136,10 +159,12 @@ describe('NodeModal — device inventory link', () => {
       ],
     } as never)
     renderModal()
+    await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+    openPicker()
 
-    expect(await screen.findByRole('option', { name: /NAS/ })).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /Patch panel/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /Shelf/ })).not.toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /NAS/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Patch panel/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Shelf/ })).not.toBeInTheDocument()
   })
 
   it('creates a separate row on demand, forcing past the address already taken', async () => {
@@ -148,8 +173,9 @@ describe('NodeModal — device inventory link', () => {
     } as never)
     const { onSubmit } = renderModal()
     await waitFor(() => expect(scanApi.pending).toHaveBeenCalled())
+    openPicker()
 
-    fireEvent.change(devicePicker(), { target: { value: '__new__' } })
+    fireEvent.click(await screen.findByRole('button', { name: /Create a separate device/ }))
 
     await waitFor(() => expect(scanApi.createPending).toHaveBeenCalled())
     // Without `force` the new row folds straight back into the one this node is
@@ -159,7 +185,7 @@ describe('NodeModal — device inventory link', () => {
       label: 'gitea',
       ip: ':3001',
     })
-    await waitFor(() => expect(devicePicker().value).toBe('dev-new'))
+    await waitFor(() => expect(linkedName()).toContain('gitea'))
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ device_id: 'dev-new' }))

--- a/frontend/src/utils/deviceFacts.ts
+++ b/frontend/src/utils/deviceFacts.ts
@@ -152,3 +152,13 @@ export function deviceFactsToNodeData(device: InventoryEntry): Partial<NodeData>
     ieee_address: device.ieee_address ?? undefined,
   }
 }
+
+/**
+ * Every address a device answers to, as one line.
+ *
+ * Two rows named `proxmox-1` are told apart by this and nothing else, so it is
+ * printed wherever a device is offered for the user to choose between.
+ */
+export function deviceAddresses(device: InventoryEntry): string {
+  return [device.ip, device.mac, device.ieee_address].filter(Boolean).join(' · ')
+}


### PR DESCRIPTION
## What

Fixes #475: two nodes describing different containers became one device, and no
edit could separate them again. The reporter had typed `:3001` — a docker port
mapping — into the IP Address field of both, and device identity is resolved
from that field, so both nodes were attached to a single Device Inventory row.
Editing one then edited the other.

Two halves: identity stops trusting a value that is not an address, and the link
between a node and its inventory row becomes something the user can see and
change.

## Changes

**Backend — identity (the bug)**

- `identity_ip_tokens()` in `services/inventory_sync.py` keeps only the tokens of
  an `ip` field that parse as an address; `find_device_for` matches on those.
  The rest stays in the field, shown and saved exactly as typed, and is simply
  not evidence of who a device is. `ieee` and `mac` matching are untouched, and
  a field mixing the two (`"dhcp, 10.0.0.5"`) still matches on the address.
- `dedupe_nodes_by_device` skips a row carrying no ieee, no mac and no address.
  It collapses two nodes drawing one row on one design and **deletes** the
  younger one, and it runs after every scan and every proxmox/zigbee/zwave
  import — so the same `:3001` could have cost the reporter a node outright.
  Proxmox and mesh rows always carry an ieee, so no importer is affected.

**Backend — new endpoints**

- `POST /api/v1/scan/pending` takes `force`, skipping the fold into a row an
  address already names. Mirrors `NodeCreate.force`.
- `GET /api/v1/scan/match?ip=&mac=&ieee=&exclude_node_id=` answers "what would
  this address link to" and writes nothing. Returns the row, which address found
  it, and every node already drawing it.

**Frontend — the node editor**

- A **Device** field under Parent Container: which inventory row this node draws,
  the inventory to move it to, and "Create a separate device" for a node that
  belongs on one of its own. Picking a row also replaces the facts on screen with
  that row's, the way the server hydrates them on read — otherwise the user saves
  a device they can see and reloads into a different one.
- Leaving the IP field asks `/scan/match` and, on a hit, offers **Link to it** or
  **Keep separate** before anything is written. Asked on blur because the save
  cannot ask: it writes to the canvas store, and the canvas is persisted later in
  one request carrying every node, long after the dialog closed.
- Rack-created gear is left out of the picker (it documents a mount, and approve
  already refuses to put one on a logical canvas). The field is hidden for canvas
  furniture and in standalone mode, which has no inventory at all.

**No migration.** Existing canvases keep the links they have; nothing is
rewritten. A pair already bonded is separated with the picker.

## Testing

- Backend, `pytest`: 9 new tests — two nodes with `ip=":3001"` get two rows, port
  mapping lists do not match, `"dhcp, 10.0.0.5"` still matches on the address,
  mac fallback, `identity_ip_tokens` units, dedupe keeping both nodes on an
  address-less row while still collapsing on a real IP or a mac, `force` minting
  a second row, and `/scan/match` (hit, miss, `:3001`, mac normalization, node
  listing, `exclude_node_id`).
- Frontend, `npm test`: 17 new tests in `NodeModalDevice.test.tsx` covering the
  picker (listing, current row, fact replacement, rack exclusion, forced create,
  failed load, furniture, standalone) and the match prompt (the ask, linking,
  keeping separate without re-asking, and silence on a new address, an existing
  link, an empty field or a failed lookup).
- Full suites green: 1403 backend, 2671 frontend.

ha-relevant: yes — the matcher and dedupe changes touch logic the HACS scanner
carries its own copy of. The node modal work is `maybe`; the HA panel has its own
editor.

Closes #475
