### PR TITLE
fix: report ping's real RTT instead of the subprocess wall-time

### DIFF
--- a/backend/app/services/status_checker.py
+++ b/backend/app/services/status_checker.py
@@ -1,6 +1,7 @@
 """Per-node status checks: ping, http, https, tcp, ssh, prometheus, health, none."""
 import asyncio
 import logging
+import re
 import socket
 import sys
 import time
@@ -31,10 +32,13 @@ async def check_node(check_method: str, target: str | None, ip: str | None) -> d
         return {"status": "unknown", "response_time_ms": None}
 
     start = time.monotonic()
+    # Set by the ping branch when ping's own stdout gave us a real RTT; the
+    # subprocess wall-clock is meaningless there (see _ping).
+    rtt_ms: int | None = None
     try:
         match check_method:
             case "ping":
-                ok = await _ping(host)
+                ok, rtt_ms = await _ping(host)
             case "http":
                 url = host if host.startswith("http") else f"http://{host}"
                 ok = await _http_get(url)
@@ -54,10 +58,13 @@ async def check_node(check_method: str, target: str | None, ip: str | None) -> d
                 url = host if host.startswith("http") else f"http://{host}/health"
                 ok = await _http_get(url)
             case _:
-                ok = await _ping(host)
+                ok, rtt_ms = await _ping(host)
 
         elapsed_ms = int((time.monotonic() - start) * 1000)
-        return {"status": "online" if ok else "offline", "response_time_ms": elapsed_ms}
+        return {
+            "status": "online" if ok else "offline",
+            "response_time_ms": rtt_ms if rtt_ms is not None else elapsed_ms,
+        }
 
     except Exception as exc:
         logger.debug("Check failed for %s (%s): %s", host, check_method, exc)
@@ -73,7 +80,42 @@ def _is_ipv6(host: str) -> bool:
         return False
 
 
-async def _ping(host: str) -> bool:
+# Pulls the per-probe RTT out of ping's stdout: Unix "time=0.344 ms", Windows
+# "time<1ms", and the localized Windows wording ("temps=1ms", "Zeit=1ms") — the
+# "<number>ms" shape survives translation even though the label does not.
+# Deliberately does NOT match the Linux summary line
+# "rtt min/avg/max/mdev = 0.344/0.401/0.459/0.057 ms": after "=" the digits are
+# followed by "/", not by "ms", so the probe lines are the only matches.
+_RTT_RE = re.compile(r"[=<]\s*([\d.,]+)\s*ms")
+
+
+def _parse_rtt_ms(output: str) -> int | None:
+    """Smallest per-probe RTT in ping's stdout, rounded to ms. None if absent.
+
+    The first probe often carries ARP resolution, so the minimum is the fairer
+    reading of the link than the first or the mean. Sub-millisecond LAN replies
+    round down to 0 — response_time_ms is an integer column, and 0 is a truer
+    answer than the ~1000 ms the subprocess wall-clock used to report.
+    """
+    values: list[float] = []
+    for raw in _RTT_RE.findall(output):
+        try:
+            values.append(float(raw.replace(",", ".")))
+        except ValueError:
+            continue
+    if not values:
+        return None
+    return round(min(values))
+
+
+async def _ping(host: str) -> tuple[bool, int | None]:
+    """Ping host. Returns (reachable, rtt_ms) — rtt_ms is None if unparseable.
+
+    The RTT comes from ping's own stdout, never from timing the subprocess: 2
+    probes at ping's default 1 s interval take ~1 s of wall-clock however fast
+    the replies come back, so the wall-clock measures ping's pacing rather than
+    the network (issue #470).
+    """
     # Send 2 probes with a ~2s timeout so a single dropped packet or a slow
     # device (ESPHome, IoT) doesn't flap a node offline. Success = any reply.
     #
@@ -95,11 +137,15 @@ async def _ping(host: str) -> bool:
         args = ["ping", *family, "-c", "2", "-W", "2", host]
     proc = await asyncio.create_subprocess_exec(
         *args,
-        stdout=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
     )
-    await proc.wait()
-    return proc.returncode == 0
+    # communicate(), not wait(): wait() on a process whose stdout pipe fills up
+    # deadlocks, and we need that stdout to read the RTT.
+    stdout, _ = await proc.communicate()
+    if proc.returncode != 0:
+        return False, None
+    return True, _parse_rtt_ms((stdout or b"").decode(errors="replace"))
 
 
 async def _http_get(url: str, verify: bool = False) -> bool:

--- a/backend/tests/test_status_checker.py
+++ b/backend/tests/test_status_checker.py
@@ -1,4 +1,5 @@
 """Tests for status_checker service: each check method."""
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -6,6 +7,7 @@ import pytest
 
 from app.services.status_checker import (
     _http_get,
+    _parse_rtt_ms,
     _ping,
     _tcp_connect,
     check_node,
@@ -67,15 +69,15 @@ async def test_check_node_unknown_without_host():
 
 @pytest.mark.asyncio
 async def test_check_node_ping_online():
-    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=True):
+    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=(True, 3)):
         result = await check_node("ping", None, "192.168.1.1")
     assert result["status"] == "online"
-    assert result["response_time_ms"] is not None
+    assert result["response_time_ms"] == 3
 
 
 @pytest.mark.asyncio
 async def test_check_node_ping_offline():
-    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=False):
+    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=(False, None)):
         result = await check_node("ping", None, "192.168.1.1")
     assert result["status"] == "offline"
 
@@ -170,7 +172,7 @@ async def test_check_node_health_appends_health():
 
 @pytest.mark.asyncio
 async def test_check_node_unknown_method_falls_back_to_ping():
-    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=True) as mock_ping:
+    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=(True, 7)) as mock_ping:
         result = await check_node("foobar", None, "10.0.0.1")
     mock_ping.assert_called_once()
     assert result["status"] == "online"
@@ -194,7 +196,7 @@ async def test_ping_uses_unix_args_on_non_windows():
         captured["args"] = args
         proc = MagicMock()
         proc.returncode = 0
-        proc.wait = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
         return proc
 
     with patch("app.services.status_checker.sys.platform", "linux"), \
@@ -223,7 +225,7 @@ async def test_ping_uses_macos_millisecond_timeout():
         captured["args"] = args
         proc = MagicMock()
         proc.returncode = 0
-        proc.wait = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
         return proc
 
     with patch("app.services.status_checker.sys.platform", "darwin"), \
@@ -244,7 +246,7 @@ async def test_ping_uses_windows_args_on_win32():
         captured["args"] = args
         proc = MagicMock()
         proc.returncode = 0
-        proc.wait = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
         return proc
 
     with patch("app.services.status_checker.sys.platform", "win32"), \
@@ -267,7 +269,7 @@ async def test_ping_ipv6_linux_uses_dash6():
         captured["args"] = args
         proc = MagicMock()
         proc.returncode = 0
-        proc.wait = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
         return proc
 
     with patch("app.services.status_checker.sys.platform", "linux"), \
@@ -287,7 +289,7 @@ async def test_ping_ipv6_macos_uses_ping6():
         captured["args"] = args
         proc = MagicMock()
         proc.returncode = 0
-        proc.wait = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
         return proc
 
     with patch("app.services.status_checker.sys.platform", "darwin"), \
@@ -305,7 +307,7 @@ async def test_ping_ipv6_windows_uses_dash6():
         captured["args"] = args
         proc = MagicMock()
         proc.returncode = 0
-        proc.wait = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
         return proc
 
     with patch("app.services.status_checker.sys.platform", "win32"), \
@@ -313,6 +315,141 @@ async def test_ping_ipv6_windows_uses_dash6():
         await _ping("2001:db8::1")
 
     assert "-6" in captured["args"]
+
+
+# --- _ping RTT parsing (issue #470) ---
+
+LINUX_PING_OUTPUT = """PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.
+64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=0.812 ms
+64 bytes from 192.168.1.1: icmp_seq=2 ttl=64 time=0.344 ms
+
+--- 192.168.1.1 ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1001ms
+rtt min/avg/max/mdev = 0.344/0.578/0.812/0.234 ms
+"""
+
+
+def test_parse_rtt_reads_unix_probe_lines_not_the_summary():
+    """The summary line's numbers must not win over the real probes."""
+    # min of the two probes (0.344), rounded — not 1001 from "time 1001ms" of
+    # the statistics line, and not anything from the rtt min/avg/max line.
+    assert _parse_rtt_ms(LINUX_PING_OUTPUT) == 0
+
+
+def test_parse_rtt_takes_the_minimum_probe():
+    output = (
+        "64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=42.5 ms\n"
+        "64 bytes from 10.0.0.1: icmp_seq=2 ttl=64 time=12.4 ms\n"
+    )
+    # First probe carries ARP resolution, so the minimum is the fair reading.
+    assert _parse_rtt_ms(output) == 12
+
+
+def test_parse_rtt_windows_sub_millisecond():
+    output = (
+        "Reply from 192.168.1.1: bytes=32 time<1ms TTL=64\r\n"
+        "Reply from 192.168.1.1: bytes=32 time<1ms TTL=64\r\n"
+    )
+    # "bytes=32" must not be read as an RTT — only "<1ms" is.
+    assert _parse_rtt_ms(output) == 1
+
+
+def test_parse_rtt_localized_windows_wording():
+    """Translated Windows keeps the "<label><sep><number>ms" shape."""
+    assert _parse_rtt_ms("Reponse de 192.168.1.1 : octets=32 temps=3ms TTL=64") == 3
+    assert _parse_rtt_ms("Antwort von 192.168.1.1: Bytes=32 Zeit=5ms TTL=64") == 5
+
+
+def test_parse_rtt_accepts_comma_decimal_separator():
+    assert _parse_rtt_ms("64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=12,7 ms") == 13
+
+
+def test_parse_rtt_returns_none_when_unparseable():
+    assert _parse_rtt_ms("") is None
+    assert _parse_rtt_ms("ping: unknown host nope.local") is None
+
+
+@pytest.mark.asyncio
+async def test_ping_returns_parsed_rtt_not_subprocess_walltime():
+    """Regression for #470: 2 probes pace at ~1s, so wall-clock is not the RTT."""
+    async def fake_exec(*args, **kwargs):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(LINUX_PING_OUTPUT.encode(), b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        ok, rtt_ms = await _ping("192.168.1.1")
+
+    assert ok is True
+    assert rtt_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_ping_captures_stdout_and_drains_it():
+    """stdout must be piped (to read the RTT) and drained via communicate()."""
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(LINUX_PING_OUTPUT.encode(), b""))
+        # wait() on a filled pipe deadlocks — it must not be what we call.
+        proc.wait = AsyncMock(side_effect=AssertionError("must use communicate()"))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await _ping("192.168.1.1")
+
+    assert captured["kwargs"]["stdout"] is asyncio.subprocess.PIPE
+
+
+@pytest.mark.asyncio
+async def test_ping_offline_reports_no_rtt():
+    async def fake_exec(*args, **kwargs):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        ok, rtt_ms = await _ping("192.168.1.99")
+
+    assert ok is False
+    assert rtt_ms is None
+
+
+@pytest.mark.asyncio
+async def test_ping_undecodable_output_falls_back_to_no_rtt():
+    """Non-UTF8 bytes from a localized ping must not raise."""
+    async def fake_exec(*args, **kwargs):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"\xff\xfe not utf8", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        ok, rtt_ms = await _ping("192.168.1.1")
+
+    assert ok is True
+    assert rtt_ms is None
+
+
+@pytest.mark.asyncio
+async def test_check_node_ping_falls_back_to_walltime_when_rtt_unparseable():
+    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=(True, None)):
+        result = await check_node("ping", None, "192.168.1.1")
+    assert result["status"] == "online"
+    assert isinstance(result["response_time_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_check_node_ping_reports_zero_rtt_not_walltime():
+    """A sub-millisecond LAN reply must survive as 0, not be treated as missing."""
+    with patch("app.services.status_checker._ping", new_callable=AsyncMock, return_value=(True, 0)):
+        result = await check_node("ping", None, "192.168.1.1")
+    assert result["response_time_ms"] == 0
 
 
 def test_is_ipv6_detection():


### PR DESCRIPTION
## What

`response_time_ms` was meaningless for every ping-checked device: it always read ~1000-1014ms, whatever the real latency. `_ping` sends 2 probes and `check_node` timed the whole subprocess, but ping paces its probes 1 second apart by default — so the measurement was ping's own pacing, not the network. This reads the RTT out of ping's stdout instead.

Closes #470.

## Changes

Backend (`app/services/status_checker.py`):

- `_ping` pipes stdout and drains it with `communicate()` instead of `wait()` — `wait()` deadlocks on a process whose stdout pipe fills up. It now returns `(reachable, rtt_ms)` rather than a bare bool.
- New `_parse_rtt_ms` / `_RTT_RE` (`[=<]\s*([\d.,]+)\s*ms`) reads the per-probe RTT across platforms and locales: Unix `time=0.344 ms`, Windows `time<1ms`, translated Windows `temps=1ms` / `Zeit=1ms`, and comma decimal separators. It deliberately does not match the Linux `rtt min/avg/max/mdev =` summary line or the `time 1001ms` statistics line. Of the two probes the minimum wins — the first often carries ARP resolution.
- `check_node` uses the parsed RTT when there is one and falls back to the subprocess wall-clock only when the output is unparseable.

Not changed: the `http` / `https` / `tcp` / `ssh` / `prometheus` / `health` methods keep their wall-clock timing, which is the real measurement for them. The 2-probe anti-flap behaviour is kept, as are the platform and IPv6 argument choices. No schema, migration or frontend change.

Behaviour note: sub-millisecond LAN replies now round to 0. `response_time_ms` is an integer column, and 0 is a truer answer than the ~1000ms it reported before.

Pre-existing and left alone, worth its own issue: an offline device still records the wall-clock, so the UI prints e.g. "4022 ms" beside an offline badge. That is true of every check method, not just ping.

## Testing

`backend/tests/test_status_checker.py` — 11 new tests:

- RTT parsing: probe lines win over the `rtt min/avg/max` summary and the `time 1001ms` statistics line; minimum probe selection; Windows sub-millisecond `time<1ms`; localized Windows wording; comma decimal separator; unparseable and empty output return `None`.
- `_ping`: returns the parsed RTT rather than the wall-time (the #470 regression); passes `stdout=PIPE` and never calls `wait()`; an unreachable host reports no RTT; non-UTF8 output does not raise.
- `check_node`: falls back to the wall-clock when the RTT is unparseable, and keeps a parsed `0` as a real value instead of treating it as missing.

Existing tests updated for the new `_ping` signature — 3 patch sites now return tuples, and the 6 platform/IPv6 argument tests mock `proc.communicate` instead of `proc.wait`. No assertion was weakened.

Verified against real ping on macOS: `check_node('ping', None, '127.0.0.1')` returns `response_time_ms: 0`, previously ~1010.

`ruff`, `mypy` and the full backend suite pass (1387 passed, 8 skipped).

ha-relevant: yes
