### PR TITLE
fix: stop a renamed service vanishing from the canvas

### DIFF
--- a/frontend/src/stores/__tests__/canvasStore/deviceFacts.test.ts
+++ b/frontend/src/stores/__tests__/canvasStore/deviceFacts.test.ts
@@ -141,4 +141,23 @@ describe('canvasStore — applyDeviceFacts keeps each node\'s arrangement', () =
     useCanvasStore.getState().applyDeviceFacts('d-1', { services: [ssh] })
     expect(useCanvasStore.getState().nodes[0].data.services).toEqual([ssh])
   })
+
+  it('redraws a renamed service instead of losing it (#468)', () => {
+    // Correcting a scanner guess in the Device Inventory is a label change, not
+    // a different service — the node keeps drawing it, under the new name.
+    useCanvasStore.getState().loadCanvas([drawnAs('n1', [ssh, kuma])], [])
+    const homepage = { ...kuma, service_name: 'Homepage' }
+    useCanvasStore.getState().applyDeviceFacts('d-1', { services: [ssh, homepage] })
+    expect(useCanvasStore.getState().nodes[0].data.services).toEqual([ssh, homepage])
+  })
+
+  it('does not claim a rename it took from the row as a canvas edit', () => {
+    useCanvasStore.getState().loadCanvas([drawnAs('n1', [ssh, kuma])], [])
+    useCanvasStore.getState().applyDeviceFacts('d-1', {
+      services: [ssh, { ...kuma, service_name: 'Homepage' }],
+    })
+    const { nodes, factsBaseline } = useCanvasStore.getState()
+    expect(changedFactFields(nodes[0].data, factsBaseline.n1)).toEqual([])
+    expect(useCanvasStore.getState().hasUnsavedChanges).toBe(false)
+  })
 })

--- a/frontend/src/utils/__tests__/deviceFacts.test.ts
+++ b/frontend/src/utils/__tests__/deviceFacts.test.ts
@@ -10,6 +10,7 @@ import {
   deviceFactsToNodeData,
   factsBaselineOf,
   factsBaselines,
+  listArrangedForNode,
 } from '@/utils/deviceFacts'
 import type { InventoryEntry, NodeData } from '@/types'
 import type { Node } from '@xyflow/react'
@@ -92,6 +93,50 @@ describe('factsBaselines', () => {
     expect(Object.keys(baselines)).toEqual(['n1', 'n2'])
     expect(changedFactFields(nodes[1].data, baselines.n2)).toEqual([])
     expect(changedFactFields(nodes[1].data, baselines.n1)).toEqual(['notes'])
+  })
+})
+
+describe('listArrangedForNode', () => {
+  const ssh = { port: 22, protocol: 'tcp' as const, service_name: 'ssh' }
+  const guessed = { port: 8096, protocol: 'tcp' as const, service_name: 'TCP/8096' }
+  const renamed = { ...guessed, service_name: 'Jellyfin' }
+
+  it('follows a rename rather than hiding the service (#468)', () => {
+    // A service is its port, not its name. Keying on the name dropped the entry
+    // the node drew and appended the renamed one hidden, so correcting a
+    // scanner guess in the Device Inventory made it vanish from the canvas.
+    expect(listArrangedForNode([ssh, guessed], [ssh, renamed])).toEqual([ssh, renamed])
+  })
+
+  it('keeps the node\'s place and flag across a rename', () => {
+    const arranged = listArrangedForNode([{ ...guessed, visible: false }, ssh], [ssh, renamed])
+    expect(arranged).toEqual([{ ...renamed, visible: false }, ssh])
+  })
+
+  it('still tells two services on the same port apart by protocol', () => {
+    const udp = { ...guessed, protocol: 'udp' as const }
+    expect(listArrangedForNode([guessed], [guessed, udp])).toEqual([
+      guessed,
+      { ...udp, visible: false },
+    ])
+  })
+
+  it('keys a port-less service by name — nothing else identifies one', () => {
+    const proxied = { protocol: 'tcp' as const, service_name: 'Vaultwarden', host: 'vault.lan' }
+    const other = { protocol: 'tcp' as const, service_name: 'Gitea', host: 'git.lan' }
+    expect(listArrangedForNode([proxied], [proxied, other])).toEqual([
+      proxied,
+      { ...other, visible: false },
+    ])
+  })
+
+  it('is unchanged for properties, which carry their own key', () => {
+    const rack = { key: 'Rack', value: 'A1', icon: null, visible: true }
+    const owner = { key: 'Owner', value: 'me', icon: null, visible: true }
+    expect(listArrangedForNode([{ ...rack, visible: false }], [rack, owner])).toEqual([
+      { ...rack, visible: false },
+      { ...owner, visible: false },
+    ])
   })
 })
 

--- a/frontend/src/utils/deviceFacts.ts
+++ b/frontend/src/utils/deviceFacts.ts
@@ -47,11 +47,25 @@ const encode = (value: unknown): string => JSON.stringify(value ?? null)
  * a service or dragging a property into place is not an edit to the device and
  * must not be reported as one — otherwise a rearranged canvas would push its
  * arrangement onto every other canvas showing the same device.
+ *
+ * A service is identified by its port and protocol, never by its name — the
+ * same identity the backend's `_service_identity_key` uses. The name is a
+ * label: the scanner guesses it, the user corrects it, and keying on it made a
+ * rename look like a different service. `listArrangedForNode` would then drop
+ * the entry the node drew and append the renamed one hidden, so correcting a
+ * service in the Device Inventory made it vanish from every canvas (issue #468).
+ *
+ * A service with no port keeps the three-part form, name included: nothing else
+ * tells two of those apart.
  */
-const keyOf = (item: Record<string, unknown>): string =>
-  'key' in item
-    ? String(item.key ?? '').toLowerCase()
-    : `${item.port ?? ''}|${item.protocol ?? ''}|${String(item.service_name ?? '').toLowerCase()}`
+const keyOf = (item: Record<string, unknown>): string => {
+  if ('key' in item) return String(item.key ?? '').toLowerCase()
+  const { port, protocol } = item
+  if (port === undefined || port === null || port === '') {
+    return `None|${protocol ?? ''}|${String(item.service_name ?? '').toLowerCase()}`
+  }
+  return `${port}|${protocol ?? ''}`
+}
 
 const encodeFacts = (field: DeviceFactField, value: unknown): string => {
   if (field !== 'services' && field !== 'properties') return encode(value)


### PR DESCRIPTION
## What

Fixes #468: renaming a service from the Device Inventory made it disappear from every canvas drawing that device, instead of redrawing it under the new name.

This is the client half of the bug found alongside #469. `37dc138` fixed the server, which now identifies a service by `port|protocol`. The frontend runs the same merge when it pushes an inventory edit into the canvases already on screen, and it was still identifying a service by `port|protocol|name` — so the two disagreed about what one service is.

## Changes

**Frontend**

- `utils/deviceFacts.ts` — `keyOf` now renders the same service identity as the backend's `_service_identity_key`: `port|protocol` when there is a port, `None|protocol|name` when there is not, since nothing else tells two port-less services apart. The property branch, which carries its own `key`, is unchanged.

No API change, no migration, no change to what is persisted.

### Root cause

An inventory edit reaches the open canvas through `applyDeviceFacts` -> `listArrangedForNode`, which matches what the node draws against what the row now holds. A rename produced a key the node had never seen, so the entry the node drew was dropped as gone from the row and the renamed one appended `visible: false` — the rule that keeps a service a later scan found off canvases nobody enabled it on. `BaseNode` filters those out, so the service vanished the moment it was corrected while the row still held it.

Saving the canvas in that state wrote the flag into `display_view`, where the backend fix honours it. Anyone who renamed a service on 3.4.1 and then saved may still have it hidden after upgrading; it comes back with the eye toggle in `DetailPanel`. Worth a line in the release note.

This has to ship in the same release as `37dc138`, or the two halves disagree again.

## Testing

Eight new tests, both levels:

- `utils/__tests__/deviceFacts.test.ts` — new `listArrangedForNode` block: a rename is followed rather than hidden, the node keeps its place and its visibility flag across one, the same port on tcp and udp stays two services, a port-less service is still keyed by name, and properties are unaffected.
- `stores/__tests__/canvasStore/deviceFacts.test.ts` — through `applyDeviceFacts`: a renamed service is redrawn, and taking the rename from the row is not reported as a canvas edit (baseline rebased, `hasUnsavedChanges` stays false).

`npm test` 2661 passed / 184 files, `npm run lint` 0 errors, `tsc -b` clean. Backend untouched.

ha-relevant: maybe
